### PR TITLE
feat: LLM-as-judge evaluator with per-metric scoring

### DIFF
--- a/app/evals/llm_judge_eval.rb
+++ b/app/evals/llm_judge_eval.rb
@@ -21,6 +21,11 @@ class LLMJudgeEval < Leva::BaseEval
     metrics = Evaluation::Metric.for_agent(agent_name(recordable)).active
     return [] if metrics.none?
 
+    if runner_result.prediction.blank?
+      Rails.logger.error("LLMJudgeEval: prediction is blank")
+      return []
+    end
+
     prompt_text = fetch_instructions(agent_name(recordable))
     prediction = JSON.parse(runner_result.prediction)
     expected_tool_calls = Evaluation::ToolCallExtractor.call(recordable.chat)
@@ -33,32 +38,31 @@ class LLMJudgeEval < Leva::BaseEval
       output: prediction.fetch("output", ""),
       metrics: metrics
     )
-  rescue JSON::ParserError => e
-    Rails.logger.error("LlmJudgeEval: failed to parse prediction JSON: #{e.message}")
+  rescue JSON::ParserError, TypeError => e
+    Rails.logger.error("LLMJudgeEval: failed to parse prediction JSON: #{e.message}")
     []
   end
 
   def evaluate_and_store(experiment, runner_result)
-    @experiment = experiment
-    @runner_result = runner_result
-
     recordable = runner_result.dataset_record.recordable
     results = evaluate(runner_result, recordable)
 
     results.map do |metric_result|
-      eval_result = Leva::EvaluationResult.create!(
-        experiment: experiment,
-        dataset_record: runner_result.dataset_record,
-        runner_result: runner_result,
-        score: metric_result[:score].to_f,
-        evaluator_class: self.class.name
-      )
-      Evaluation::Justification.create!(
-        evaluation_result: eval_result,
-        metric_name: metric_result[:metric_name],
-        justification: metric_result[:justification]
-      )
-      eval_result
+      ActiveRecord::Base.transaction do
+        eval_result = Leva::EvaluationResult.create!(
+          experiment: experiment,
+          dataset_record: runner_result.dataset_record,
+          runner_result: runner_result,
+          score: metric_result[:score].to_f,
+          evaluator_class: self.class.name
+        )
+        Evaluation::Justification.create!(
+          evaluation_result: eval_result,
+          metric_name: metric_result[:metric_name],
+          justification: metric_result[:justification]
+        )
+        eval_result
+      end
     end
   end
 
@@ -93,7 +97,7 @@ class LLMJudgeEval < Leva::BaseEval
 
     parse_judge_response(response.content)
   rescue StandardError => e
-    Rails.logger.error("LlmJudgeEval: judge call failed: #{e.message}")
+    Rails.logger.error("LLMJudgeEval: judge call failed: #{e.message}")
     []
   end
 
@@ -125,15 +129,25 @@ class LLMJudgeEval < Leva::BaseEval
     parsed = JSON.parse(content)
     raise ArgumentError, "expected Array" unless parsed.is_a?(Array)
 
-    parsed.map do |entry|
-      {
-        metric_name: entry["metric_name"].to_s,
-        score: entry["score"].to_f,
-        justification: entry["justification"].to_s
-      }
-    end
+    parsed.each_with_index.filter_map { |entry, i| normalize_entry(entry, i) }
   rescue JSON::ParserError, ArgumentError => e
-    Rails.logger.error("LlmJudgeEval: failed to parse judge response: #{e.message}")
+    Rails.logger.error("LLMJudgeEval: failed to parse judge response: #{e.message}")
     []
+  end
+
+  def normalize_entry(entry, index)
+    score = Float(entry["score"])
+    metric_name = entry["metric_name"].to_s.strip
+    justification = entry["justification"].to_s.strip
+
+    unless score.between?(1.0, 5.0) && metric_name.present? && justification.present?
+      Rails.logger.warn("LLMJudgeEval: dropping entry #{index}: score out of range or missing fields")
+      return nil
+    end
+
+    { metric_name: metric_name, score: score, justification: justification }
+  rescue ArgumentError, TypeError
+    Rails.logger.warn("LLMJudgeEval: dropping entry #{index}: unparseable score #{entry['score'].inspect}")
+    nil
   end
 end

