### PR TITLE
feat: install and configure Leva gem as evaluation foundation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gem "sqlite-vec"
 gem "aasm", "~> 5.5"
 gem "view_component", "~> 4.6"
 
+# Evaluation framework
+gem "leva"
+gem "liquid"
+
 # LLM
 gem "ruby_llm", github: "crmne/ruby_llm", branch: "main"
 gem "ruby_llm-monitoring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,13 @@ GEM
       addressable (~> 2.8)
       childprocess (~> 5.0)
       logger (~> 1.6)
+    leva (0.3.4)
+      liquid (~> 5.5)
+      rails (>= 7.2.0)
     lint_roller (1.1.0)
+    liquid (5.12.0)
+      bigdecimal
+      strscan (>= 3.1.1)
     listen (3.10.0)
       logger
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -701,6 +707,8 @@ DEPENDENCIES
   google-apis-gmail_v1
   googleauth
   jsbundling-rails
+  leva
+  liquid
   mail (~> 2.8)
   mutant
   mutant-rspec
@@ -835,7 +843,9 @@ CHECKSUMS
   jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
+  leva (0.3.4) sha256=75c6e0b855e23f7ea37b1eba1c4c4839600f2d61cd501f77527f603bfec62cf5
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  liquid (5.12.0) sha256=5a3c2c2430cd925d21c53e4ed9abea52cd0a9da53b541422f81dee79aca2a673
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   localhost (1.7.0) sha256=09b32819537f914ccdf0a7c595fab162517401b6ef644a2afd3708d943c4547f
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/app/components/ui/navbar_component.rb
+++ b/app/components/ui/navbar_component.rb
@@ -15,7 +15,8 @@ module UI
         NavItem.new(label: "Actions",   path: helpers.orchestration_actions_path),
         NavItem.new(label: "Emails",    path: helpers.application_mails_path),
         NavItem.new(label: "Interviews", path: helpers.interviews_path),
-        NavItem.new(label: "Monitoring", path: helpers.ruby_llm_monitoring.root_path)
+        NavItem.new(label: "Monitoring", path: helpers.ruby_llm_monitoring.root_path),
+        NavItem.new(label: "Evaluation", path: helpers.leva.root_path)
       ]
     end
 

--- a/app/models/orchestration/action_run.rb
+++ b/app/models/orchestration/action_run.rb
@@ -1,5 +1,7 @@
 module Orchestration
   class ActionRun < ApplicationRecord
+    include Leva::Recordable
+
     self.table_name = "action_runs"
 
     STATUSES = %w[pending running completed failed].freeze
@@ -9,5 +11,38 @@ module Orchestration
     belongs_to :chat, optional: true
 
     validates :status, presence: true, inclusion: { in: STATUSES }
+
+    def ground_truth
+      output&.dig("classification")
+    end
+
+    def index_attributes
+      {
+        status: status,
+        action: step_action.action.name,
+        started_at: started_at,
+        finished_at: finished_at
+      }
+    end
+
+    def show_attributes
+      {
+        status: status,
+        action: step_action.action.name,
+        input: input,
+        output: output,
+        error: error,
+        started_at: started_at,
+        finished_at: finished_at
+      }
+    end
+
+    def to_llm_context
+      {
+        action: step_action.action.name,
+        input: input,
+        status: status
+      }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   mount RubyLLM::Monitoring::Engine, at: "/monitoring"
+  mount Leva::Engine, at: "/leva"
 
   resources :chats, only: [ :index, :show, :destroy ] do
     collection do

