### PR TITLE
Issue #6 — Pipeline builder UI

### DIFF
--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class PipelinesController < ApplicationController
+    before_action :set_pipeline, only: [ :show, :edit, :update, :destroy ]
+
+    def index
+      @pipelines = Orchestration::Pipeline
+        .left_joins(:steps)
+        .select("pipelines.*, COUNT(steps.id) AS step_count")
+        .group("pipelines.id")
+        .order("pipelines.name")
+    end
+
+    def new
+      @pipeline = Orchestration::Pipeline.new
+    end
+
+    def create
+      @pipeline = Orchestration::Pipeline.new(pipeline_params)
+      if @pipeline.save
+        redirect_to orchestration_pipeline_path(@pipeline), notice: "Pipeline created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def show
+      @steps = @pipeline.steps.includes(step_actions: :action)
+      @actions = Orchestration::Action.order(:name)
+    end
+
+    def edit
+    end
+
+    def update
+      if @pipeline.update(pipeline_params)
+        redirect_to orchestration_pipeline_path(@pipeline), notice: "Pipeline updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @pipeline.destroy
+      redirect_to orchestration_pipelines_path, notice: "Pipeline deleted."
+    end
+
+    private
+
+    def set_pipeline
+      @pipeline = Orchestration::Pipeline.find(params[:id])
+    end
+
+    def pipeline_params
+      params.require(:orchestration_pipeline).permit(:name, :description, :enabled)
+    end
+  end
+end

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepActionsController < ApplicationController
+    before_action :set_pipeline
+    before_action :set_step
+
+    def create
+      next_position = (@step.step_actions.maximum(:position) || 0) + 1
+      @step_action = @step.step_actions.build(step_action_params.merge(position: next_position))
+      if @step_action.save
+        redirect_to orchestration_pipeline_path(@pipeline), notice: "Action attached."
+      else
+        redirect_to orchestration_pipeline_path(@pipeline), alert: "Could not attach action."
+      end
+    end
+
+    def destroy
+      @step_action = @step.step_actions.find(params[:id])
+      @step_action.destroy
+      redirect_to orchestration_pipeline_path(@pipeline), notice: "Action detached."
+    end
+
+    private
+
+    def set_pipeline
+      @pipeline = Orchestration::Pipeline.find(params[:pipeline_id])
+    end
+
+    def set_step
+      @step = @pipeline.steps.find(params[:step_id])
+    end
+
+    def step_action_params
+      parsed = params.require(:orchestration_step_action).permit(:action_id, :params)
+      if parsed[:params].present?
+        parsed[:params] = JSON.parse(parsed[:params])
+      end
+      parsed
+    rescue JSON::ParserError
+      params.require(:orchestration_step_action).permit(:action_id, :params)
+    end
+  end
+end

