### PR TITLE
feat: manual pipeline run trigger from UI

### DIFF
--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -32,9 +32,18 @@ module Orchestration
     end
 
     def run
-      pipeline_run = @pipeline.pipeline_runs.create!(status: "pending", triggered_by: "manual")
-      PipelineRunJob.perform_later(pipeline_run.id)
-      redirect_to orchestration_pipeline_path(@pipeline), notice: "Pipeline run triggered."
+      if @pipeline.pipeline_runs.exists?(status: %w[pending running])
+        redirect_to orchestration_pipeline_path(@pipeline), alert: "A run is already pending."
+        return
+      end
+
+      pipeline_run = @pipeline.pipeline_runs.create(status: "pending", triggered_by: "manual")
+      if pipeline_run.persisted?
+        PipelineRunJob.perform_later(pipeline_run.id)
+        redirect_to orchestration_pipeline_path(@pipeline), notice: "Pipeline run triggered."
+      else
+        redirect_to orchestration_pipeline_path(@pipeline), alert: "Failed to trigger pipeline run."
+      end
     end
 
     def edit

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -2,7 +2,7 @@
 
 module Orchestration
   class PipelinesController < ApplicationController
-    before_action :set_pipeline, only: [ :show, :edit, :update, :destroy ]
+    before_action :set_pipeline, only: [ :show, :edit, :update, :destroy, :run ]
 
     def index
       @pipelines = Orchestration::Pipeline
@@ -28,6 +28,13 @@ module Orchestration
     def show
       @steps = @pipeline.steps.includes(step_actions: :action)
       @actions = Orchestration::Action.order(:name)
+      @latest_run = @pipeline.pipeline_runs.order(created_at: :desc).first
+    end
+
+    def run
+      pipeline_run = @pipeline.pipeline_runs.create!(status: "pending", triggered_by: "manual")
+      PipelineRunJob.perform_later(pipeline_run.id)
+      redirect_to orchestration_pipeline_path(@pipeline), notice: "Pipeline run triggered."
     end
 
     def edit

--- a/app/views/orchestration/pipelines/show.html.erb
+++ b/app/views/orchestration/pipelines/show.html.erb
@@ -15,6 +15,8 @@
     <% end %>
   </div>
   <div class="flex items-center gap-3">
+    <%= button_to "Run now", run_orchestration_pipeline_path(@pipeline), method: :post,
+          class: "px-4 py-2 text-sm text-white font-medium bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
     <%= link_to "Edit", edit_orchestration_pipeline_path(@pipeline), class: "px-4 py-2 text-sm text-indigo-600 hover:text-indigo-800 font-medium border border-indigo-200 rounded-lg hover:bg-indigo-50 transition-colors" %>
     <%= button_to "Delete", orchestration_pipeline_path(@pipeline), method: :delete,
           form: { data: { turbo_confirm: "Delete pipeline \"#{@pipeline.name}\"? This will also delete all steps and step-actions." } },
@@ -29,6 +31,21 @@
 
 <% if alert.present? %>
   <div class="mb-4 px-4 py-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm"><%= alert %></div>
+<% end %>
+
+<% if @latest_run %>
+  <div class="mb-4 px-4 py-3 bg-gray-50 border border-gray-200 text-gray-700 rounded-lg text-sm">
+    Latest run: <span class="font-medium"><%= @latest_run.status %></span>
+    <% if @latest_run.started_at %>
+      &middot; started <%= @latest_run.started_at.strftime("%Y-%m-%d %H:%M:%S") %>
+    <% end %>
+    <% if @latest_run.finished_at %>
+      &middot; finished <%= @latest_run.finished_at.strftime("%Y-%m-%d %H:%M:%S") %>
+    <% end %>
+    <% if @latest_run.error.present? %>
+      &middot; <span class="text-red-600"><%= @latest_run.error %></span>
+    <% end %>
+  </div>
 <% end %>
 
 <div class="grid grid-cols-1 gap-6">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
   namespace :orchestration do
     resources :actions
     resources :pipelines do
+      member do
+        post :run
+      end
       resources :steps, only: [ :create, :update, :destroy ] do
         member do
           patch :move_up

--- a/db/migrate/20260330145327_add_index_to_pipeline_runs_pipeline_id_created_at.rb
+++ b/db/migrate/20260330145327_add_index_to_pipeline_runs_pipeline_id_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToPipelineRunsPipelineIdCreatedAt < ActiveRecord::Migration[8.1]
+  def change
+    add_index :pipeline_runs, [ :pipeline_id, :created_at ]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,10 @@ CREATE UNIQUE INDEX "index_application_mails_on_email_id" ON "application_mails"
 CREATE INDEX "index_application_mails_on_date" ON "application_mails" ("date") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "interviews" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "company" varchar NOT NULL, "job_title" varchar NOT NULL, "status" varchar DEFAULT 'pending_reply', "applied_at" date, "rejected_at" date, "first_interview_at" date, "second_interview_at" date, "third_interview_at" date, "fourth_interview_at" date, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_interviews_on_company_and_job_title" ON "interviews" ("company", "job_title") /*application='ApplicationPipeline'*/;
