### PR TITLE
feat: scheduled pipeline runs (cron-based + enable/disable)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "tailwindcss-rails"
 # Pipeline
 gem "async"
 gem "async-job-adapter-active_job"
+gem "fugit"
 gem "dotenv-rails"
 gem "dry-cli"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,8 @@ GEM
       zeitwerk (~> 2.6)
     erb (6.0.2)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     event_stream_parser (1.0.0)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
@@ -241,6 +243,9 @@ GEM
       path_expander (~> 2.0)
       prism (~> 1.7)
       sexp_processor (~> 4.8)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     google-apis-core (1.0.2)
@@ -380,6 +385,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.5)
     rack-session (2.1.1)
@@ -608,6 +614,7 @@ DEPENDENCIES
   dry-cli
   factory_bot_rails
   falcon
+  fugit
   google-apis-gmail_v1
   googleauth
   mail (~> 2.8)
@@ -694,6 +701,7 @@ CHECKSUMS
   dry-types (1.9.1) sha256=baebeecdb9f8395d6c9d227b62011279440943e3ef2468fe8ccc1ba11467f178
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
+  et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   event_stream_parser (1.0.0) sha256=a2683bab70126286f8184dc88f7968ffc4028f813161fb073ec90d171f7de3c8
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
@@ -708,6 +716,7 @@ CHECKSUMS
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
   flay (2.14.2) sha256=d153a8928a0b6f74d4aab7a97577b12440d02df928ffbafb6ebe4bb6730a53f8
   flog (4.9.4) sha256=12cc054fab7a2cbd2a906514397c4d7788954d530564782d6f14939dc2dfbcbb
+  fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   google-apis-core (1.0.2) sha256=ba4579aaadc902d6cc7bc8db88f566ab00f5e31ea87ab41e9f9a032c470f2629
   google-apis-gmail_v1 (0.47.0) sha256=3064434b6da55b85e2828ce4bb0f4d04e8cfd187a4ab262ceb1dcb01f98e49ef
@@ -773,6 +782,7 @@ CHECKSUMS
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -2,7 +2,7 @@
 
 module Orchestration
   class PipelinesController < ApplicationController
-    before_action :set_pipeline, only: [ :show, :edit, :update, :destroy, :run ]
+    before_action :set_pipeline, only: [ :show, :edit, :update, :destroy, :run, :toggle ]
 
     def index
       @pipelines = Orchestration::Pipeline
@@ -46,6 +46,12 @@ module Orchestration
       end
     end
 
+    def toggle
+      @pipeline.update!(enabled: !@pipeline.enabled)
+      redirect_to request.referer || orchestration_pipeline_path(@pipeline),
+                  notice: "Pipeline #{@pipeline.enabled? ? 'enabled' : 'disabled'}."
+    end
+
     def edit
     end
 
@@ -69,7 +75,7 @@ module Orchestration
     end
 
     def pipeline_params
-      params.require(:orchestration_pipeline).permit(:name, :description, :enabled)
+      params.require(:orchestration_pipeline).permit(:name, :description, :enabled, :cron_expression)
     end
   end
 end

--- a/app/jobs/scheduler_job.rb
+++ b/app/jobs/scheduler_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SchedulerJob < ApplicationJob
+  def perform
+    Orchestration::Pipeline
+      .where(enabled: true)
+      .where.not(cron_expression: [ nil, "" ])
+      .each do |pipeline|
+        next if pipeline.pipeline_runs.exists?(status: "running")
+
+        reference_time = pipeline.pipeline_runs
+          .where(status: "completed")
+          .order(finished_at: :desc)
+          .pick(:finished_at) || pipeline.created_at
+
+        next_time = pipeline.next_run_at(from: reference_time)
+        next unless next_time && next_time <= Time.current
+
+        pipeline_run = pipeline.pipeline_runs.create!(
+          status: "pending",
+          triggered_by: "schedule"
+        )
+        PipelineRunJob.perform_later(pipeline_run.id)
+      end
+  end
+end

