### PR TITLE
feat: run dashboard (history, step progress, action detail)

### DIFF
--- a/app/controllers/orchestration/pipeline_runs_controller.rb
+++ b/app/controllers/orchestration/pipeline_runs_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class PipelineRunsController < ApplicationController
+    before_action :set_pipeline
+
+    def index
+      @runs = @pipeline.pipeline_runs.order(created_at: :desc)
+    end
+
+    def show
+      @run = @pipeline.pipeline_runs.find(params[:id])
+      action_runs_by_step = @run.action_runs
+        .includes(step_action: :action)
+        .group_by { |ar| ar.step_action.step_id }
+      @steps_with_action_runs = @pipeline.steps.order(:position).map do |step|
+        action_runs = action_runs_by_step.fetch(step.id, [])
+        { step: step, action_runs: action_runs, derived_status: derive_status(action_runs) }
+      end
+    end
+
+    private
+
+    def set_pipeline
+      @pipeline = Orchestration::Pipeline.find(params[:pipeline_id])
+    end
+
+    def derive_status(action_runs)
+      return "pending" if action_runs.empty?
+      return "failed" if action_runs.any? { |ar| ar.status == "failed" }
+      return "running" if action_runs.any? { |ar| ar.status == "running" }
+      return "completed" if action_runs.all? { |ar| ar.status == "completed" }
+
+      "pending"
+    end
+  end
+end

--- a/app/controllers/orchestration/pipeline_runs_controller.rb
+++ b/app/controllers/orchestration/pipeline_runs_controller.rb
@@ -5,7 +5,7 @@ module Orchestration
     before_action :set_pipeline
 
     def index
-      @runs = @pipeline.pipeline_runs.order(created_at: :desc)
+      @pagy, @runs = pagy(:offset, @pipeline.pipeline_runs.order(created_at: :desc))
     end
 
     def show
@@ -13,25 +13,16 @@ module Orchestration
       action_runs_by_step = @run.action_runs
         .includes(step_action: :action)
         .group_by { |ar| ar.step_action.step_id }
-      @steps_with_action_runs = @pipeline.steps.order(:position).map do |step|
+      @steps_with_action_runs = @pipeline.steps.map do |step|
         action_runs = action_runs_by_step.fetch(step.id, [])
-        { step: step, action_runs: action_runs, derived_status: derive_status(action_runs) }
+        { step: step, action_runs: action_runs, derived_status: Orchestration::Step.derive_status(action_runs) }
       end
     end
 
     private
 
     def set_pipeline
-      @pipeline = Orchestration::Pipeline.find(params[:pipeline_id])
-    end
-
-    def derive_status(action_runs)
-      return "pending" if action_runs.empty?
-      return "failed" if action_runs.any? { |ar| ar.status == "failed" }
-      return "running" if action_runs.any? { |ar| ar.status == "running" }
-      return "completed" if action_runs.all? { |ar| ar.status == "completed" }
-
-      "pending"
+      @pipeline = Orchestration::Pipeline.includes(:steps).find(params[:pipeline_id])
     end
   end
 end

--- a/app/models/orchestration/step.rb
+++ b/app/models/orchestration/step.rb
@@ -8,5 +8,14 @@ module Orchestration
 
     validates :name, presence: true
     validates :position, presence: true, uniqueness: { scope: :pipeline_id }
+
+    def self.derive_status(action_runs)
+      return "pending" if action_runs.empty?
+      return "failed" if action_runs.any? { |ar| ar.status == "failed" }
+      return "running" if action_runs.any? { |ar| ar.status == "running" }
+      return "completed" if action_runs.all? { |ar| ar.status == "completed" }
+
+      "pending"
+    end
   end
 end

--- a/app/views/orchestration/pipeline_runs/_status_badge.html.erb
+++ b/app/views/orchestration/pipeline_runs/_status_badge.html.erb
@@ -1,0 +1,7 @@
+<% badge_classes = case status
+  when "completed" then "bg-green-100 text-green-800"
+  when "running"   then "bg-blue-100 text-blue-800"
+  when "failed"    then "bg-red-100 text-red-800"
+  else                  "bg-gray-100 text-gray-600"
+  end %>
+<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium <%= badge_classes %>"><%= status %></span>