--- a/app/controllers/orchestration/steps_controller.rb
+++ b/app/controllers/orchestration/steps_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepsController < ApplicationController
+    before_action :set_pipeline
+    before_action :set_step, only: [ :update, :destroy, :move_up, :move_down ]
+
+    def create
+      next_position = (@pipeline.steps.maximum(:position) || 0) + 1
+      @step = @pipeline.steps.build(step_params.merge(position: next_position))
+      if @step.save
+        redirect_to orchestration_pipeline_path(@pipeline), notice: "Step added."
+      else
+        @steps = @pipeline.steps.includes(step_actions: :action)
+        @actions = Orchestration::Action.order(:name)
+        render "orchestration/pipelines/show", status: :unprocessable_entity
+      end
+    end
+
+    def update
+      if @step.update(step_params)
+        redirect_to orchestration_pipeline_path(@pipeline), notice: "Step updated."
+      else
+        @steps = @pipeline.steps.includes(step_actions: :action)
+        @actions = Orchestration::Action.order(:name)
+        render "orchestration/pipelines/show", status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @step.destroy
+      redirect_to orchestration_pipeline_path(@pipeline), notice: "Step removed."
+    end
+
+    def move_up
+      prev_step = @pipeline.steps.where("position < ?", @step.position).order(position: :desc).first
+      swap_positions(@step, prev_step) if prev_step
+      redirect_to orchestration_pipeline_path(@pipeline)
+    end
+
+    def move_down
+      next_step = @pipeline.steps.where("position > ?", @step.position).order(position: :asc).first
+      swap_positions(@step, next_step) if next_step
+      redirect_to orchestration_pipeline_path(@pipeline)
+    end
+
+    private
+
+    def set_pipeline
+      @pipeline = Orchestration::Pipeline.find(params[:pipeline_id])
+    end
+
+    def set_step
+      @step = @pipeline.steps.find(params[:id])
+    end
+
+    def step_params
+      parsed = params.require(:orchestration_step).permit(:name, :input_mapping)
+      if parsed[:input_mapping].present?
+        parsed[:input_mapping] = JSON.parse(parsed[:input_mapping])
+      end
+      parsed
+    rescue JSON::ParserError
+      params.require(:orchestration_step).permit(:name, :input_mapping)
+    end
+
+    def swap_positions(step_a, step_b)
+      pos_a = step_a.position
+      pos_b = step_b.position
+      temp = @pipeline.steps.maximum(:position) + 1
+
+      ActiveRecord::Base.transaction do
+        step_a.update_column(:position, temp)
+        step_b.update_column(:position, pos_a)
+        step_a.update_column(:position, pos_b)
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
     <nav class="bg-white border-b border-gray-200 px-6 py-3 flex items-center gap-4">
       <%= link_to "Application Pipeline", root_path, class: "font-semibold text-gray-800 hover:text-gray-600" %>
       <%= link_to "Chats", chats_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "Pipelines", orchestration_pipelines_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
       <%= link_to "Actions", orchestration_actions_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
       <%= link_to "Emails", application_mails_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
       <%= link_to "Interviews", interviews_path, class: "text-sm text-gray-500 hover:text-gray-700" %>

--- a/app/views/orchestration/pipelines/_form.html.erb
+++ b/app/views/orchestration/pipelines/_form.html.erb
@@ -1,0 +1,35 @@
+<%= form_with model: pipeline, url: pipeline.new_record? ? orchestration_pipelines_path : orchestration_pipeline_path(pipeline), class: "space-y-6" do |f| %>
+  <% if pipeline.errors.any? %>
+    <div class="px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800">
+      <p class="font-medium mb-1">Please fix the following errors:</p>
+      <ul class="list-disc list-inside space-y-0.5">
+        <% pipeline.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :name, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if pipeline.errors[:name].any?}" %>
+    <% if pipeline.errors[:name].any? %>
+      <p class="mt-1 text-xs text-red-600"><%= pipeline.errors[:name].first %></p>
+    <% end %>
+  </div>
+
+  <div>
+    <%= f.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :description, rows: 2, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <%= f.check_box :enabled, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>
+    <%= f.label :enabled, "Enabled", class: "text-sm font-medium text-gray-700" %>
+  </div>
+
+  <div class="flex items-center gap-3 pt-2">
+    <%= f.submit class: "px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
+    <%= link_to "Cancel", orchestration_pipelines_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
+  </div>
+<% end %>

--- a/app/views/orchestration/pipelines/edit.html.erb
+++ b/app/views/orchestration/pipelines/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "Edit Pipeline" %>
+
+<div class="mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">Edit Pipeline</h1>
+</div>
+
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 max-w-2xl">
+  <%= render "form", pipeline: @pipeline %>
+</div>

