### PR TITLE
feat: evaluation comparison service and compare rake task

### DIFF
--- a/app/services/evaluation/comparison.rb
+++ b/app/services/evaluation/comparison.rb
@@ -39,11 +39,18 @@ module Evaluation
     private
 
     def per_metric_averages(experiment)
+      conn = Leva::EvaluationResult.connection
+      results_table       = conn.quote_table_name(Leva::EvaluationResult.table_name)
+      justifications_table = conn.quote_table_name(Evaluation::Justification.table_name)
+
       Leva::EvaluationResult
-        .joins("INNER JOIN evaluation_justifications ON evaluation_justifications.evaluation_result_id = leva_evaluation_results.id")
+        .joins(
+          "INNER JOIN #{justifications_table} " \
+          "ON #{justifications_table}.evaluation_result_id = #{results_table}.id"
+        )
         .where(experiment: experiment)
-        .group("evaluation_justifications.metric_name")
-        .average(:score)
+        .group("#{justifications_table}.metric_name")
+        .average("#{results_table}.score")
         .transform_keys(&:to_s)
     end
 

--- a/app/services/evaluation/comparison.rb
+++ b/app/services/evaluation/comparison.rb
@@ -1,0 +1,54 @@
+module Evaluation
+  class Comparison
+    ComparisonResult = Data.define(:baseline_score, :candidate_score, :baseline_metrics, :candidate_metrics, :metric_deltas, :overall_delta)
+
+    def self.call(baseline_experiment:, candidate_experiment:)
+      new(baseline_experiment: baseline_experiment, candidate_experiment: candidate_experiment).call
+    end
+
+    def initialize(baseline_experiment:, candidate_experiment:)
+      @baseline_experiment  = baseline_experiment
+      @candidate_experiment = candidate_experiment
+    end
+
+    def call
+      baseline_metrics  = per_metric_averages(@baseline_experiment)
+      candidate_metrics = per_metric_averages(@candidate_experiment)
+      all_metric_names  = (baseline_metrics.keys | candidate_metrics.keys)
+
+      metric_deltas = all_metric_names.index_with do |name|
+        b = baseline_metrics[name]
+        c = candidate_metrics[name]
+        (b && c) ? c - b : nil
+      end
+
+      baseline_score  = overall_average(@baseline_experiment)
+      candidate_score = overall_average(@candidate_experiment)
+      overall_delta   = (baseline_score && candidate_score) ? candidate_score - baseline_score : nil
+
+      ComparisonResult.new(
+        baseline_score: baseline_score,
+        candidate_score: candidate_score,
+        baseline_metrics: baseline_metrics,
+        candidate_metrics: candidate_metrics,
+        metric_deltas: metric_deltas,
+        overall_delta: overall_delta
+      )
+    end
+
+    private
+
+    def per_metric_averages(experiment)
+      Leva::EvaluationResult
+        .joins("INNER JOIN evaluation_justifications ON evaluation_justifications.evaluation_result_id = leva_evaluation_results.id")
+        .where(experiment: experiment)
+        .group("evaluation_justifications.metric_name")
+        .average(:score)
+        .transform_keys(&:to_s)
+    end
+
+    def overall_average(experiment)
+      Leva::EvaluationResult.where(experiment: experiment).average(:score)
+    end
+  end
+end

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -51,4 +51,38 @@ namespace :evaluation do
     end
     Rails.logger.info "Migrated #{agent_classes.size} agent prompts to Leva::Prompt."
   end