--- a/app/views/orchestration/pipeline_runs/index.html.erb
+++ b/app/views/orchestration/pipeline_runs/index.html.erb
@@ -12,6 +12,9 @@
 </div>
 
 <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+  <% if @pagy.count > 0 %>
+    <div class="px-6 py-3 border-b border-gray-100 text-xs text-gray-500"><%= @pagy.count %> total</div>
+  <% end %>
   <% if @runs.empty? %>
     <p class="px-6 py-8 text-center text-gray-400 text-sm">No runs yet.</p>
   <% else %>
@@ -54,5 +57,6 @@
         <% end %>
       </tbody>
     </table>
+    <%== @pagy.series_nav %>
   <% end %>
 </div>

--- a/app/views/orchestration/pipeline_runs/index.html.erb
+++ b/app/views/orchestration/pipeline_runs/index.html.erb
@@ -1,0 +1,58 @@
+<% content_for :title, "Run History — #{@pipeline.name}" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900">Run History</h1>
+    <p class="mt-1 text-sm text-gray-500"><%= @pipeline.name %></p>
+  </div>
+  <div class="flex items-center gap-3">
+    <%= link_to "Pipeline", orchestration_pipeline_path(@pipeline),
+          class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
+</div>
+
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+  <% if @runs.empty? %>
+    <p class="px-6 py-8 text-center text-gray-400 text-sm">No runs yet.</p>
+  <% else %>
+    <table class="w-full text-sm">
+      <thead class="bg-gray-50 border-b border-gray-200">
+        <tr>
+          <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Status</th>
+          <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Triggered by</th>
+          <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Started</th>
+          <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Finished</th>
+          <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Duration</th>
+          <th class="px-6 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100">
+        <% @runs.each do |run| %>
+          <tr class="hover:bg-gray-50 transition-colors">
+            <td class="px-6 py-4">
+              <%= render partial: "orchestration/pipeline_runs/status_badge", locals: { status: run.status } %>
+            </td>
+            <td class="px-6 py-4 text-gray-600"><%= run.triggered_by || "—" %></td>
+            <td class="px-6 py-4 text-gray-600">
+              <%= run.started_at ? run.started_at.strftime("%Y-%m-%d %H:%M:%S") : "—" %>
+            </td>
+            <td class="px-6 py-4 text-gray-600">
+              <%= run.finished_at ? run.finished_at.strftime("%Y-%m-%d %H:%M:%S") : "—" %>
+            </td>
+            <td class="px-6 py-4 text-gray-600">
+              <% if run.started_at && run.finished_at %>
+                <%= distance_of_time_in_words(run.started_at, run.finished_at) %>
+              <% else %>
+                —
+              <% end %>
+            </td>
+            <td class="px-6 py-4 text-right">
+              <%= link_to "Details", orchestration_pipeline_pipeline_run_path(@pipeline, run),
+                    class: "text-indigo-600 hover:text-indigo-800 font-medium text-xs" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>