--- a/app/views/orchestration/pipelines/index.html.erb
+++ b/app/views/orchestration/pipelines/index.html.erb
@@ -1,0 +1,58 @@
+<% content_for :title, "Pipelines" %>
+
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">Pipelines</h1>
+  <%= link_to "New Pipeline", new_orchestration_pipeline_path, class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors" %>
+</div>
+
+<% if notice.present? %>
+  <div class="mb-4 px-4 py-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm"><%= notice %></div>
+<% end %>
+
+<% if alert.present? %>
+  <div class="mb-4 px-4 py-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm"><%= alert %></div>
+<% end %>
+
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+  <table class="w-full text-sm">
+    <thead class="bg-gray-50 border-b border-gray-200">
+      <tr>
+        <th class="px-4 py-3 text-left font-medium text-gray-600">Name</th>
+        <th class="px-4 py-3 text-left font-medium text-gray-600">Description</th>
+        <th class="px-4 py-3 text-left font-medium text-gray-600">Steps</th>
+        <th class="px-4 py-3 text-left font-medium text-gray-600">Status</th>
+        <th class="px-4 py-3"></th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100">
+      <% if @pipelines.empty? %>
+        <tr>
+          <td colspan="5" class="px-4 py-10 text-center text-gray-400">No pipelines found.</td>
+        </tr>
+      <% else %>
+        <% @pipelines.each do |pipeline| %>
+          <tr class="hover:bg-gray-50 transition-colors">
+            <td class="px-4 py-3 font-medium text-gray-900">
+              <%= link_to pipeline.name, orchestration_pipeline_path(pipeline), class: "hover:text-indigo-600" %>
+            </td>
+            <td class="px-4 py-3 text-gray-500"><%= pipeline.description || "—" %></td>
+            <td class="px-4 py-3 text-gray-500"><%= pipeline.step_count %></td>
+            <td class="px-4 py-3">
+              <% if pipeline.enabled? %>
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Enabled</span>
+              <% else %>
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">Disabled</span>
+              <% end %>
+            </td>
+            <td class="px-4 py-3 text-right flex items-center justify-end gap-3">
+              <%= link_to "Edit", edit_orchestration_pipeline_path(pipeline), class: "text-indigo-600 hover:text-indigo-800 font-medium" %>
+              <%= button_to "Delete", orchestration_pipeline_path(pipeline), method: :delete,
+                    form: { data: { turbo_confirm: "Delete pipeline \"#{pipeline.name}\"? This will also delete all steps and step-actions." } },
+                    class: "text-red-500 hover:text-red-700 font-medium bg-transparent border-0 cursor-pointer p-0" %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/orchestration/pipelines/new.html.erb
+++ b/app/views/orchestration/pipelines/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "New Pipeline" %>
+
+<div class="mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">New Pipeline</h1>
+</div>
+
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 max-w-2xl">
+  <%= render "form", pipeline: @pipeline %>
+</div>