--- a/app/evals/llm_judge_eval.rb
+++ b/app/evals/llm_judge_eval.rb
@@ -1,0 +1,139 @@
+class LLMJudgeEval < Leva::BaseEval
+  SYSTEM_PROMPT = <<~PROMPT.freeze
+    You are an impartial LLM judge evaluating an AI agent's response.
+    You will be given the agent's instructions, the input it received, the expected tool call sequence,
+    the actual tool call sequence, the output, and a set of evaluation metrics with rubrics.
+
+    For each metric, assign a score from 1 to 5 and provide a justification.
+    Return ONLY a JSON array with no additional text. Each element must have:
+    - "metric_name": the metric name (string)
+    - "score": integer from 1 to 5
+    - "justification": explanation of the score (string)
+  PROMPT
+
+  @judge_model = ENV.fetch("JUDGE_LLM_MODEL", "claude-sonnet-4-6")
+
+  class << self
+    attr_accessor :judge_model
+  end
+
+  def evaluate(runner_result, recordable)
+    metrics = Evaluation::Metric.for_agent(agent_name(recordable)).active
+    return [] if metrics.none?
+
+    prompt_text = fetch_instructions(agent_name(recordable))
+    prediction = JSON.parse(runner_result.prediction)
+    expected_tool_calls = Evaluation::ToolCallExtractor.call(recordable.chat)
+
+    call_judge(
+      instructions: prompt_text,
+      input: recordable.input,
+      expected_tool_calls: expected_tool_calls,
+      actual_tool_calls: prediction.fetch("tool_calls", []),
+      output: prediction.fetch("output", ""),
+      metrics: metrics
+    )
+  rescue JSON::ParserError => e
+    Rails.logger.error("LlmJudgeEval: failed to parse prediction JSON: #{e.message}")
+    []
+  end
+
+  def evaluate_and_store(experiment, runner_result)
+    @experiment = experiment
+    @runner_result = runner_result
+
+    recordable = runner_result.dataset_record.recordable
+    results = evaluate(runner_result, recordable)
+
+    results.map do |metric_result|
+      eval_result = Leva::EvaluationResult.create!(
+        experiment: experiment,
+        dataset_record: runner_result.dataset_record,
+        runner_result: runner_result,
+        score: metric_result[:score].to_f,
+        evaluator_class: self.class.name
+      )
+      Evaluation::Justification.create!(
+        evaluation_result: eval_result,
+        metric_name: metric_result[:metric_name],
+        justification: metric_result[:justification]
+      )
+      eval_result
+    end
+  end
+
+  private
+
+  def agent_name(recordable)
+    recordable.step_action.action.agent_class
+  end
+
+  def fetch_instructions(agent_name)
+    Leva::Prompt
+      .where(name: agent_name)
+      .order(version: :desc, id: :desc)
+      .first
+      &.system_prompt
+  end
+
+  def call_judge(instructions:, input:, expected_tool_calls:, actual_tool_calls:, output:, metrics:)
+    user_message = build_user_message(
+      instructions: instructions,
+      input: input,
+      expected_tool_calls: expected_tool_calls,
+      actual_tool_calls: actual_tool_calls,
+      output: output,
+      metrics: metrics
+    )
+
+    response = RubyLLM.chat(model: self.class.judge_model)
+                      .with_temperature(0)
+                      .with_instructions(SYSTEM_PROMPT)
+                      .ask(user_message)
+
+    parse_judge_response(response.content)
+  rescue StandardError => e
+    Rails.logger.error("LlmJudgeEval: judge call failed: #{e.message}")
+    []
+  end
+
+  def build_user_message(instructions:, input:, expected_tool_calls:, actual_tool_calls:, output:, metrics:)
+    rubrics = metrics.map { |m| "- #{m.name}: #{m.description}" }.join("\n")
+
+    <<~MSG
+      ## Agent Instructions
+      #{instructions}
+
+      ## Input
+      #{JSON.pretty_generate(input)}
+
+      ## Expected Tool Call Sequence
+      #{JSON.pretty_generate(expected_tool_calls)}
+
+      ## Actual Tool Call Sequence
+      #{JSON.pretty_generate(actual_tool_calls)}
+
+      ## Agent Output
+      #{output}
+
+      ## Evaluation Metrics
+      #{rubrics}
+    MSG
+  end
+
+  def parse_judge_response(content)
+    parsed = JSON.parse(content)
+    raise ArgumentError, "expected Array" unless parsed.is_a?(Array)
+
+    parsed.map do |entry|
+      {
+        metric_name: entry["metric_name"].to_s,
+        score: entry["score"].to_f,
+        justification: entry["justification"].to_s
+      }
+    end
+  rescue JSON::ParserError, ArgumentError => e
+    Rails.logger.error("LlmJudgeEval: failed to parse judge response: #{e.message}")
+    []
+  end
+end