--- a/app/views/orchestration/pipeline_runs/show.html.erb
+++ b/app/views/orchestration/pipeline_runs/show.html.erb
@@ -1,0 +1,110 @@
+<% content_for :title, "Run ##{@run.id} — #{@pipeline.name}" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <div class="flex items-center gap-3">
+      <h1 class="text-2xl font-bold text-gray-900">Run #<%= @run.id %></h1>
+      <%= render partial: "orchestration/pipeline_runs/status_badge", locals: { status: @run.status } %>
+    </div>
+    <p class="mt-1 text-sm text-gray-500"><%= @pipeline.name %></p>
+  </div>
+  <div class="flex items-center gap-3">
+    <%= link_to "Run History", orchestration_pipeline_pipeline_runs_path(@pipeline),
+          class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Pipeline", orchestration_pipeline_path(@pipeline),
+          class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
+</div>
+
+<div class="mb-6 bg-white rounded-xl shadow-sm border border-gray-200 px-6 py-4">
+  <dl class="grid grid-cols-2 gap-4 sm:grid-cols-4 text-sm">
+    <div>
+      <dt class="text-xs font-medium text-gray-500 uppercase tracking-wider">Triggered by</dt>
+      <dd class="mt-1 text-gray-900"><%= @run.triggered_by || "—" %></dd>
+    </div>
+    <div>
+      <dt class="text-xs font-medium text-gray-500 uppercase tracking-wider">Started</dt>
+      <dd class="mt-1 text-gray-900"><%= @run.started_at ? @run.started_at.strftime("%Y-%m-%d %H:%M:%S") : "—" %></dd>
+    </div>
+    <div>
+      <dt class="text-xs font-medium text-gray-500 uppercase tracking-wider">Finished</dt>
+      <dd class="mt-1 text-gray-900"><%= @run.finished_at ? @run.finished_at.strftime("%Y-%m-%d %H:%M:%S") : "—" %></dd>
+    </div>
+    <div>
+      <dt class="text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</dt>
+      <dd class="mt-1 text-gray-900">
+        <% if @run.started_at && @run.finished_at %>
+          <%= distance_of_time_in_words(@run.started_at, @run.finished_at) %>
+        <% else %>
+          —
+        <% end %>
+      </dd>
+    </div>
+  </dl>
+  <% if @run.error.present? %>
+    <div class="mt-4 px-4 py-3 bg-red-50 border border-red-200 text-red-800 rounded-lg text-sm">
+      <%= @run.error %>
+    </div>
+  <% end %>
+</div>
+
+<div class="grid grid-cols-1 gap-4">
+  <% @steps_with_action_runs.each do |entry| %>
+    <% step = entry[:step] %>
+    <% action_runs = entry[:action_runs] %>
+    <% derived_status = entry[:derived_status] %>
+
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+      <div class="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
+        <span class="flex-shrink-0 w-6 h-6 bg-indigo-100 text-indigo-700 text-xs font-bold rounded-full flex items-center justify-center"><%= step.position %></span>
+        <h2 class="text-base font-semibold text-gray-900 flex-1"><%= step.name %></h2>
+        <%= render partial: "orchestration/pipeline_runs/status_badge", locals: { status: derived_status } %>
+      </div>
+
+      <% if action_runs.empty? %>
+        <p class="px-6 py-4 text-sm text-gray-400">No action runs recorded for this step.</p>
+      <% else %>
+        <div class="divide-y divide-gray-100">
+          <% action_runs.each do |ar| %>
+            <div class="px-6 py-4">
+              <div class="flex items-center justify-between mb-3">
+                <div class="flex items-center gap-3">
+                  <span class="font-medium text-sm text-gray-900"><%= ar.step_action.action.name %></span>
+                  <%= render partial: "orchestration/pipeline_runs/status_badge", locals: { status: ar.status } %>
+                </div>
+                <div class="text-xs text-gray-500">
+                  <% if ar.started_at %>
+                    <%= ar.started_at.strftime("%H:%M:%S") %>
+                    <% if ar.finished_at %>
+                      → <%= ar.finished_at.strftime("%H:%M:%S") %>
+                    <% end %>
+                  <% end %>
+                </div>
+              </div>
+
+              <% if ar.error.present? %>
+                <div class="mb-3 px-3 py-2 bg-red-50 border border-red-200 text-red-700 rounded text-xs">
+                  <%= ar.error %>
+                </div>
+              <% end %>
+
+              <% if ar.input.present? %>
+                <details class="mb-2">
+                  <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700">Input</summary>
+                  <pre class="mt-2 p-3 bg-gray-50 border border-gray-200 rounded text-xs font-mono overflow-x-auto"><%= JSON.pretty_generate(ar.input) %></pre>
+                </details>
+              <% end %>
+
+              <% if ar.output.present? %>
+                <details class="mb-2">
+                  <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700">Output</summary>
+                  <pre class="mt-2 p-3 bg-gray-50 border border-gray-200 rounded text-xs font-mono overflow-x-auto"><%= JSON.pretty_generate(ar.output) %></pre>
+                </details>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/orchestration/pipelines/show.html.erb
+++ b/app/views/orchestration/pipelines/show.html.erb
@@ -21,6 +21,7 @@
     <%= button_to "Delete", orchestration_pipeline_path(@pipeline), method: :delete,
           form: { data: { turbo_confirm: "Delete pipeline \"#{@pipeline.name}\"? This will also delete all steps and step-actions." } },
           class: "px-4 py-2 text-sm text-red-600 hover:text-red-800 font-medium border border-red-200 rounded-lg hover:bg-red-50 transition-colors bg-transparent cursor-pointer" %>