+
+  desc "Compare two experiments and print per-metric deltas (e.g. rake evaluation:compare[1,2])"
+  task :compare, [ :baseline_id, :candidate_id ] => :environment do |_, args|
+    baseline_id  = args[:baseline_id]  or raise ArgumentError, "Usage: rake evaluation:compare[baseline_id,candidate_id]"
+    candidate_id = args[:candidate_id] or raise ArgumentError, "Usage: rake evaluation:compare[baseline_id,candidate_id]"
+
+    baseline  = Leva::Experiment.find(baseline_id)
+    candidate = Leva::Experiment.find(candidate_id)
+
+    result = Evaluation::Comparison.call(baseline_experiment: baseline, candidate_experiment: candidate)
+
+    puts "Experiment comparison"
+    puts "  Baseline:  ##{baseline.id} — #{baseline.name}"
+    puts "  Candidate: ##{candidate.id} — #{candidate.name}"
+    puts ""
+    puts format("%-30s %8s %8s %10s", "Metric", "Baseline", "Candidate", "Delta")
+    puts "-" * 60
+
+    result.metric_deltas.each do |metric_name, delta|
+      b_avg     = result.baseline_metrics[metric_name]
+      c_avg     = result.candidate_metrics[metric_name]
+      b_str     = b_avg ? format("%.2f", b_avg) : "n/a"
+      c_str     = c_avg ? format("%.2f", c_avg) : "n/a"
+      delta_str = delta  ? format("%+.2f", delta) : "n/a"
+
+      puts format("%-30s %8s %8s %10s", metric_name, b_str, c_str, delta_str)
+    end
+
+    puts "-" * 60
+    baseline_str  = result.baseline_score  ? format("%.2f", result.baseline_score)  : "n/a"
+    candidate_str = result.candidate_score ? format("%.2f", result.candidate_score) : "n/a"
+    delta_str     = result.overall_delta   ? format("%+.2f", result.overall_delta)  : "n/a"
+    puts format("%-30s %8s %8s %10s", "OVERALL", baseline_str, candidate_str, delta_str)
+  end
 end

--- a/sig/app/services/evaluation/comparison.rbs
+++ b/sig/app/services/evaluation/comparison.rbs
@@ -1,0 +1,38 @@
+module Evaluation
+  class Comparison
+    class ComparisonResult
+      attr_reader baseline_score: Float?
+      attr_reader candidate_score: Float?
+      attr_reader baseline_metrics: Hash[String, Float]
+      attr_reader candidate_metrics: Hash[String, Float]
+      attr_reader metric_deltas: Hash[String, Float?]
+      attr_reader overall_delta: Float?
+
+      def initialize: (
+        baseline_score: Float?,
+        candidate_score: Float?,
+        baseline_metrics: Hash[String, Float],
+        candidate_metrics: Hash[String, Float],
+        metric_deltas: Hash[String, Float?],
+        overall_delta: Float?
+      ) -> void
+    end
+
+    def self.call: (
+      baseline_experiment: Leva::Experiment,
+      candidate_experiment: Leva::Experiment
+    ) -> ComparisonResult
+
+    def initialize: (
+      baseline_experiment: Leva::Experiment,
+      candidate_experiment: Leva::Experiment
+    ) -> void
+
+    def call: () -> ComparisonResult
+
+    private
+
+    def per_metric_averages: (Leva::Experiment experiment) -> Hash[String, Float]
+    def overall_average: (Leva::Experiment experiment) -> Float?
+  end
+end

--- a/sig/shims/external_gems.rbs
+++ b/sig/shims/external_gems.rbs
@@ -163,6 +163,8 @@ module Leva
     def self.joins: (String sql) -> untyped
     def self.where: (**untyped attrs) -> untyped
     def self.average: (Symbol column) -> Float?
+    def self.connection: () -> untyped
+    def self.table_name: () -> String
     def score: () -> Float?
     def evaluator_class: () -> String
   end

--- a/sig/shims/external_gems.rbs
+++ b/sig/shims/external_gems.rbs
@@ -153,8 +153,16 @@ module Leva
     def recordable: () -> untyped
   end
 
+  class Experiment
+    def id: () -> Integer
+    def name: () -> String
+  end
+
   class EvaluationResult
     def self.create!: (**untyped attrs) -> EvaluationResult
+    def self.joins: (String sql) -> untyped
+    def self.where: (**untyped attrs) -> untyped
+    def self.average: (Symbol column) -> Float?
     def score: () -> Float?
     def evaluator_class: () -> String
   end