--- a/app/models/evaluation/justification.rb
+++ b/app/models/evaluation/justification.rb
@@ -1,0 +1,10 @@
+module Evaluation
+  class Justification < ApplicationRecord
+    self.table_name = "evaluation_justifications"
+
+    belongs_to :evaluation_result, class_name: "Leva::EvaluationResult"
+
+    validates :metric_name, presence: true
+    validates :justification, presence: true
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module ApplicationPipeline
     # Use async-job adapter backed by Async::Job::Processor::Inline.
     config.active_job.queue_adapter = :async_job
 
-    # Autoload app/pipeline and app/tools in addition to standard Rails paths.
-    config.autoload_paths += %w[pipeline tools].map { |d| Rails.root.join("app", d).to_s }
+    # Autoload app/pipeline, app/tools, and app/evals in addition to standard Rails paths.
+    config.autoload_paths += %w[pipeline tools evals].map { |d| Rails.root.join("app", d).to_s }
   end
 end

--- a/db/migrate/20260429112350_create_evaluation_justifications.rb
+++ b/db/migrate/20260429112350_create_evaluation_justifications.rb
@@ -1,0 +1,14 @@
+class CreateEvaluationJustifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :evaluation_justifications do |t|
+      t.integer :evaluation_result_id, null: false
+      t.string :metric_name, null: false
+      t.text :justification, null: false
+
+      t.timestamps
+    end
+
+    add_index :evaluation_justifications, :evaluation_result_id
+    add_foreign_key :evaluation_justifications, :leva_evaluation_results, column: :evaluation_result_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,10 +5,6 @@ CREATE UNIQUE INDEX "index_application_mails_on_email_id" ON "application_mails"
 CREATE INDEX "index_application_mails_on_date" ON "application_mails" ("date") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "interviews" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "company" varchar NOT NULL, "job_title" varchar NOT NULL, "status" varchar DEFAULT 'pending_reply', "applied_at" date, "rejected_at" date, "first_interview_at" date, "second_interview_at" date, "third_interview_at" date, "fourth_interview_at" date, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_interviews_on_company_and_job_title" ON "interviews" ("company", "job_title") /*application='ApplicationPipeline'*/;
-CREATE VIRTUAL TABLE email_vectors USING vec0(
-  email_id TEXT PRIMARY KEY,
-  embedding FLOAT[1536]
-);
 CREATE TABLE IF NOT EXISTS "email_vectors_info" (key text primary key, value any);
 CREATE TABLE IF NOT EXISTS "email_vectors_chunks"(chunk_id INTEGER PRIMARY KEY AUTOINCREMENT,size INTEGER NOT NULL,validity BLOB NOT NULL,rowids BLOB NOT NULL);
 CREATE TABLE IF NOT EXISTS "email_vectors_rowids"(rowid INTEGER PRIMARY KEY AUTOINCREMENT,id TEXT UNIQUE NOT NULL,chunk_id INTEGER,chunk_offset INTEGER);
@@ -140,7 +136,13 @@ CREATE INDEX "index_leva_optimization_runs_on_status" ON "leva_optimization_runs
 CREATE INDEX "index_leva_prompts_on_name" ON "leva_prompts" ("name") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "evaluation_metrics" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "agent_name" varchar NOT NULL, "name" varchar NOT NULL, "description" text NOT NULL, "weight" decimal DEFAULT 1.0 NOT NULL, "active" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_evaluation_metrics_on_agent_name_and_name" ON "evaluation_metrics" ("agent_name", "name");