--- a/app/views/orchestration/pipelines/show.html.erb
+++ b/app/views/orchestration/pipelines/show.html.erb
@@ -1,0 +1,130 @@
+<% content_for :title, @pipeline.name %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <div class="flex items-center gap-3">
+      <h1 class="text-2xl font-bold text-gray-900"><%= @pipeline.name %></h1>
+      <% if @pipeline.enabled? %>
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Enabled</span>
+      <% else %>
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">Disabled</span>
+      <% end %>
+    </div>
+    <% if @pipeline.description.present? %>
+      <p class="mt-1 text-sm text-gray-500"><%= @pipeline.description %></p>
+    <% end %>
+  </div>
+  <div class="flex items-center gap-3">
+    <%= link_to "Edit", edit_orchestration_pipeline_path(@pipeline), class: "px-4 py-2 text-sm text-indigo-600 hover:text-indigo-800 font-medium border border-indigo-200 rounded-lg hover:bg-indigo-50 transition-colors" %>
+    <%= button_to "Delete", orchestration_pipeline_path(@pipeline), method: :delete,
+          form: { data: { turbo_confirm: "Delete pipeline \"#{@pipeline.name}\"? This will also delete all steps and step-actions." } },
+          class: "px-4 py-2 text-sm text-red-600 hover:text-red-800 font-medium border border-red-200 rounded-lg hover:bg-red-50 transition-colors bg-transparent cursor-pointer" %>
+    <%= link_to "All Pipelines", orchestration_pipelines_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
+</div>
+
+<% if notice.present? %>
+  <div class="mb-4 px-4 py-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm"><%= notice %></div>
+<% end %>
+
+<% if alert.present? %>
+  <div class="mb-4 px-4 py-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm"><%= alert %></div>
+<% end %>
+
+<div class="grid grid-cols-1 gap-6">
+  <%# Steps section %>
+  <turbo-frame id="steps">
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+      <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-gray-900">Steps</h2>
+      </div>
+
+      <% if @steps.empty? %>
+        <p class="px-6 py-8 text-center text-gray-400 text-sm">No steps yet. Add a step below.</p>
+      <% else %>
+        <div class="divide-y divide-gray-100">
+          <% @steps.each_with_index do |step, idx| %>
+            <div class="px-6 py-4">
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex items-start gap-3 flex-1 min-w-0">
+                  <span class="mt-0.5 flex-shrink-0 w-6 h-6 bg-indigo-100 text-indigo-700 text-xs font-bold rounded-full flex items-center justify-center"><%= step.position %></span>
+                  <div class="flex-1 min-w-0">
+                    <p class="font-medium text-gray-900"><%= step.name %></p>
+
+                    <% if step.step_actions.any? %>
+                      <div class="mt-2 flex flex-wrap gap-2">
+                        <% step.step_actions.each do |sa| %>
+                          <div class="flex items-center gap-1 bg-gray-100 rounded-lg px-2 py-1 text-xs">
+                            <span class="font-medium text-gray-700"><%= sa.action.name %></span>
+                            <% if sa.params.present? %>
+                              <span class="text-gray-500 font-mono"><%= sa.params.to_json %></span>
+                            <% end %>
+                            <%= button_to "×", orchestration_pipeline_step_step_action_path(@pipeline, step, sa),
+                                  method: :delete,
+                                  form: { data: { turbo_confirm: "Detach action \"#{sa.action.name}\"?" } },
+                                  class: "ml-1 text-gray-400 hover:text-red-500 bg-transparent border-0 cursor-pointer p-0 font-bold" %>
+                          </div>
+                        <% end %>
+                      </div>
+                    <% end %>
+
+                    <% if step.input_mapping.present? %>
+                      <div class="mt-2">
+                        <span class="text-xs text-gray-400">Input mapping: </span>
+                        <code class="text-xs text-gray-600 font-mono"><%= step.input_mapping.to_json %></code>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2 flex-shrink-0">
+                  <% unless idx == 0 %>
+                    <%= button_to "↑", move_up_orchestration_pipeline_step_path(@pipeline, step),
+                          method: :patch,
+                          class: "text-gray-400 hover:text-gray-600 bg-transparent border border-gray-200 rounded px-2 py-1 text-xs cursor-pointer hover:bg-gray-50 transition-colors" %>
+                  <% end %>
+                  <% unless idx == @steps.length - 1 %>
+                    <%= button_to "↓", move_down_orchestration_pipeline_step_path(@pipeline, step),
+                          method: :patch,
+                          class: "text-gray-400 hover:text-gray-600 bg-transparent border border-gray-200 rounded px-2 py-1 text-xs cursor-pointer hover:bg-gray-50 transition-colors" %>
+                  <% end %>
+                  <%= button_to "Remove", orchestration_pipeline_step_path(@pipeline, step),
+                        method: :delete,
+                        form: { data: { turbo_confirm: "Remove step \"#{step.name}\"?" } },
+                        class: "text-red-500 hover:text-red-700 bg-transparent border-0 cursor-pointer p-0 text-xs font-medium" %>
+                </div>
+              </div>
+
+              <%# Attach action form %>
+              <div class="mt-3 pt-3 border-t border-gray-100">
+                <%= form_with url: orchestration_pipeline_step_step_actions_path(@pipeline, step),
+                              method: :post, class: "flex items-center gap-2" do |f| %>
+                  <%= f.select :orchestration_step_action_action_id,
+                        options_for_select(@actions.map { |a| [a.name, a.id] }),
+                        { include_blank: "— attach action —" },
+                        name: "orchestration_step_action[action_id]",
+                        class: "flex-1 border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+                  <%= f.text_field :params_override, placeholder: '{"key":"val"} optional',
+                        name: "orchestration_step_action[params]",
+                        class: "w-40 border border-gray-300 rounded-lg px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+                  <%= f.submit "Attach", class: "px-3 py-1.5 bg-indigo-600 text-white text-xs font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <%# Add step form %>
+      <div class="px-6 py-4 border-t border-gray-200 bg-gray-50 rounded-b-xl">
+        <%= form_with url: orchestration_pipeline_steps_path(@pipeline), method: :post,
+                      class: "flex items-center gap-2" do |f| %>
+          <%= f.text_field :name, placeholder: "New step name",
+                name: "orchestration_step[name]",
+                class: "flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+          <%= f.submit "Add Step", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
+        <% end %>
+      </div>
+    </div>
+  </turbo-frame>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,15 @@ Rails.application.routes.draw do
 
   namespace :orchestration do
     resources :actions