--- a/app/jobs/scheduler_job.rb
+++ b/app/jobs/scheduler_job.rb
@@ -2,24 +2,22 @@
 
 class SchedulerJob < ApplicationJob
   def perform
+    running_ids = Orchestration::PipelineRun.where(status: "running").select(:pipeline_id)
+    latest_completed = Orchestration::PipelineRun
+      .where(status: "completed")
+      .group(:pipeline_id)
+      .maximum(:finished_at)
+
     Orchestration::Pipeline
       .where(enabled: true)
       .where.not(cron_expression: [ nil, "" ])
+      .where.not(id: running_ids)
       .each do |pipeline|
-        next if pipeline.pipeline_runs.exists?(status: "running")
-
-        reference_time = pipeline.pipeline_runs
-          .where(status: "completed")
-          .order(finished_at: :desc)
-          .pick(:finished_at) || pipeline.created_at
-
+        reference_time = latest_completed[pipeline.id] || pipeline.created_at
         next_time = pipeline.next_run_at(from: reference_time)
         next unless next_time && next_time <= Time.current
 
-        pipeline_run = pipeline.pipeline_runs.create!(
-          status: "pending",
-          triggered_by: "schedule"
-        )
+        pipeline_run = pipeline.pipeline_runs.create!(status: "pending", triggered_by: "schedule")
         PipelineRunJob.perform_later(pipeline_run.id)
       end
   end

--- a/app/models/orchestration/pipeline.rb
+++ b/app/models/orchestration/pipeline.rb
@@ -6,12 +6,19 @@ module Orchestration
     has_many :pipeline_runs, class_name: "Orchestration::PipelineRun", dependent: :destroy
 
     validates :name, presence: true
+    validate :cron_expression_parseable, if: -> { cron_expression.present? }
 
     def next_run_at(from: Time.current)
       return nil if cron_expression.blank?
       cron = Fugit::Cron.parse(cron_expression)
       return nil unless cron
       cron.next_time(from).to_t
+    end
+
+    private
+
+    def cron_expression_parseable
+      errors.add(:cron_expression, "is not a valid cron expression") unless Fugit::Cron.parse(cron_expression)
     end
   end
 end

--- a/app/models/orchestration/pipeline.rb
+++ b/app/models/orchestration/pipeline.rb
@@ -6,5 +6,12 @@ module Orchestration
     has_many :pipeline_runs, class_name: "Orchestration::PipelineRun", dependent: :destroy
 
     validates :name, presence: true
+
+    def next_run_at(from: Time.current)
+      return nil if cron_expression.blank?
+      cron = Fugit::Cron.parse(cron_expression)
+      return nil unless cron
+      cron.next_time(from).to_t
+    end
   end
 end

--- a/app/views/orchestration/pipelines/_form.html.erb
+++ b/app/views/orchestration/pipelines/_form.html.erb
@@ -23,6 +23,12 @@
     <%= f.text_area :description, rows: 2, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
   </div>
 
+  <div>
+    <%= f.label :cron_expression, "Cron Schedule", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :cron_expression, placeholder: "e.g. 0 * * * * (hourly)", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+    <p class="mt-1 text-xs text-gray-400">Standard 5-field cron expression. Leave blank to disable scheduled runs.</p>
+  </div>
+
   <div class="flex items-center gap-2">
     <%= f.check_box :enabled, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>
     <%= f.label :enabled, "Enabled", class: "text-sm font-medium text-gray-700" %>

--- a/app/views/orchestration/pipelines/index.html.erb
+++ b/app/views/orchestration/pipelines/index.html.erb
@@ -45,6 +45,8 @@
               <% end %>
             </td>
             <td class="px-4 py-3 text-right flex items-center justify-end gap-3">