+CREATE TABLE IF NOT EXISTS "evaluation_justifications" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "evaluation_result_id" integer NOT NULL, "metric_name" varchar NOT NULL, "justification" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_517f4d40a2"
+FOREIGN KEY ("evaluation_result_id")
+  REFERENCES "leva_evaluation_results" ("id")
+);
+CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id");
 INSERT INTO "schema_migrations" (version) VALUES
+('20260429112350'),
 ('20260427135859'),
 ('20260427000001'),
 ('20260414120027'),

--- a/sig/app/evals/llm_judge_eval.rbs
+++ b/sig/app/evals/llm_judge_eval.rbs
@@ -16,4 +16,5 @@ class LLMJudgeEval < Leva::BaseEval
   def call_judge: (instructions: String?, input: untyped, expected_tool_calls: Array[untyped], actual_tool_calls: Array[untyped], output: String, metrics: untyped) -> Array[metric_result]
   def build_user_message: (instructions: String?, input: untyped, expected_tool_calls: Array[untyped], actual_tool_calls: Array[untyped], output: String, metrics: untyped) -> String
   def parse_judge_response: (String content) -> Array[metric_result]
+  def normalize_entry: (untyped entry, Integer index) -> metric_result?
 end

--- a/sig/app/evals/llm_judge_eval.rbs
+++ b/sig/app/evals/llm_judge_eval.rbs
@@ -1,0 +1,19 @@
+class LLMJudgeEval < Leva::BaseEval
+  type metric_result = { metric_name: String, score: Float, justification: String }
+
+  @judge_model: String
+
+  def self.judge_model: () -> String
+  def self.judge_model=: (String model) -> String
+
+  def evaluate: (Leva::RunnerResult runner_result, untyped recordable) -> Array[metric_result]
+  def evaluate_and_store: (untyped experiment, Leva::RunnerResult runner_result) -> Array[Leva::EvaluationResult]
+
+  private
+
+  def agent_name: (untyped recordable) -> String
+  def fetch_instructions: (String agent_name) -> String?
+  def call_judge: (instructions: String?, input: untyped, expected_tool_calls: Array[untyped], actual_tool_calls: Array[untyped], output: String, metrics: untyped) -> Array[metric_result]
+  def build_user_message: (instructions: String?, input: untyped, expected_tool_calls: Array[untyped], actual_tool_calls: Array[untyped], output: String, metrics: untyped) -> String
+  def parse_judge_response: (String content) -> Array[metric_result]
+end

--- a/sig/app/models/evaluation/justification.rbs
+++ b/sig/app/models/evaluation/justification.rbs
@@ -1,0 +1,7 @@
+module Evaluation
+  class Justification < ApplicationRecord
+    def evaluation_result: () -> Leva::EvaluationResult
+    def metric_name: () -> String
+    def justification: () -> String
+  end
+end

--- a/sig/shims/external_gems.rbs
+++ b/sig/shims/external_gems.rbs
@@ -139,6 +139,26 @@ module Leva
     def execute_and_store: (untyped experiment, untyped dataset_record, untyped prompt) -> untyped
   end
 
+  class BaseEval
+    def evaluate: (RunnerResult runner_result, untyped recordable) -> untyped
+    def evaluate_and_store: (untyped experiment, RunnerResult runner_result) -> untyped
+  end
+
+  class RunnerResult
+    def prediction: () -> String
+    def dataset_record: () -> DatasetRecord
+  end
+
+  class DatasetRecord
+    def recordable: () -> untyped
+  end
+
+  class EvaluationResult
+    def self.create!: (**untyped attrs) -> EvaluationResult
+    def score: () -> Float?
+    def evaluator_class: () -> String
+  end
+
   class Prompt
     def self.find_by: (**untyped attrs) -> Prompt?
     def self.find_by!: (**untyped attrs) -> Prompt