+    resources :pipelines do
+      resources :steps, only: [ :create, :update, :destroy ] do
+        member do
+          patch :move_up
+          patch :move_down
+        end
+        resources :step_actions, only: [ :create, :destroy ]
+      end
+    end
   end
 
   root to: "chats#index"

--- a/sig/app/controllers/orchestration/pipelines_controller.rbs
+++ b/sig/app/controllers/orchestration/pipelines_controller.rbs
@@ -1,0 +1,16 @@
+module Orchestration
+  class PipelinesController < ApplicationController
+    def index: () -> void
+    def new: () -> void
+    def create: () -> void
+    def show: () -> void
+    def edit: () -> void
+    def update: () -> void
+    def destroy: () -> void
+
+    private
+
+    def set_pipeline: () -> void
+    def pipeline_params: () -> ActionController::Parameters
+  end
+end

--- a/sig/app/controllers/orchestration/step_actions_controller.rbs
+++ b/sig/app/controllers/orchestration/step_actions_controller.rbs
@@ -1,0 +1,12 @@
+module Orchestration
+  class StepActionsController < ApplicationController
+    def create: () -> void
+    def destroy: () -> void
+
+    private
+
+    def set_pipeline: () -> void
+    def set_step: () -> void
+    def step_action_params: () -> ActionController::Parameters
+  end
+end

--- a/sig/app/controllers/orchestration/steps_controller.rbs
+++ b/sig/app/controllers/orchestration/steps_controller.rbs
@@ -1,0 +1,16 @@
+module Orchestration
+  class StepsController < ApplicationController
+    def create: () -> void
+    def update: () -> void
+    def destroy: () -> void
+    def move_up: () -> void
+    def move_down: () -> void
+
+    private
+
+    def set_pipeline: () -> void
+    def set_step: () -> void
+    def step_params: () -> ActionController::Parameters
+    def swap_positions: (Orchestration::Step step_a, Orchestration::Step step_b) -> void
+  end
+end