+              <%= button_to pipeline.enabled? ? "Disable" : "Enable", toggle_orchestration_pipeline_path(pipeline), method: :patch,
+                    class: "text-gray-500 hover:text-gray-700 font-medium bg-transparent border-0 cursor-pointer p-0" %>
               <%= link_to "Edit", edit_orchestration_pipeline_path(pipeline), class: "text-indigo-600 hover:text-indigo-800 font-medium" %>
               <%= button_to "Delete", orchestration_pipeline_path(pipeline), method: :delete,
                     form: { data: { turbo_confirm: "Delete pipeline \"#{pipeline.name}\"? This will also delete all steps and step-actions." } },

--- a/app/views/orchestration/pipelines/show.html.erb
+++ b/app/views/orchestration/pipelines/show.html.erb
@@ -13,10 +13,15 @@
     <% if @pipeline.description.present? %>
       <p class="mt-1 text-sm text-gray-500"><%= @pipeline.description %></p>
     <% end %>
+    <% if @pipeline.cron_expression.present? %>
+      <p class="mt-1 text-xs text-gray-400 font-mono">Schedule: <%= @pipeline.cron_expression %></p>
+    <% end %>
   </div>
   <div class="flex items-center gap-3">
     <%= button_to "Run now", run_orchestration_pipeline_path(@pipeline), method: :post,
           class: "px-4 py-2 text-sm text-white font-medium bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
+    <%= button_to @pipeline.enabled? ? "Disable" : "Enable", toggle_orchestration_pipeline_path(@pipeline), method: :patch,
+          class: "px-4 py-2 text-sm font-medium border rounded-lg transition-colors bg-transparent cursor-pointer #{@pipeline.enabled? ? 'text-gray-600 border-gray-200 hover:bg-gray-50' : 'text-green-600 border-green-200 hover:bg-green-50'}" %>
     <%= link_to "Edit", edit_orchestration_pipeline_path(@pipeline), class: "px-4 py-2 text-sm text-indigo-600 hover:text-indigo-800 font-medium border border-indigo-200 rounded-lg hover:bg-indigo-50 transition-colors" %>
     <%= button_to "Delete", orchestration_pipeline_path(@pipeline), method: :delete,
           form: { data: { turbo_confirm: "Delete pipeline \"#{@pipeline.name}\"? This will also delete all steps and step-actions." } },

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,10 @@
+# Solid Queue recurring tasks configuration.
+# Requires Solid Queue as the queue adapter.
+# See https://github.com/rails/solid_queue#recurring-tasks
+
+production:
+  scheduler:
+    class: SchedulerJob
+    schedule: "* * * * *"
+    queue: default
+    description: "Check enabled pipelines and enqueue due runs every minute"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     resources :pipelines do
       member do
         post :run
+        patch :toggle
       end
       resources :pipeline_runs, only: [ :index, :show ]
       resources :steps, only: [ :create, :update, :destroy ] do

--- a/db/migrate/20260330154456_add_cron_expression_to_pipelines.rb
+++ b/db/migrate/20260330154456_add_cron_expression_to_pipelines.rb
@@ -1,0 +1,6 @@
+class AddCronExpressionToPipelines < ActiveRecord::Migration[8.1]
+  def change
+    add_column :pipelines, :cron_expression, :string
+    remove_column :pipelines, :schedule_interval, :integer
+  end
+end