+    <%= link_to "Run History", orchestration_pipeline_pipeline_runs_path(@pipeline), class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= link_to "All Pipelines", orchestration_pipelines_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       member do
         post :run
       end
+      resources :pipeline_runs, only: [ :index, :show ]
       resources :steps, only: [ :create, :update, :destroy ] do
         member do
           patch :move_up

--- a/sig/app/controllers/orchestration/pipeline_runs_controller.rbs
+++ b/sig/app/controllers/orchestration/pipeline_runs_controller.rbs
@@ -6,6 +6,5 @@ module Orchestration
     private
 
     def set_pipeline: () -> void
-    def derive_status: (Array[Orchestration::ActionRun] action_runs) -> String
   end
 end

--- a/sig/app/controllers/orchestration/pipeline_runs_controller.rbs
+++ b/sig/app/controllers/orchestration/pipeline_runs_controller.rbs
@@ -1,0 +1,11 @@
+module Orchestration
+  class PipelineRunsController < ApplicationController
+    def index: () -> void
+    def show: () -> void
+
+    private
+
+    def set_pipeline: () -> void
+    def derive_status: (Array[Orchestration::ActionRun] action_runs) -> String
+  end
+end

--- a/sig/app/models/orchestration/step.rbs
+++ b/sig/app/models/orchestration/step.rbs
@@ -9,6 +9,8 @@ module Orchestration
     def input_mapping: () -> Hash[String, untyped]?
     def input_mapping=: (Hash[String, untyped]?) -> Hash[String, untyped]?
 
+    def self.derive_status: (Array[Orchestration::ActionRun] action_runs) -> String
+
     def pipeline: () -> Orchestration::Pipeline
     def pipeline=: (Orchestration::Pipeline) -> Orchestration::Pipeline
     def step_actions: () -> ActiveRecord::Associations::CollectionProxy[Orchestration::StepAction]

--- a/spec/models/orchestration/step_spec.rb
+++ b/spec/models/orchestration/step_spec.rb
@@ -13,6 +13,41 @@ RSpec.describe Orchestration::Step do
                     :orchestration_step, :pipeline, :orchestration_pipeline
   end
 
+  describe '.derive_status' do
+    def stub_run(status)
+      instance_double(Orchestration::ActionRun, status: status)
+    end
+
+    it 'returns pending when action_runs is empty' do
+      expect(described_class.derive_status([])).to eq('pending')
+    end
+
+    it 'returns completed when all action_runs are completed' do
+      runs = [ stub_run('completed'), stub_run('completed') ]
+      expect(described_class.derive_status(runs)).to eq('completed')
+    end
+
+    it 'returns failed when any action_run is failed' do
+      runs = [ stub_run('completed'), stub_run('failed') ]
+      expect(described_class.derive_status(runs)).to eq('failed')
+    end
+
+    it 'returns running when any action_run is running and none failed' do
+      runs = [ stub_run('completed'), stub_run('running') ]
+      expect(described_class.derive_status(runs)).to eq('running')
+    end
+
+    it 'returns failed over running when both are present' do
+      runs = [ stub_run('failed'), stub_run('running') ]
+      expect(described_class.derive_status(runs)).to eq('failed')
+    end
+
+    it 'returns pending when all action_runs are pending' do
+      runs = [ stub_run('pending'), stub_run('pending') ]
+      expect(described_class.derive_status(runs)).to eq('pending')
+    end
+  end
+
   describe 'associations' do
     it 'destroys step_actions when step is destroyed' do
       pipeline = create(:orchestration_pipeline)