--- a/spec/services/evaluation/comparison_spec.rb
+++ b/spec/services/evaluation/comparison_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+RSpec.describe Evaluation::Comparison do
+  def make_eval_result(experiment:, score:, metric_name:)
+    runner_result = create(:leva_runner_result, experiment: experiment)
+    eval_result = create(:leva_evaluation_result,
+      experiment: experiment,
+      runner_result: runner_result,
+      dataset_record: runner_result.dataset_record,
+      score: score)
+    create(:evaluation_justification, evaluation_result: eval_result, metric_name: metric_name)
+    eval_result
+  end
+
+  let(:baseline)  { create(:leva_experiment, name: "baseline") }
+  let(:candidate) { create(:leva_experiment, name: "candidate") }
+
+  describe ".call" do
+    context "when both experiments have the same metrics" do
+      before do
+        make_eval_result(experiment: baseline,  score: 3.0, metric_name: "accuracy")
+        make_eval_result(experiment: baseline,  score: 2.0, metric_name: "relevance")
+        make_eval_result(experiment: candidate, score: 4.0, metric_name: "accuracy")
+        make_eval_result(experiment: candidate, score: 3.0, metric_name: "relevance")
+      end
+
+      it "returns a ComparisonResult" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result).to be_a(Evaluation::Comparison::ComparisonResult)
+      end
+
+      it "computes per-metric deltas (positive = improvement)" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.metric_deltas["accuracy"]).to be_within(0.001).of(1.0)
+        expect(result.metric_deltas["relevance"]).to be_within(0.001).of(1.0)
+      end
+
+      it "computes baseline_score as overall average" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.baseline_score).to be_within(0.001).of(2.5)
+      end
+
+      it "computes candidate_score as overall average" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.candidate_score).to be_within(0.001).of(3.5)
+      end
+
+      it "computes overall_delta = candidate_score - baseline_score" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.overall_delta).to be_within(0.001).of(1.0)
+      end
+    end
+
+    context "when candidate regresses on a metric" do
+      before do
+        make_eval_result(experiment: baseline,  score: 4.0, metric_name: "accuracy")
+        make_eval_result(experiment: candidate, score: 2.0, metric_name: "accuracy")
+      end
+
+      it "reports a negative delta for that metric" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.metric_deltas["accuracy"]).to be_within(0.001).of(-2.0)
+      end
+    end
+
+    context "when metrics differ between experiments" do
+      before do
+        make_eval_result(experiment: baseline,  score: 3.0, metric_name: "accuracy")
+        make_eval_result(experiment: candidate, score: 4.0, metric_name: "accuracy")
+        make_eval_result(experiment: baseline,  score: 2.0, metric_name: "only_in_baseline")
+        make_eval_result(experiment: candidate, score: 5.0, metric_name: "only_in_candidate")
+      end
+
+      it "includes all metrics in metric_deltas" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.metric_deltas.keys).to contain_exactly("accuracy", "only_in_baseline", "only_in_candidate")
+      end
+
+      it "sets nil delta for metrics present only in one experiment" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.metric_deltas["only_in_baseline"]).to be_nil
+        expect(result.metric_deltas["only_in_candidate"]).to be_nil
+      end
+
+      it "computes delta normally for shared metrics" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.metric_deltas["accuracy"]).to be_within(0.001).of(1.0)
+      end
+    end
+
+    context "when a metric has multiple eval results" do
+      before do
+        make_eval_result(experiment: baseline,  score: 2.0, metric_name: "accuracy")
+        make_eval_result(experiment: baseline,  score: 4.0, metric_name: "accuracy")
+        make_eval_result(experiment: candidate, score: 3.0, metric_name: "accuracy")
+        make_eval_result(experiment: candidate, score: 5.0, metric_name: "accuracy")
+      end
+
+      it "averages scores per metric before computing delta" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.metric_deltas["accuracy"]).to be_within(0.001).of(1.0)
+      end
+    end
+
+    context "when one experiment has no evaluation results" do
+      before do
+        make_eval_result(experiment: baseline, score: 3.0, metric_name: "accuracy")
+      end
+
+      it "returns nil for candidate_score" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.candidate_score).to be_nil
+      end
+
+      it "returns nil for overall_delta" do
+        result = described_class.call(baseline_experiment: baseline, candidate_experiment: candidate)
+        expect(result.overall_delta).to be_nil
+      end
+    end
+  end
+end