--- a/db/migrate/20260330160511_add_index_to_pipelines_enabled_and_cron_expression.rb
+++ b/db/migrate/20260330160511_add_index_to_pipelines_enabled_and_cron_expression.rb
@@ -1,0 +1,5 @@
+class AddIndexToPipelinesEnabledAndCronExpression < ActiveRecord::Migration[8.1]
+  def change
+    add_index :pipelines, [ :enabled, :cron_expression ]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -43,7 +43,6 @@ CREATE INDEX "index_messages_on_role" ON "messages" ("role") /*application='Appl
 CREATE INDEX "index_messages_on_chat_id" ON "messages" ("chat_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_messages_on_model_id" ON "messages" ("model_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_messages_on_tool_call_id" ON "messages" ("tool_call_id") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "pipelines" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "schedule_interval" integer, "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE TABLE IF NOT EXISTS "steps" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_id" integer NOT NULL, "name" varchar NOT NULL, "position" integer NOT NULL, "input_mapping" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_bbcf3ea2ee"
 FOREIGN KEY ("pipeline_id")
   REFERENCES "pipelines" ("id")
@@ -78,7 +77,9 @@ CREATE INDEX "index_action_runs_on_pipeline_run_id" ON "action_runs" ("pipeline_
 CREATE INDEX "index_action_runs_on_step_action_id" ON "action_runs" ("step_action_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_action_runs_on_status" ON "action_runs" ("status") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_pipeline_runs_on_pipeline_id_and_created_at" ON "pipeline_runs" ("pipeline_id", "created_at") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "pipelines" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "cron_expression" varchar);
 INSERT INTO "schema_migrations" (version) VALUES
+('20260330154456'),
 ('20260330145327'),
 ('20260321000006'),
 ('20260321000005'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -78,7 +78,9 @@ CREATE INDEX "index_action_runs_on_step_action_id" ON "action_runs" ("step_actio
 CREATE INDEX "index_action_runs_on_status" ON "action_runs" ("status") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_pipeline_runs_on_pipeline_id_and_created_at" ON "pipeline_runs" ("pipeline_id", "created_at") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "pipelines" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "cron_expression" varchar);
+CREATE INDEX "index_pipelines_on_enabled_and_cron_expression" ON "pipelines" ("enabled", "cron_expression") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260330160511'),
 ('20260330154456'),
 ('20260330145327'),
 ('20260321000006'),

--- a/sig/app/controllers/orchestration/pipelines_controller.rbs
+++ b/sig/app/controllers/orchestration/pipelines_controller.rbs
@@ -5,6 +5,7 @@ module Orchestration
     def create: () -> void
     def show: () -> void
     def run: () -> void
+    def toggle: () -> void
     def edit: () -> void
     def update: () -> void
     def destroy: () -> void

--- a/sig/app/jobs/scheduler_job.rbs
+++ b/sig/app/jobs/scheduler_job.rbs
@@ -1,0 +1,3 @@
+class SchedulerJob < ApplicationJob
+  def perform: () -> void
+end

--- a/sig/app/models/orchestration/pipeline.rbs
+++ b/sig/app/models/orchestration/pipeline.rbs
@@ -6,10 +6,12 @@ module Orchestration
     def name=: (String?) -> String?
     def description: () -> String?
     def description=: (String?) -> String?
-    def schedule_interval: () -> Integer?
-    def schedule_interval=: (Integer?) -> Integer?
+    def cron_expression: () -> String?
+    def cron_expression=: (String?) -> String?
     def enabled: () -> bool
     def enabled=: (bool) -> bool
+
+    def next_run_at: (?from: Time) -> Time?
 
     def steps: () -> ActiveRecord::Associations::CollectionProxy[Orchestration::Step]
     def pipeline_runs: () -> ActiveRecord::Associations::CollectionProxy[Orchestration::PipelineRun]

--- a/sig/app/models/orchestration/pipeline.rbs
+++ b/sig/app/models/orchestration/pipeline.rbs
@@ -15,5 +15,9 @@ module Orchestration
 
     def steps: () -> ActiveRecord::Associations::CollectionProxy[Orchestration::Step]
     def pipeline_runs: () -> ActiveRecord::Associations::CollectionProxy[Orchestration::PipelineRun]
+
+    private
+
+    def cron_expression_parseable: () -> void
   end
 end

--- a/spec/jobs/scheduler_job_spec.rb
+++ b/spec/jobs/scheduler_job_spec.rb
@@ -69,6 +69,26 @@ RSpec.describe SchedulerJob do
       end
     end
 
+    context "with multiple due pipelines" do
+      it "issues a fixed number of queries regardless of pipeline count" do
+        3.times do
+          p = create(:orchestration_pipeline, enabled: true, cron_expression: cron_expression)
+          p.update_column(:created_at, 2.hours.ago)
+        end
+
+        # 3 constant read queries (running ids, latest completed, pipeline load)
+        # + 1 INSERT per due pipeline — no per-pipeline read queries (no N+1)
+        query_count = 0
+        counter = ->(*, **) { query_count += 1 }
+        ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+          described_class.new.perform
+        end
+
+        # 16 would be the N+1 count (old impl); ceiling here ensures reads stay constant
+        expect(query_count).to be <= 12
+      end
+    end
+
     context "when the next tick is in the future" do
       it "does not enqueue a run" do
         # Use an expression that only runs at midnight, so next run is in the future

--- a/spec/jobs/scheduler_job_spec.rb
+++ b/spec/jobs/scheduler_job_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchedulerJob do
+  let(:cron_expression) { "* * * * *" } # every minute
+
+  before do
+    allow(PipelineRunJob).to receive(:perform_later)
+  end
+
+  describe "#perform" do
+    context "when a pipeline is enabled with a cron_expression and is due" do
+      let!(:pipeline) do
+        p = create(:orchestration_pipeline, enabled: true, cron_expression: cron_expression)
+        p.update_column(:created_at, 2.hours.ago)
+        p
+      end
+
+      it "creates a pending pipeline run attributed to the pipeline" do
+        described_class.new.perform
+
+        run = Orchestration::PipelineRun.last
+        expect(run.pipeline).to eq(pipeline)
+        expect(run.triggered_by).to eq("schedule")
+        expect(run.status).to eq("pending")
+      end
+
+      it "enqueues PipelineRunJob for the created run" do
+        described_class.new.perform
+        expect(PipelineRunJob).to have_received(:perform_later).with(Orchestration::PipelineRun.last.id)
+      end
+    end
+
+    context "when a pipeline is disabled" do
+      it "does not enqueue a run" do
+        create(:orchestration_pipeline, enabled: false, cron_expression: cron_expression)
+
+        expect {
+          described_class.new.perform
+        }.not_to change(Orchestration::PipelineRun, :count)
+
+        expect(PipelineRunJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when a pipeline has no cron_expression" do
+      it "does not enqueue a run" do
+        create(:orchestration_pipeline, enabled: true, cron_expression: nil)
+
+        expect {
+          described_class.new.perform
+        }.not_to change(Orchestration::PipelineRun, :count)
+
+        expect(PipelineRunJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when a pipeline already has a running run" do
+      it "does not enqueue another run" do
+        pipeline = create(:orchestration_pipeline, enabled: true, cron_expression: cron_expression)
+        create(:orchestration_pipeline_run, pipeline: pipeline, status: "running")
+
+        expect {
+          described_class.new.perform
+        }.not_to change(Orchestration::PipelineRun, :count)
+
+        expect(PipelineRunJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when the next tick is in the future" do
+      it "does not enqueue a run" do
+        # Use an expression that only runs at midnight, so next run is in the future
+        pipeline = create(:orchestration_pipeline, enabled: true, cron_expression: "0 0 * * *")
+        # Simulate a completed run that just finished now, so next run is tomorrow midnight
+        create(:orchestration_pipeline_run,
+               pipeline: pipeline,
+               status: "completed",
+               finished_at: Time.current)
+
+        expect {
+          described_class.new.perform
+        }.not_to change(Orchestration::PipelineRun, :count)
+      end
+    end
+  end
+end

--- a/spec/models/orchestration/pipeline_spec.rb
+++ b/spec/models/orchestration/pipeline_spec.rb
@@ -28,4 +28,30 @@ RSpec.describe Orchestration::Pipeline do
       expect { pipeline.destroy }.to change(Orchestration::PipelineRun, :count).by(-1)
     end
   end
+
+  describe '#next_run_at' do
+    it 'returns nil when cron_expression is nil' do
+      pipeline = build(:orchestration_pipeline, cron_expression: nil)
+      expect(pipeline.next_run_at).to be_nil
+    end
+
+    it 'returns nil when cron_expression is blank' do
+      pipeline = build(:orchestration_pipeline, cron_expression: '')
+      expect(pipeline.next_run_at).to be_nil
+    end
+
+    it 'returns the next scheduled time from the given reference time' do
+      pipeline = build(:orchestration_pipeline, cron_expression: '0 * * * *')
+      from = Time.utc(2026, 3, 30, 10, 0, 0)
+      result = pipeline.next_run_at(from: from)
+      expect(result).to eq(Time.utc(2026, 3, 30, 11, 0, 0))
+    end
+
+    it 'defaults from to Time.current when not provided' do
+      pipeline = build(:orchestration_pipeline, cron_expression: '0 * * * *')
+      result = pipeline.next_run_at
+      expect(result).to be_a(Time)
+      expect(result).to be > Time.current
+    end
+  end
 end

--- a/spec/models/orchestration/pipeline_spec.rb
+++ b/spec/models/orchestration/pipeline_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe Orchestration::Pipeline do
       pipeline = described_class.new(name: 'My Pipeline')
       expect(pipeline.enabled).to be true
     end
+
+    it 'is valid with a blank cron_expression' do
+      pipeline = build(:orchestration_pipeline, cron_expression: '')
+      expect(pipeline).to be_valid
+    end
+
+    it 'is valid with a valid cron_expression' do
+      pipeline = build(:orchestration_pipeline, cron_expression: '0 * * * *')
+      expect(pipeline).to be_valid
+    end
+
+    it 'is invalid with a malformed cron_expression' do
+      pipeline = build(:orchestration_pipeline, cron_expression: 'not-a-cron')
+      expect(pipeline).not_to be_valid
+      expect(pipeline.errors[:cron_expression]).to be_present
+    end
   end
 
   describe 'associations' do

--- a/spec/requests/orchestration/pipelines_spec.rb
+++ b/spec/requests/orchestration/pipelines_spec.rb
@@ -379,6 +379,37 @@ RSpec.describe "Orchestration::Pipelines" do
     end
   end
 
+  describe "PATCH /orchestration/pipelines/:id/toggle" do
+    it "disables an enabled pipeline and redirects" do
+      pipeline = create(:orchestration_pipeline, enabled: true)
+
+      patch toggle_orchestration_pipeline_path(pipeline)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(pipeline.reload.enabled).to be false
+    end
+
+    it "enables a disabled pipeline and redirects" do
+      pipeline = create(:orchestration_pipeline, enabled: false)
+
+      patch toggle_orchestration_pipeline_path(pipeline)
+
+      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+      expect(pipeline.reload.enabled).to be true
+    end
+  end
+
+  describe "POST /orchestration/pipelines with cron_expression" do
+    it "creates a pipeline with cron_expression" do
+      post orchestration_pipelines_path, params: {
+        orchestration_pipeline: { name: "Cron Pipeline", cron_expression: "0 * * * *", enabled: true }
+      }
+
+      expect(response).to redirect_to(orchestration_pipeline_path(Orchestration::Pipeline.last))
+      expect(Orchestration::Pipeline.last.cron_expression).to eq("0 * * * *")
+    end
+  end
+
   describe "DELETE /orchestration/pipelines/:pipeline_id/steps/:step_id/step_actions/:id" do
     it "detaches action from step and redirects to pipeline show" do
       pipeline = create(:orchestration_pipeline)


### PR DESCRIPTION
## Summary
- Add `cron_expression` field to pipelines (replaces `schedule_interval`); `Pipeline#next_run_at` computes next scheduled time via `fugit`
- `SchedulerJob` queries enabled pipelines with due cron ticks and enqueues `PipelineRunJob` with `triggered_by: "schedule"` (skips disabled, nil-expression, and already-running pipelines)
- Enable/disable toggle on pipeline index and show pages; `cron_expression` field in edit form; `config/recurring.yml` for Solid Queue recurring task setup

Closes #9

## Test plan
- [x] All new tests pass (TDD red-green-refactor)
- [x] Full test suite passes (453 examples, 0 failures)
- [x] RuboCop passes (no offenses)
- [x] RBS signatures updated for Pipeline, PipelinesController, SchedulerJob

🤖 Generated with [Claude Code](https://claude.com/claude-code)