+CREATE VIRTUAL TABLE email_vectors USING vec0(
+  email_id TEXT PRIMARY KEY,
+  embedding FLOAT[1536]
+);
 CREATE TABLE IF NOT EXISTS "email_vectors_info" (key text primary key, value any);
 CREATE TABLE IF NOT EXISTS "email_vectors_chunks"(chunk_id INTEGER PRIMARY KEY AUTOINCREMENT,size INTEGER NOT NULL,validity BLOB NOT NULL,rowids BLOB NOT NULL);
 CREATE TABLE IF NOT EXISTS "email_vectors_rowids"(rowid INTEGER PRIMARY KEY AUTOINCREMENT,id TEXT UNIQUE NOT NULL,chunk_id INTEGER,chunk_offset INTEGER);
@@ -73,7 +77,9 @@ FOREIGN KEY ("step_action_id")
 CREATE INDEX "index_action_runs_on_pipeline_run_id" ON "action_runs" ("pipeline_run_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_action_runs_on_step_action_id" ON "action_runs" ("step_action_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_action_runs_on_status" ON "action_runs" ("status") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_pipeline_runs_on_pipeline_id_and_created_at" ON "pipeline_runs" ("pipeline_id", "created_at") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260330145327'),
 ('20260321000006'),
 ('20260321000005'),
 ('20260321000004'),

--- a/sig/app/controllers/orchestration/pipelines_controller.rbs
+++ b/sig/app/controllers/orchestration/pipelines_controller.rbs
@@ -4,6 +4,7 @@ module Orchestration
     def new: () -> void
     def create: () -> void
     def show: () -> void
+    def run: () -> void
     def edit: () -> void
     def update: () -> void
     def destroy: () -> void

--- a/spec/requests/orchestration/pipelines_spec.rb
+++ b/spec/requests/orchestration/pipelines_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe "Orchestration::Pipelines" do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it "displays latest run status when a run exists" do
+      pipeline = create(:orchestration_pipeline, name: "Show Pipeline")
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed")
+
+      get orchestration_pipeline_path(pipeline)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("completed")
+    end
   end
 
   describe "GET /orchestration/pipelines/:id/edit" do
@@ -298,6 +308,50 @@ RSpec.describe "Orchestration::Pipelines" do
 
       expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
       expect(Orchestration::StepAction.last.params).to eq({ "override" => "true" })
+    end
+  end
+
+  describe "POST /orchestration/pipelines/:id/run" do
+    it "creates a PipelineRun with status pending and triggered_by manual" do
+      pipeline = create(:orchestration_pipeline)
+      allow(PipelineRunJob).to receive(:perform_later)
+
+      expect {
+        post run_orchestration_pipeline_path(pipeline)
+      }.to change(Orchestration::PipelineRun, :count).by(1)
+
+      run = Orchestration::PipelineRun.last
+      expect(run.status).to eq("pending")
+      expect(run.triggered_by).to eq("manual")
+    end
+
+    it "associates the created PipelineRun with the pipeline" do
+      pipeline = create(:orchestration_pipeline)
+      allow(PipelineRunJob).to receive(:perform_later)
+
+      post run_orchestration_pipeline_path(pipeline)
+
+      expect(Orchestration::PipelineRun.last.pipeline).to eq(pipeline)
+    end
+
+    it "enqueues PipelineRunJob with the pipeline_run_id" do
+      pipeline = create(:orchestration_pipeline)
+      allow(PipelineRunJob).to receive(:perform_later)
+
+      post run_orchestration_pipeline_path(pipeline)
+
+      expect(PipelineRunJob).to have_received(:perform_later).with(Orchestration::PipelineRun.last.id)
+    end
+
+    it "redirects to pipeline show page with a notice" do
+      pipeline = create(:orchestration_pipeline)
+      allow(PipelineRunJob).to receive(:perform_later)
+
+      post run_orchestration_pipeline_path(pipeline)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      follow_redirect!
+      expect(response.body).to include("Pipeline run triggered.")
     end
   end
 

--- a/spec/requests/orchestration/pipelines_spec.rb
+++ b/spec/requests/orchestration/pipelines_spec.rb
@@ -353,6 +353,30 @@ RSpec.describe "Orchestration::Pipelines" do
       follow_redirect!
       expect(response.body).to include("Pipeline run triggered.")
     end
+
+    it "does not create a second run and redirects with alert when a pending run already exists" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "pending")
+
+      expect {
+        post run_orchestration_pipeline_path(pipeline)
+      }.not_to change(Orchestration::PipelineRun, :count)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      follow_redirect!
+      expect(response.body).to include("A run is already pending.")
+    end
+
+    it "does not create a run and redirects with alert when a run is already running" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "running")
+
+      expect {
+        post run_orchestration_pipeline_path(pipeline)
+      }.not_to change(Orchestration::PipelineRun, :count)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+    end
   end
 
   describe "DELETE /orchestration/pipelines/:pipeline_id/steps/:step_id/step_actions/:id" do


### PR DESCRIPTION
## Summary
- Add \"Run now\" button to pipeline show page
- Clicking creates a `PipelineRun` (status: pending, triggered_by: manual) and enqueues `PipelineRunJob`
- Pipeline show page now displays the latest run status (pending/running/completed/failed)

Closes #7

## Test plan
- [x] All new tests pass (TDD red-green-refactor)
- [x] Full test suite passes (425 examples, 0 failures)
- [x] RuboCop passes (no offenses)
- [x] RBS signatures updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)