--- a/spec/evals/llm_judge_eval_spec.rb
+++ b/spec/evals/llm_judge_eval_spec.rb
@@ -1,0 +1,166 @@
+require "rails_helper"
+
+RSpec.describe LLMJudgeEval do
+  subject(:eval_instance) { described_class.new }
+
+  let(:agent_name) { "Emails::ClassifyAgent" }
+
+  describe "#evaluate" do
+    let(:recordable) do
+      instance_double(
+        Orchestration::ActionRun,
+        input: { "email" => "subject: Job offer" },
+        chat: instance_double(RubyLLM::Chat, messages: []),
+        step_action: instance_double(
+          Orchestration::StepAction,
+          action: instance_double(Orchestration::Action, agent_class: agent_name)
+        )
+      )
+    end
+    let(:runner_result) do
+      prediction = { tool_calls: [ { tool_name: "classify_email", arguments: { label: "offer" } } ], output: "Classified." }.to_json
+      instance_double(
+        Leva::RunnerResult,
+        prediction: prediction,
+        dataset_record: instance_double(Leva::DatasetRecord, recordable: recordable)
+      )
+    end
+    let(:llm_response_body) do
+      scores = JSON.generate([
+        { "metric_name" => "tool_call_accuracy", "score" => 4, "justification" => "Correct tool called." },
+        { "metric_name" => "output_quality", "score" => 5, "justification" => "Clear output." }
+      ])
+      { id: "msg_01", type: "message", role: "assistant", content: [ { type: "text", text: scores } ], model: "claude-sonnet-4-6", stop_reason: "end_turn", usage: { input_tokens: 200, output_tokens: 80 } }.to_json
+    end
+
+    before do
+      create(:evaluation_metric, agent_name: agent_name, name: "tool_call_accuracy", description: "Score tool call order.")
+      create(:evaluation_metric, agent_name: agent_name, name: "output_quality", description: "Score output quality.")
+
+      prompt_double = instance_double(Leva::Prompt, system_prompt: "You are a classifier.")
+      prompt_rel = instance_double(ActiveRecord::Relation)
+      allow(Leva::Prompt).to receive(:where).with(name: agent_name).and_return(prompt_rel)
+      allow(prompt_rel).to receive(:order).with(version: :desc, id: :desc).and_return(prompt_rel)
+      allow(prompt_rel).to receive(:first).and_return(prompt_double)
+
+      allow(Evaluation::ToolCallExtractor).to receive(:call).and_return(
+        [ { tool_name: "classify_email", arguments: { label: "offer" }, result: "done" } ]
+      )
+
+      stub_request(:post, %r{api\.anthropic\.com})
+        .to_return(status: 200, body: llm_response_body, headers: { "Content-Type" => "application/json" })
+    end
+
+    it "returns per-metric scores with justifications" do
+      results = eval_instance.evaluate(runner_result, recordable)
+      expect(results.size).to eq(2)
+      expect(results.first).to include(metric_name: "tool_call_accuracy", score: 4.0, justification: a_kind_of(String))
+    end
+
+    it "includes all metrics in the LLM request" do
+      eval_instance.evaluate(runner_result, recordable)
+
+      expect(WebMock).to have_requested(:post, %r{api\.anthropic\.com}).with { |req|
+        body = JSON.parse(req.body)
+        messages_text = body["messages"].to_s
+        messages_text.include?("classify_email") &&
+          messages_text.include?("tool_call_accuracy") &&
+          messages_text.include?("output_quality")
+      }
+    end
+
+    it "uses temperature 0 for reproducibility" do
+      eval_instance.evaluate(runner_result, recordable)
+
+      expect(WebMock).to have_requested(:post, %r{api\.anthropic\.com}).with { |req|
+        JSON.parse(req.body)["temperature"] == 0
+      }
+    end
+
+    context "when the LLM returns invalid JSON" do
+      let(:llm_response_body) do
+        { id: "msg_02", type: "message", role: "assistant", content: [ { type: "text", text: "not json" } ], model: "claude-sonnet-4-6", stop_reason: "end_turn", usage: { input_tokens: 10, output_tokens: 5 } }.to_json
+      end
+
+      it "returns an empty array without raising" do
+        expect(eval_instance.evaluate(runner_result, recordable)).to eq([])
+      end
+    end
+
+    context "when no active metrics exist" do
+      before { Evaluation::Metric.update_all(active: false) }
+
+      it "skips the LLM call and returns an empty array" do
+        result = eval_instance.evaluate(runner_result, recordable)
+        expect(result).to eq([])
+        expect(WebMock).not_to have_requested(:post, %r{api\.anthropic\.com})
+      end
+    end
+  end
+
+  describe "#evaluate_and_store" do
+    let!(:leva_dataset) { Leva::Dataset.create!(name: "test_dataset") }
+    let!(:leva_prompt) { Leva::Prompt.create!(name: agent_name, system_prompt: "You are a classifier.", user_prompt: "Classify: {{input}}") }
+    let!(:leva_experiment) { Leva::Experiment.create!(name: "test_exp", dataset: leva_dataset, status: :pending, prompt: leva_prompt, runner_class: "Evaluation::StubbedAgentRun", evaluator_classes: [ "LLMJudgeEval" ]) }
+    let!(:leva_dataset_record) { Leva::DatasetRecord.create!(dataset: leva_dataset, recordable: create(:orchestration_action_run, status: "completed")) }
+    let!(:leva_runner_result) do
+      Leva::RunnerResult.create!(
+        experiment: leva_experiment,
+        dataset_record: leva_dataset_record,
+        prompt: leva_prompt,
+        prediction: { tool_calls: [], output: "classified" }.to_json,
+        runner_class: "Evaluation::StubbedAgentRun"
+      )
+    end
+
+    before do
+      create(:evaluation_metric, agent_name: agent_name, name: "tool_call_accuracy", description: "Tool call accuracy.")
+      create(:evaluation_metric, agent_name: agent_name, name: "output_quality", description: "Output quality.")
+      allow(Evaluation::ToolCallExtractor).to receive(:call).and_return([])
+
+      scores = JSON.generate([
+        { "metric_name" => "tool_call_accuracy", "score" => 4, "justification" => "Good." },
+        { "metric_name" => "output_quality", "score" => 5, "justification" => "Excellent." }
+      ])
+      body = { id: "msg_01", type: "message", role: "assistant", content: [ { type: "text", text: scores } ], model: "claude-sonnet-4-6", stop_reason: "end_turn", usage: { input_tokens: 200, output_tokens: 80 } }.to_json
+      stub_request(:post, %r{api\.anthropic\.com})
+        .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
+    end
+
+    it "creates one EvaluationResult per metric" do
+      expect {
+        eval_instance.evaluate_and_store(leva_experiment, leva_runner_result)
+      }.to change(Leva::EvaluationResult, :count).by(2)
+    end
+
+    it "creates one Justification per metric" do
+      expect {
+        eval_instance.evaluate_and_store(leva_experiment, leva_runner_result)
+      }.to change(Evaluation::Justification, :count).by(2)
+    end
+
+    it "stores scores between 1 and 5" do
+      eval_instance.evaluate_and_store(leva_experiment, leva_runner_result)
+      expect(Leva::EvaluationResult.last(2).map(&:score)).to all(be_between(1, 5))
+    end
+
+    it "links justifications to their evaluation results" do
+      eval_instance.evaluate_and_store(leva_experiment, leva_runner_result)
+      expect(Evaluation::Justification.last.evaluation_result).to be_a(Leva::EvaluationResult)
+    end
+  end
+
+  describe "judge_model configuration" do
+    it "defaults to claude-sonnet-4-6" do
+      expect(described_class.judge_model).to eq("claude-sonnet-4-6")
+    end
+
+    it "can be overridden" do
+      original = described_class.judge_model
+      described_class.judge_model = "claude-opus-4-7"
+      expect(described_class.judge_model).to eq("claude-opus-4-7")
+    ensure
+      described_class.judge_model = original
+    end
+  end
+end