--- a/db/migrate/20260414120021_create_leva_datasets.leva.rb
+++ b/db/migrate/20260414120021_create_leva_datasets.leva.rb
@@ -1,0 +1,11 @@
+# This migration comes from leva (originally 20240813172916)
+class CreateLevaDatasets < ActiveRecord::Migration[7.2]
+  def change
+    create_table :leva_datasets do |t|
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260414120022_create_leva_dataset_records.leva.rb
+++ b/db/migrate/20260414120022_create_leva_dataset_records.leva.rb
@@ -1,0 +1,12 @@
+# This migration comes from leva (originally 20240813173033)
+class CreateLevaDatasetRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :leva_dataset_records do |t|
+      t.references :dataset, null: false, foreign_key: { to_table: :leva_datasets }
+      t.references :recordable, polymorphic: true, null: false
+      t.text :actual_result
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260414120023_create_leva_prompts.leva.rb
+++ b/db/migrate/20260414120023_create_leva_prompts.leva.rb
@@ -1,0 +1,14 @@
+# This migration comes from leva (originally 20240813173034)
+class CreateLevaPrompts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :leva_prompts do |t|
+      t.string :name
+      t.integer :version
+      t.text :system_prompt
+      t.text :user_prompt
+      t.text :metadata
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260414120024_create_leva_experiments.leva.rb
+++ b/db/migrate/20260414120024_create_leva_experiments.leva.rb
@@ -1,0 +1,17 @@
+# This migration comes from leva (originally 20240813173035)
+class CreateLevaExperiments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :leva_experiments do |t|
+      t.string :name
+      t.text :description
+      t.references :dataset, null: false, foreign_key: { to_table: :leva_datasets }
+      t.references :prompt, null: true, foreign_key: { to_table: :leva_prompts }
+      t.integer :status
+      t.text :metadata
+      t.string :runner_class
+      t.text :evaluator_classes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260414120025_create_leva_runner_results.leva.rb
+++ b/db/migrate/20260414120025_create_leva_runner_results.leva.rb
@@ -1,0 +1,15 @@
+# This migration comes from leva (originally 20240813173040)
+class CreateLevaRunnerResults < ActiveRecord::Migration[7.2]
+  def change
+    create_table :leva_runner_results do |t|
+      t.references :experiment, null: true, foreign_key: { to_table: :leva_experiments }
+      t.references :dataset_record, null: false, foreign_key: { to_table: :leva_dataset_records }
+      t.references :prompt, null: false, foreign_key: { to_table: :leva_prompts }
+      t.integer :prompt_version
+      t.text :prediction
+      t.string :runner_class
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260414120026_create_leva_evaluation_results.leva.rb
+++ b/db/migrate/20260414120026_create_leva_evaluation_results.leva.rb
@@ -1,0 +1,14 @@
+# This migration comes from leva (originally 20240813173050)
+class CreateLevaEvaluationResults < ActiveRecord::Migration[7.2]
+  def change
+    create_table :leva_evaluation_results do |t|
+      t.references :experiment, null: true, foreign_key: { to_table: :leva_experiments }
+      t.references :dataset_record, null: false, foreign_key: { to_table: :leva_dataset_records }
+      t.references :runner_result, null: false, foreign_key: { to_table: :leva_runner_results }
+      t.string :evaluator_class, null: false
+      t.float :score
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260414120027_create_leva_optimization_runs.leva.rb
+++ b/db/migrate/20260414120027_create_leva_optimization_runs.leva.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This migration comes from leva (originally 20241204000001)
+class CreateLevaOptimizationRuns < ActiveRecord::Migration[7.2]
+  def change
+    create_table :leva_optimization_runs do |t|
+      t.references :dataset, null: false, foreign_key: { to_table: :leva_datasets }
+      t.references :prompt, foreign_key: { to_table: :leva_prompts }
+      t.string :status, default: "pending", null: false
+      t.string :current_step
+      t.integer :progress, default: 0, null: false
+      t.integer :examples_processed, default: 0
+      t.integer :total_examples
+      t.string :prompt_name, null: false
+      t.string :mode, default: "light", null: false
+      t.text :error_message
+      t.json :metadata
+      t.string :model
+      t.string :optimizer, default: "bootstrap", null: false
+
+      t.timestamps
+    end
+
+    add_index :leva_optimization_runs, :status
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -79,13 +79,72 @@ FOREIGN KEY ("pipeline_run_id")
 , CONSTRAINT "fk_rails_2f2096f1b1"
 FOREIGN KEY ("chat_id")
   REFERENCES "chats" ("id")