--- a/spec/requests/orchestration/pipeline_runs_spec.rb
+++ b/spec/requests/orchestration/pipeline_runs_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Orchestration::PipelineRuns" do
+  describe "GET /orchestration/pipelines/:pipeline_id/pipeline_runs" do
+    it "returns 200 and lists runs with status, triggered_by, and timestamps" do
+      pipeline = create(:orchestration_pipeline, name: "My Pipeline")
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed",
+             triggered_by: "manual", started_at: Time.zone.parse("2026-03-01 10:00:00"),
+             finished_at: Time.zone.parse("2026-03-01 10:05:00"))
+
+      get orchestration_pipeline_pipeline_runs_path(pipeline)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("completed")
+      expect(response.body).to include("manual")
+    end
+
+    it "shows empty state when no runs exist" do
+      pipeline = create(:orchestration_pipeline)
+
+      get orchestration_pipeline_pipeline_runs_path(pipeline)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("No runs yet")
+    end
+
+    it "lists runs in reverse chronological order" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed",
+             created_at: 2.hours.ago)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "failed",
+             created_at: 1.hour.ago)
+
+      get orchestration_pipeline_pipeline_runs_path(pipeline)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.index("failed")).to be < response.body.index("completed")
+    end
+  end
+
+  describe "GET /orchestration/pipelines/:pipeline_id/pipeline_runs/:id" do
+    let(:pipeline) { create(:orchestration_pipeline, name: "My Pipeline") }
+    let(:step) { create(:orchestration_step, pipeline: pipeline, name: "Parse Step", position: 1) }
+    let(:action) { create(:orchestration_action, name: "Parser Action") }
+    let(:step_action) { create(:orchestration_step_action, step: step, action: action, position: 1) }
+
+    it "returns 200 and shows run details" do
+      run = create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed",
+                   triggered_by: "manual", started_at: Time.zone.parse("2026-03-01 10:00:00"),
+                   finished_at: Time.zone.parse("2026-03-01 10:05:00"))
+
+      get orchestration_pipeline_pipeline_run_path(pipeline, run)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("completed")
+      expect(response.body).to include("manual")
+    end
+
+    it "shows step-level derived status for action_runs" do
+      run = create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed")
+      create(:orchestration_action_run, pipeline_run: run, step_action: step_action,
+             status: "completed", started_at: Time.zone.parse("2026-03-01 10:00:00"),
+             finished_at: Time.zone.parse("2026-03-01 10:01:00"))
+
+      get orchestration_pipeline_pipeline_run_path(pipeline, run)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Parse Step")
+      expect(response.body).to include("Parser Action")
+    end
+
+    it "shows formatted JSON for action_run input and output" do
+      run = create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed")
+      create(:orchestration_action_run, pipeline_run: run, step_action: step_action,
+             status: "completed", input: { "email" => "test@example.com" },
+             output: { "result" => "ok" })
+
+      get orchestration_pipeline_pipeline_run_path(pipeline, run)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("test@example.com")
+      expect(response.body).to include("result")
+    end
+
+    it "shows error text when action_run has an error" do
+      run = create(:orchestration_pipeline_run, pipeline: pipeline, status: "failed",
+                   error: "Pipeline failed")
+      create(:orchestration_action_run, pipeline_run: run, step_action: step_action,
+             status: "failed", error: "Action timed out")
+
+      get orchestration_pipeline_pipeline_run_path(pipeline, run)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Action timed out")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `PipelineRunsController` with `index` and `show` actions nested under pipelines
- Index page: paginated list of runs with status badge, triggered_by, timestamps, duration
- Show page: step-by-step progress with derived status per step; per-action detail with status, timing, and collapsible JSON input/output; error display

Closes #8

## Test plan
- [x] All new tests pass (TDD red-green-refactor)
- [x] Full test suite passes (434 examples, 0 failures)
- [x] RuboCop passes (no offenses)
- [x] RBS signatures updated and validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)