--- a/spec/evals/llm_judge_eval_spec.rb
+++ b/spec/evals/llm_judge_eval_spec.rb
@@ -87,6 +87,33 @@ RSpec.describe LLMJudgeEval do
       end
     end
 
+    context "when prediction is nil" do
+      let(:runner_result) do
+        instance_double(
+          Leva::RunnerResult,
+          prediction: nil,
+          dataset_record: instance_double(Leva::DatasetRecord, recordable: recordable)
+        )
+      end
+
+      it "returns an empty array without raising" do
+        expect(eval_instance.evaluate(runner_result, recordable)).to eq([])
+      end
+    end
+
+    context "when the LLM returns a score outside 1–5" do
+      let(:llm_response_body) do
+        scores = JSON.generate([
+          { "metric_name" => "tool_call_accuracy", "score" => 10, "justification" => "Way off." }
+        ])
+        { id: "msg_03", type: "message", role: "assistant", content: [ { type: "text", text: scores } ], model: "claude-sonnet-4-6", stop_reason: "end_turn", usage: { input_tokens: 10, output_tokens: 5 } }.to_json
+      end
+
+      it "drops the invalid entry and returns an empty array" do
+        expect(eval_instance.evaluate(runner_result, recordable)).to eq([])
+      end
+    end
+
     context "when no active metrics exist" do
       before { Evaluation::Metric.update_all(active: false) }
 