- ON DELETE SET NULL
 );
 CREATE INDEX "index_action_runs_on_pipeline_run_id" ON "action_runs" ("pipeline_run_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_action_runs_on_step_action_id" ON "action_runs" ("step_action_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_action_runs_on_status" ON "action_runs" ("status") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_action_runs_on_chat_id" ON "action_runs" ("chat_id") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "leva_datasets" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "description" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "leva_dataset_records" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "dataset_id" integer NOT NULL, "recordable_type" varchar NOT NULL, "recordable_id" integer NOT NULL, "actual_result" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_a0599aa621"
+FOREIGN KEY ("dataset_id")
+  REFERENCES "leva_datasets" ("id")
+);
+CREATE INDEX "index_leva_dataset_records_on_dataset_id" ON "leva_dataset_records" ("dataset_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_dataset_records_on_recordable" ON "leva_dataset_records" ("recordable_type", "recordable_id") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "leva_prompts" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "version" integer, "system_prompt" text, "user_prompt" text, "metadata" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "leva_experiments" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "description" text, "dataset_id" integer NOT NULL, "prompt_id" integer, "status" integer, "metadata" text, "runner_class" varchar, "evaluator_classes" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_067bfa5025"
+FOREIGN KEY ("dataset_id")
+  REFERENCES "leva_datasets" ("id")
+, CONSTRAINT "fk_rails_4aa77a56d1"
+FOREIGN KEY ("prompt_id")
+  REFERENCES "leva_prompts" ("id")
+);
+CREATE INDEX "index_leva_experiments_on_dataset_id" ON "leva_experiments" ("dataset_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_experiments_on_prompt_id" ON "leva_experiments" ("prompt_id") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "leva_runner_results" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "experiment_id" integer, "dataset_record_id" integer NOT NULL, "prompt_id" integer NOT NULL, "prompt_version" integer, "prediction" text, "runner_class" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_abd1d29b91"
+FOREIGN KEY ("experiment_id")
+  REFERENCES "leva_experiments" ("id")
+, CONSTRAINT "fk_rails_bbc5ca9d18"
+FOREIGN KEY ("dataset_record_id")
+  REFERENCES "leva_dataset_records" ("id")
+, CONSTRAINT "fk_rails_919dd5b17f"
+FOREIGN KEY ("prompt_id")
+  REFERENCES "leva_prompts" ("id")
+);
+CREATE INDEX "index_leva_runner_results_on_experiment_id" ON "leva_runner_results" ("experiment_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_runner_results_on_dataset_record_id" ON "leva_runner_results" ("dataset_record_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_runner_results_on_prompt_id" ON "leva_runner_results" ("prompt_id") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "leva_evaluation_results" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "experiment_id" integer, "dataset_record_id" integer NOT NULL, "runner_result_id" integer NOT NULL, "evaluator_class" varchar NOT NULL, "score" float, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_54593eaaa5"
+FOREIGN KEY ("experiment_id")
+  REFERENCES "leva_experiments" ("id")
+, CONSTRAINT "fk_rails_e225e3559f"
+FOREIGN KEY ("dataset_record_id")
+  REFERENCES "leva_dataset_records" ("id")
+, CONSTRAINT "fk_rails_706698fcd9"
+FOREIGN KEY ("runner_result_id")
+  REFERENCES "leva_runner_results" ("id")
+);
+CREATE INDEX "index_leva_evaluation_results_on_experiment_id" ON "leva_evaluation_results" ("experiment_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_evaluation_results_on_dataset_record_id" ON "leva_evaluation_results" ("dataset_record_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_evaluation_results_on_runner_result_id" ON "leva_evaluation_results" ("runner_result_id") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "leva_optimization_runs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "dataset_id" integer NOT NULL, "prompt_id" integer, "status" varchar DEFAULT 'pending' NOT NULL, "current_step" varchar, "progress" integer DEFAULT 0 NOT NULL, "examples_processed" integer DEFAULT 0, "total_examples" integer, "prompt_name" varchar NOT NULL, "mode" varchar DEFAULT 'light' NOT NULL, "error_message" text, "metadata" json, "model" varchar, "optimizer" varchar DEFAULT 'bootstrap' NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_7f27bdc0a6"
+FOREIGN KEY ("dataset_id")
+  REFERENCES "leva_datasets" ("id")
+, CONSTRAINT "fk_rails_b09005ac77"
+FOREIGN KEY ("prompt_id")
+  REFERENCES "leva_prompts" ("id")
+);
+CREATE INDEX "index_leva_optimization_runs_on_dataset_id" ON "leva_optimization_runs" ("dataset_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_optimization_runs_on_prompt_id" ON "leva_optimization_runs" ("prompt_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_leva_optimization_runs_on_status" ON "leva_optimization_runs" ("status") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260414120027'),
+('20260414120026'),
+('20260414120025'),
+('20260414120024'),
+('20260414120023'),
+('20260414120022'),
+('20260414120021'),
 ('20260411074607'),
 ('20260410145544'),
 ('20260410145543'),

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -453,6 +453,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: strscan
+  version: '0'
+  source:
+    type: stdlib
 - name: tempfile
   version: '0'
   source:

--- a/sig/app/models/orchestration/action_run.rbs
+++ b/sig/app/models/orchestration/action_run.rbs
@@ -25,5 +25,10 @@ module Orchestration
     def chat=: (Chat?) -> Chat?
     def chat_id: () -> Integer?
     def chat_id=: (Integer?) -> Integer?
+
+    def ground_truth: () -> String?
+    def index_attributes: () -> Hash[Symbol, untyped]
+    def show_attributes: () -> Hash[Symbol, untyped]
+    def to_llm_context: () -> Hash[Symbol, untyped]
   end
 end

--- a/spec/components/ui/navbar_component_spec.rb
+++ b/spec/components/ui/navbar_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UI::NavbarComponent, type: :component do
   it "renders all nav items" do
     items = rendered.css("[data-testid='navbar-item']")
     labels = items.map { |n| n.text.strip }
-    expect(labels).to eq(%w[Chats Pipelines Actions Emails Interviews Monitoring])
+    expect(labels).to eq(%w[Chats Pipelines Actions Emails Interviews Monitoring Evaluation])
   end
 
   it "renders a nav element" do

--- a/spec/models/orchestration/action_run_spec.rb
+++ b/spec/models/orchestration/action_run_spec.rb
@@ -34,4 +34,55 @@ RSpec.describe Orchestration::ActionRun do
       expect(action_run.chat).to eq(chat)
     end
   end
+
+  describe 'Leva::Recordable' do
+    it 'includes Leva::Recordable' do
+      expect(described_class.ancestors).to include(Leva::Recordable)
+    end
+
+    it 'has dataset_records association' do
+      action_run = create(:orchestration_action_run)
+      expect(action_run.dataset_records).to eq([])
+    end
+
+    describe '#ground_truth' do
+      it 'returns the output classification from action run output' do
+        action_run = create(:orchestration_action_run, output: { 'classification' => 'offer' })
+        expect(action_run.ground_truth).to eq('offer')
+      end
+
+      it 'returns nil when output is blank' do
+        action_run = create(:orchestration_action_run, output: nil)
+        expect(action_run.ground_truth).to be_nil
+      end
+    end
+
+    describe '#index_attributes' do
+      it 'returns hash with status and action name' do
+        action_run = create(:orchestration_action_run, status: 'completed')
+        result = action_run.index_attributes
+        expect(result).to include(status: 'completed')
+        expect(result).to have_key(:action)
+      end
+    end
+
+    describe '#show_attributes' do
+      it 'returns hash including input, output, and status' do
+        action_run = create(:orchestration_action_run, status: 'completed', input: { 'email' => 'test' }, output: { 'result' => 'ok' })
+        result = action_run.show_attributes
+        expect(result).to include(status: 'completed')
+        expect(result).to have_key(:input)
+        expect(result).to have_key(:output)
+      end
+    end
+
+    describe '#to_llm_context' do
+      it 'returns hash with input and action info' do
+        action_run = create(:orchestration_action_run, input: { 'email' => 'test body' })
+        result = action_run.to_llm_context
+        expect(result).to have_key(:input)
+        expect(result).to have_key(:action)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Installs `leva` gem and runs its migrations (7 new tables: datasets, dataset_records, prompts, experiments, runner_results, evaluation_results, optimization_runs)
- Mounts `Leva::Engine` at `/leva` and adds Evaluation link to navbar
- Includes `Leva::Recordable` in `Orchestration::ActionRun` and implements `ground_truth`, `index_attributes`, `show_attributes`, `to_llm_context`

Closes #31

## Test plan
- [x] New `Leva::Recordable` behavior tests pass (ActionRun spec)
- [x] Navbar spec updated and passes
- [x] All 921 existing tests still pass
- [x] RuboCop passes
- [x] Steep type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)