### PR TITLE
feat: async-job infrastructure setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "pagy"
 
 # Pipeline
 gem "async"
+gem "async-job-adapter-active_job"
 gem "dotenv-rails"
 gem "dry-cli"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,12 @@ GEM
       traces (~> 0.10)
     async-http-cache (0.4.6)
       async-http (~> 0.56)
+    async-job (0.11.1)
+      async (~> 2.9)
+      string-format (~> 0.2)
+    async-job-adapter-active_job (0.18.4)
+      async-job (~> 0.9)
+      async-service (~> 0.12)
     async-pool (0.11.2)
       async (>= 2.0)
     async-service (0.21.0)
@@ -469,6 +475,7 @@ PLATFORMS
 
 DEPENDENCIES
   async
+  async-job-adapter-active_job
   debug
   dotenv-rails
   dry-cli
@@ -511,6 +518,8 @@ CHECKSUMS
   async-container (0.34.4) sha256=0d705d485802a01c9dba070e7288257b4d8032f7f052d4e8753d76f74673ff66
   async-http (0.94.2) sha256=c5ca94b337976578904a373833abe5b8dfb466a2946af75c4ae38c409c5c78b2
   async-http-cache (0.4.6) sha256=2038d1f093182f16b50b4db271c25085e3938da10bfcfc2904cadb0530fddfd6
+  async-job (0.11.1) sha256=6a43c732597d490dd0dabc4fa390faed0b0fde9226a3a33f25979ff356a096a1
+  async-job-adapter-active_job (0.18.4) sha256=b687965682c6ba8b10c94a571a979d6a28cd9a86e0c00946ee4e541544b9728d
   async-pool (0.11.2) sha256=0a43a17b02b04d9c451b7d12fafa9a50e55dc6dd00d4369aca00433f16a7e3ed
   async-service (0.21.0) sha256=3bc9e0f8dc293ba8855bc790959db7f981ae22bbb731456d221d93b388e9706f
   async-utilization (0.3.2) sha256=201a27e0948fe23fc14a01a0ecbe5e420e27cebae3a51f36e56fc45fb31df3b4

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require_relative "boot"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-# require "active_job/railtie"
+require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
@@ -41,6 +41,9 @@ module ApplicationPipeline
 
     # Use SQL schema format so sqlite-vec virtual tables are preserved correctly.
     config.active_record.schema_format = :sql
+
+    # Use async-job adapter backed by Async::Job::Processor::Inline.
+    config.active_job.queue_adapter = :async_job
 
     # Autoload app/pipeline and app/tools in addition to standard Rails paths.
     config.autoload_paths += %w[pipeline tools].map { |d| Rails.root.join("app", d).to_s }

--- a/config/initializers/async_job.rb
+++ b/config/initializers/async_job.rb
@@ -1,0 +1,3 @@
+Rails.application.config.async_job.define_queue("default") do
+  dequeue Async::Job::Processor::Inline
+end

--- a/sig/app/jobs/application_job.rbs
+++ b/sig/app/jobs/application_job.rbs
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/spec/jobs/async_job_infrastructure_spec.rb
+++ b/spec/jobs/async_job_infrastructure_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "async-job infrastructure" do
+  describe "queue adapter" do
+    it "is configured as :async_job" do
+      expect(Rails.application.config.active_job.queue_adapter).to eq(:async_job)
+    end
+  end
+
+  describe "job execution" do
+    before do
+      stub_const("SmokeJob", Class.new(ApplicationJob) do
+        cattr_accessor :executed, default: false
+
+        def perform
+          self.class.executed = true
+        end
+      end)
+    end
+
+    after { SmokeJob.executed = false }
+
+    it "executes a job synchronously via perform_later" do
+      SmokeJob.perform_later
+
+      expect(SmokeJob.executed).to be true
+    end
+  end
+end


### PR DESCRIPTION
  ## Summary                                                                                                                   
  - Add `async-job-adapter-active_job` gem and configure `:async_job` queue adapter                                            
  - Re-enable `active_job/railtie` and create initializer with `Processor::Inline` default queue                               
  - Smoke test verifies `perform_later` executes synchronously in-process                                                      
                                                                                                                               
  Closes #3                                                                                                                    
                                                                                                                               
  ## Test plan                                                                                                                 
  - [x] All new tests pass (TDD red-green-refactor)
  - [x] Full test suite passes (101 examples, 0 failures)                                                                      
  - [x] RBS signatures updated and validated                                                                                   
                                                                                                                               
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