--- a/spec/factories/evaluation_justifications.rb
+++ b/spec/factories/evaluation_justifications.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :evaluation_justification, class: "Evaluation::Justification" do
+    association :evaluation_result, factory: :leva_evaluation_result
+    metric_name { "tool_call_accuracy" }
+    justification { "The agent called the correct tools in the right order." }
+  end
+end

--- a/spec/factories/leva.rb
+++ b/spec/factories/leva.rb
@@ -1,0 +1,40 @@
+FactoryBot.define do
+  factory :leva_dataset, class: "Leva::Dataset" do
+    sequence(:name) { |n| "dataset_#{n}" }
+  end
+
+  factory :leva_prompt, class: "Leva::Prompt" do
+    sequence(:name) { |n| "agent_#{n}" }
+    system_prompt { "System prompt" }
+    user_prompt { "User prompt {{input}}" }
+  end
+
+  factory :leva_experiment, class: "Leva::Experiment" do
+    sequence(:name) { |n| "experiment_#{n}" }
+    status { :pending }
+    runner_class { "Evaluation::StubbedAgentRun" }
+    evaluator_classes { [ "LLMJudgeEval" ] }
+    association :dataset, factory: :leva_dataset
+    association :prompt, factory: :leva_prompt
+  end
+
+  factory :leva_dataset_record, class: "Leva::DatasetRecord" do
+    association :dataset, factory: :leva_dataset
+    association :recordable, factory: :orchestration_action_run
+  end
+
+  factory :leva_runner_result, class: "Leva::RunnerResult" do
+    prediction { { tool_calls: [], output: "classified" }.to_json }
+    runner_class { "Evaluation::StubbedAgentRun" }
+    association :experiment, factory: :leva_experiment
+    association :dataset_record, factory: :leva_dataset_record
+    association :prompt, factory: :leva_prompt
+  end
+
+  factory :leva_evaluation_result, class: "Leva::EvaluationResult" do
+    evaluator_class { "LLMJudgeEval" }
+    score { 4.0 }
+    association :dataset_record, factory: :leva_dataset_record
+    association :runner_result, factory: :leva_runner_result
+  end
+end


### PR DESCRIPTION
## Summary
- Implements `LLMJudgeEval < Leva::BaseEval` in `app/evals/llm_judge_eval.rb`
- Judge calls configurable model (default `claude-sonnet-4-6`, env: `JUDGE_LLM_MODEL`) at temperature 0 with full agent context: instructions, input, expected/actual tool calls, output, and metric rubrics
- Creates one `Leva::EvaluationResult` (score 1–5) per active `Evaluation::Metric`; justification text stored in companion `Evaluation::Justification` model via new migration

Closes #24

## Test plan
- [x] 11 new specs covering `#evaluate`, `#evaluate_and_store`, error handling, and model configuration
- [x] Full suite: 991 examples, 0 failures
- [x] RuboCop: no offenses
- [x] Steep: no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)