--- a/spec/requests/orchestration/pipelines_spec.rb
+++ b/spec/requests/orchestration/pipelines_spec.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Orchestration::Pipelines" do
+  describe "GET /orchestration/pipelines" do
+    it "returns 200 and lists pipelines with step count and enabled status" do
+      pipeline = create(:orchestration_pipeline, name: "My Pipeline", enabled: true)
+      create(:orchestration_step, pipeline: pipeline)
+      create(:orchestration_step, pipeline: pipeline)
+
+      get orchestration_pipelines_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("My Pipeline")
+      expect(response.body).to include("2")
+    end
+
+    it "shows disabled status for disabled pipeline" do
+      create(:orchestration_pipeline, name: "Disabled Pipeline", enabled: false)
+
+      get orchestration_pipelines_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Disabled Pipeline")
+    end
+  end
+
+  describe "GET /orchestration/pipelines/new" do
+    it "returns 200 with form" do
+      get new_orchestration_pipeline_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("name")
+    end
+  end
+
+  describe "POST /orchestration/pipelines" do
+    context "with valid params" do
+      it "creates a pipeline and redirects" do
+        expect {
+          post orchestration_pipelines_path, params: {
+            orchestration_pipeline: { name: "New Pipeline", description: "A desc", enabled: true }
+          }
+        }.to change(Orchestration::Pipeline, :count).by(1)
+
+        expect(response).to redirect_to(orchestration_pipeline_path(Orchestration::Pipeline.last))
+      end
+    end
+
+    context "with invalid params" do
+      it "renders new with 422" do
+        post orchestration_pipelines_path, params: {
+          orchestration_pipeline: { name: "" }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "GET /orchestration/pipelines/:id" do
+    it "returns 200 and shows pipeline name" do
+      pipeline = create(:orchestration_pipeline, name: "Show Pipeline")
+
+      get orchestration_pipeline_path(pipeline)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Show Pipeline")
+    end
+
+    it "shows ordered steps and their actions" do
+      pipeline = create(:orchestration_pipeline, name: "Show Pipeline")
+      step1 = create(:orchestration_step, pipeline: pipeline, name: "First Step", position: 1)
+      step2 = create(:orchestration_step, pipeline: pipeline, name: "Second Step", position: 2)
+      action = create(:orchestration_action, name: "My Action")
+      create(:orchestration_step_action, step: step1, action: action, position: 1)
+
+      get orchestration_pipeline_path(pipeline)
+
+      expect(response.body).to include("First Step")
+      expect(response.body).to include("Second Step")
+      expect(response.body).to include("My Action")
+    end
+
+    it "shows input mapping on steps" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_step, pipeline: pipeline, position: 1,
+             input_mapping: { "email" => "$.output.email" })
+
+      get orchestration_pipeline_path(pipeline)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /orchestration/pipelines/:id/edit" do
+    it "returns 200 with form populated" do
+      pipeline = create(:orchestration_pipeline, name: "Edit Me")
+
+      get edit_orchestration_pipeline_path(pipeline)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Edit Me")
+    end
+  end
+
+  describe "PATCH /orchestration/pipelines/:id" do
+    context "with valid params" do
+      it "updates and redirects" do
+        pipeline = create(:orchestration_pipeline, name: "Old Name")
+
+        patch orchestration_pipeline_path(pipeline), params: {
+          orchestration_pipeline: { name: "New Name" }
+        }
+
+        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+        expect(pipeline.reload.name).to eq("New Name")
+      end
+    end
+
+    context "with invalid params" do
+      it "renders edit with 422" do
+        pipeline = create(:orchestration_pipeline)
+
+        patch orchestration_pipeline_path(pipeline), params: {
+          orchestration_pipeline: { name: "" }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "DELETE /orchestration/pipelines/:id" do
+    it "destroys pipeline and cascades through steps and step_actions" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline, position: 1)
+      action = create(:orchestration_action)
+      create(:orchestration_step_action, step: step, action: action, position: 1)
+
+      expect {
+        delete orchestration_pipeline_path(pipeline)
+      }.to change(Orchestration::Pipeline, :count).by(-1)
+        .and change(Orchestration::Step, :count).by(-1)
+        .and change(Orchestration::StepAction, :count).by(-1)
+
+      expect(response).to redirect_to(orchestration_pipelines_path)
+    end
+  end
+
+  describe "POST /orchestration/pipelines/:pipeline_id/steps" do
+    it "adds a step to the pipeline and redirects to show" do
+      pipeline = create(:orchestration_pipeline)
+
+      expect {
+        post orchestration_pipeline_steps_path(pipeline), params: {
+          orchestration_step: { name: "New Step" }
+        }
+      }.to change(Orchestration::Step, :count).by(1)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(Orchestration::Step.last.position).to eq(1)
+    end
+
+    it "appends step after existing steps" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_step, pipeline: pipeline, position: 1)
+
+      post orchestration_pipeline_steps_path(pipeline), params: {
+        orchestration_step: { name: "Second Step" }
+      }
+
+      expect(Orchestration::Step.last.position).to eq(2)
+    end
+
+    it "renders pipeline show with 422 on invalid params" do
+      pipeline = create(:orchestration_pipeline)
+
+      post orchestration_pipeline_steps_path(pipeline), params: {
+        orchestration_step: { name: "" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "PATCH /orchestration/pipelines/:pipeline_id/steps/:id" do
+    it "updates step name and input_mapping and redirects to show" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline, name: "Old", position: 1)
+
+      patch orchestration_pipeline_step_path(pipeline, step), params: {
+        orchestration_step: { name: "Updated", input_mapping: '{"key":"val"}' }
+      }
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(step.reload.name).to eq("Updated")
+    end
+
+    it "renders show with 422 on invalid params" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline, position: 1)
+
+      patch orchestration_pipeline_step_path(pipeline, step), params: {
+        orchestration_step: { name: "" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "DELETE /orchestration/pipelines/:pipeline_id/steps/:id" do
+    it "removes step from pipeline and redirects to show" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline, position: 1)
+
+      expect {
+        delete orchestration_pipeline_step_path(pipeline, step)
+      }.to change(Orchestration::Step, :count).by(-1)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+    end
+  end
+
+  describe "PATCH /orchestration/pipelines/:pipeline_id/steps/:id/move_up" do
+    it "swaps position with the step above and redirects" do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+      step2 = create(:orchestration_step, pipeline: pipeline, position: 2)
+
+      patch move_up_orchestration_pipeline_step_path(pipeline, step2)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(step2.reload.position).to eq(1)
+      expect(step1.reload.position).to eq(2)
+    end
+
+    it "does nothing when step is already first and redirects" do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+
+      patch move_up_orchestration_pipeline_step_path(pipeline, step1)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(step1.reload.position).to eq(1)
+    end
+  end
+
+  describe "PATCH /orchestration/pipelines/:pipeline_id/steps/:id/move_down" do
+    it "swaps position with the step below and redirects" do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+      step2 = create(:orchestration_step, pipeline: pipeline, position: 2)
+
+      patch move_down_orchestration_pipeline_step_path(pipeline, step1)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(step1.reload.position).to eq(2)
+      expect(step2.reload.position).to eq(1)
+    end
+
+    it "does nothing when step is already last and redirects" do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+
+      patch move_down_orchestration_pipeline_step_path(pipeline, step1)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(step1.reload.position).to eq(1)
+    end
+  end
+
+  describe "POST /orchestration/pipelines/:pipeline_id/steps/:step_id/step_actions" do
+    it "attaches an action to the step and redirects to pipeline show" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline, position: 1)
+      action = create(:orchestration_action)
+
+      expect {
+        post orchestration_pipeline_step_step_actions_path(pipeline, step), params: {
+          orchestration_step_action: { action_id: action.id }
+        }
+      }.to change(Orchestration::StepAction, :count).by(1)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(Orchestration::StepAction.last.position).to eq(1)
+    end
+
+    it "attaches with optional params override JSON" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline, position: 1)
+      action = create(:orchestration_action)
+
+      post orchestration_pipeline_step_step_actions_path(pipeline, step), params: {
+        orchestration_step_action: { action_id: action.id, params: '{"override":"true"}' }
+      }
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(Orchestration::StepAction.last.params).to eq({ "override" => "true" })
+    end
+  end
+
+  describe "DELETE /orchestration/pipelines/:pipeline_id/steps/:step_id/step_actions/:id" do
+    it "detaches action from step and redirects to pipeline show" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline, position: 1)
+      action = create(:orchestration_action)
+      step_action = create(:orchestration_step_action, step: step, action: action, position: 1)
+
+      expect {
+        delete orchestration_pipeline_step_step_action_path(pipeline, step, step_action)
+      }.to change(Orchestration::StepAction, :count).by(-1)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+    end
+  end
+end


### PR DESCRIPTION
What was built:                                                                         
  - PipelinesController — full CRUD (index, new, create, show, edit, update, destroy)   
  - StepsController — create, update, destroy, move_up, move_down (safe 3-step swap to    
  avoid DB-level unique constraint violations)                                        
  - StepActionsController — create (with optional params JSON override), destroy          
  - Routes nested under namespace :orchestration                                        
  - 5 ERB views with Tailwind + Turbo Frame wrapper on steps section for in-place         
  reordering                                                                            
  - "Pipelines" added to nav                                                              
  - RBS signatures for all 3 controllers 