--- a/spec/tasks/evaluation_compare_spec.rb
+++ b/spec/tasks/evaluation_compare_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "evaluation:compare rake task" do # rubocop:disable RSpec/DescribeClass
+  let(:task_name) { "evaluation:compare" }
+  let(:baseline)  { create(:leva_experiment, name: "baseline-exp") }
+  let(:candidate) { create(:leva_experiment, name: "candidate-exp") }
+
+  def make_eval_result(experiment:, score:, metric_name:)
+    runner_result = create(:leva_runner_result, experiment: experiment)
+    eval_result = create(:leva_evaluation_result,
+      experiment: experiment,
+      runner_result: runner_result,
+      dataset_record: runner_result.dataset_record,
+      score: score)
+    create(:evaluation_justification, evaluation_result: eval_result, metric_name: metric_name)
+  end
+
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task[task_name].reenable
+  end
+
+  context "when both IDs are provided and experiments exist" do
+    before do
+      make_eval_result(experiment: baseline,  score: 3.0, metric_name: "accuracy")
+      make_eval_result(experiment: candidate, score: 4.0, metric_name: "accuracy")
+    end
+
+    it "prints experiment names" do
+      expect { Rake::Task[task_name].invoke(baseline.id, candidate.id) }
+        .to output(/##{baseline.id}.*baseline-exp/).to_stdout
+      Rake::Task[task_name].reenable
+      expect { Rake::Task[task_name].invoke(baseline.id, candidate.id) }
+        .to output(/##{candidate.id}.*candidate-exp/).to_stdout
+    end
+
+    it "prints a positive delta for an improved metric" do
+      expect { Rake::Task[task_name].invoke(baseline.id, candidate.id) }
+        .to output(/accuracy.*\+1\.00/).to_stdout
+    end
+
+    it "prints overall scores and delta" do
+      expect { Rake::Task[task_name].invoke(baseline.id, candidate.id) }
+        .to output(/OVERALL.*3\.00.*4\.00.*\+1\.00/).to_stdout
+    end
+  end
+
+  context "when baseline ID is missing" do
+    it "raises ArgumentError with usage message" do
+      expect { Rake::Task[task_name].invoke(nil, candidate.id) }
+        .to raise_error(ArgumentError, /Usage/)
+    end
+  end
+
+  context "when candidate ID is missing" do
+    it "raises ArgumentError with usage message" do
+      expect { Rake::Task[task_name].invoke(baseline.id, nil) }
+        .to raise_error(ArgumentError, /Usage/)
+    end
+  end
+
+  context "when a metric exists only in baseline" do
+    before do
+      make_eval_result(experiment: baseline, score: 3.0, metric_name: "only_baseline")
+    end
+
+    it "prints n/a for the candidate column and delta" do
+      expect { Rake::Task[task_name].invoke(baseline.id, candidate.id) }
+        .to output(/only_baseline.*n\/a.*n\/a/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Evaluation::Comparison.call(baseline_experiment:, candidate_experiment:)` returning a `ComparisonResult` with per-metric and overall score deltas
- Per-metric scores aggregated from `Leva::EvaluationResult` joined with `Evaluation::Justification` records; metrics only present in one experiment get `nil` delta
- Adds `rake evaluation:compare[experiment_id_1,experiment_id_2]` that prints a formatted comparison table to stdout

Closes #26

## Test plan
- [x] 12 new specs covering: basic comparison, regressions, differing metric sets, multi-result averaging, empty experiments
- [x] Full RSpec suite passes (1005 examples, 0 failures)
- [x] RuboCop passes (0 offenses)
- [x] Steep type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)