### PR TITLE
feat: metrics management UI and prompt diff component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "falcon", require: false
 
 # Pagination
 gem "pagy"
+gem "diffy"
 gem "csv"
 
 # Assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.6.2)
+    diffy (3.4.4)
     docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
@@ -699,6 +700,7 @@ DEPENDENCIES
   brakeman
   capybara (~> 3.40)
   csv
+  diffy
   dotenv-rails
   dry-cli
   factory_bot_rails
@@ -787,6 +789,7 @@ CHECKSUMS
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   descendants_tracker (0.0.4) sha256=e9c41dd4cfbb85829a9301ea7e7c48c2a03b26f09319db230e6479ccdc780897
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  diffy (3.4.4) sha256=79384ab5ca82d0e115b2771f0961e27c164c456074bd2ec46b637ebf7b6e47e3
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab

--- a/app/components/evaluation/metric_list_component.html.erb
+++ b/app/components/evaluation/metric_list_component.html.erb
@@ -1,0 +1,13 @@
+<%= render UI::TableComponent.new(collection: @metrics, empty_message: "No metrics found.") do |table| %>
+  <% table.with_columns([
+    { key: "name",        label: "Name",        variant: :mono },
+    { key: "description", label: "Description", cell: ->(m) { m.description } },
+    { key: "weight",      label: "Weight",      variant: :subtle, cell: ->(m) { m.weight.to_s } },
+    { key: "active",      label: "Active",      cell: ->(m) { m.active? ? "Yes" : "No" } }
+  ]) %>
+  <% table.with_action_column(
+    actions: ->(metric) {
+      [{ label: "Edit", url: edit_evaluation_metric_path(metric), variant: :primary }]
+    }
+  ) %>
+<% end %>

--- a/app/components/evaluation/metric_list_component.rb
+++ b/app/components/evaluation/metric_list_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class MetricListComponent < ViewComponent::Base
+    def initialize(metrics:)
+      @metrics = metrics
+    end
+
+    def empty?
+      @metrics.empty?
+    end
+  end
+end

--- a/app/components/evaluation/metric_list_component.rb
+++ b/app/components/evaluation/metric_list_component.rb
@@ -5,9 +5,5 @@ module Evaluation
     def initialize(metrics:)
       @metrics = metrics
     end
-
-    def empty?
-      @metrics.empty?
-    end
   end
 end

--- a/app/components/evaluation/prompt_diff_component.html.erb
+++ b/app/components/evaluation/prompt_diff_component.html.erb
@@ -11,7 +11,7 @@
       <% system_prompt_diff.each do |line| %>
         <div class="flex gap-2 px-3 py-0.5 <%= line_class(line) %>">
           <span class="select-none w-4 shrink-0"><%= line_prefix(line) %></span>
-          <span><%= line.text %></span>
+          <span class="whitespace-pre-wrap"><%= line.text %></span>
         </div>
       <% end %>
     </div>
@@ -23,7 +23,7 @@
       <% user_prompt_diff.each do |line| %>
         <div class="flex gap-2 px-3 py-0.5 <%= line_class(line) %>">
           <span class="select-none w-4 shrink-0"><%= line_prefix(line) %></span>
-          <span><%= line.text %></span>
+          <span class="whitespace-pre-wrap"><%= line.text %></span>
         </div>
       <% end %>
     </div>

--- a/app/components/evaluation/prompt_diff_component.html.erb
+++ b/app/components/evaluation/prompt_diff_component.html.erb
@@ -1,0 +1,31 @@
+<div data-diff class="space-y-6">
+  <div>
+    <div class="flex items-center justify-between mb-2">
+      <h3 class="text-sm font-semibold text-gray-700">System Prompt</h3>
+      <div class="flex gap-4 text-xs text-gray-400">
+        <span class="text-red-500"><%= version_a %></span>
+        <span class="text-green-600"><%= version_b %></span>
+      </div>
+    </div>
+    <div class="font-mono text-xs rounded-lg border border-gray-200 overflow-auto bg-gray-50">
+      <% system_prompt_diff.each do |line| %>
+        <div class="flex gap-2 px-3 py-0.5 <%= line_class(line) %>">
+          <span class="select-none w-4 shrink-0"><%= line_prefix(line) %></span>
+          <span><%= line.text %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div>
+    <h3 class="text-sm font-semibold text-gray-700 mb-2">User Prompt</h3>
+    <div class="font-mono text-xs rounded-lg border border-gray-200 overflow-auto bg-gray-50">
+      <% user_prompt_diff.each do |line| %>
+        <div class="flex gap-2 px-3 py-0.5 <%= line_class(line) %>">
+          <span class="select-none w-4 shrink-0"><%= line_prefix(line) %></span>
+          <span><%= line.text %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/evaluation/prompt_diff_component.rb
+++ b/app/components/evaluation/prompt_diff_component.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class PromptDiffComponent < ViewComponent::Base
+    Line = Data.define(:text, :type)
+
+    def initialize(prompt_a:, prompt_b:)
+      @prompt_a = prompt_a
+      @prompt_b = prompt_b
+    end
+
+    def system_prompt_diff
+      diff_lines(@prompt_a.system_prompt.to_s, @prompt_b.system_prompt.to_s)
+    end
+
+    def user_prompt_diff
+      diff_lines(@prompt_a.user_prompt.to_s, @prompt_b.user_prompt.to_s)
+    end
+
+    def line_class(line)
+      case line.type
+      when :added   then "bg-green-100 text-green-800"
+      when :removed then "bg-red-100 text-red-800"
+      else               "text-gray-700"
+      end
+    end
+
+    def line_prefix(line)
+      case line.type
+      when :added   then "+"
+      when :removed then "−"
+      else               " "
+      end
+    end
+
+    def version_a = "v#{@prompt_a.version}"
+    def version_b = "v#{@prompt_b.version}"
+
+    private
+
+    def diff_lines(text_a, text_b)
+      lines_a = text_a.lines.map(&:chomp)
+      lines_b = text_b.lines.map(&:chomp)
+      lcs = longest_common_subsequence(lines_a, lines_b)
+      build_diff(lines_a, lines_b, lcs)
+    end
+
+    def longest_common_subsequence(a, b)
+      m, n = a.size, b.size
+      dp = Array.new(m + 1) { Array.new(n + 1, 0) }
+      (1..m).each do |i|
+        (1..n).each do |j|
+          dp[i][j] = a[i - 1] == b[j - 1] ? dp[i - 1][j - 1] + 1 : [ dp[i - 1][j], dp[i][j - 1] ].max
+        end
+      end
+      dp
+    end
+
+    def build_diff(a, b, dp)
+      result = []
+      i, j = a.size, b.size
+      while i > 0 || j > 0
+        if i > 0 && j > 0 && a[i - 1] == b[j - 1]
+          result.unshift(Line.new(text: a[i - 1], type: :unchanged))
+          i -= 1
+          j -= 1
+        elsif j > 0 && (i.zero? || dp[i][j - 1] >= dp[i - 1][j])
+          result.unshift(Line.new(text: b[j - 1], type: :added))
+          j -= 1
+        else
+          result.unshift(Line.new(text: a[i - 1], type: :removed))
+          i -= 1
+        end
+      end
+      result
+    end
+  end
+end

--- a/app/components/evaluation/prompt_diff_component.rb
+++ b/app/components/evaluation/prompt_diff_component.rb
@@ -2,19 +2,18 @@
 
 module Evaluation
   class PromptDiffComponent < ViewComponent::Base
-    Line = Data.define(:text, :type)
-
     def initialize(prompt_a:, prompt_b:)
       @prompt_a = prompt_a
       @prompt_b = prompt_b
+      @differ = PromptDiffer.new(prompt_a, prompt_b)
     end
 
     def system_prompt_diff
-      diff_lines(@prompt_a.system_prompt.to_s, @prompt_b.system_prompt.to_s)
+      @differ.system_prompt_diff
     end
 
     def user_prompt_diff
-      diff_lines(@prompt_a.user_prompt.to_s, @prompt_b.user_prompt.to_s)
+      @differ.user_prompt_diff
     end
 
     def line_class(line)
@@ -35,44 +34,5 @@ module Evaluation
 
     def version_a = "v#{@prompt_a.version}"
     def version_b = "v#{@prompt_b.version}"
-
-    private
-
-    def diff_lines(text_a, text_b)
-      lines_a = text_a.lines.map(&:chomp)
-      lines_b = text_b.lines.map(&:chomp)
-      lcs = longest_common_subsequence(lines_a, lines_b)
-      build_diff(lines_a, lines_b, lcs)
-    end
-
-    def longest_common_subsequence(a, b)
-      m, n = a.size, b.size
-      dp = Array.new(m + 1) { Array.new(n + 1, 0) }
-      (1..m).each do |i|
-        (1..n).each do |j|
-          dp[i][j] = a[i - 1] == b[j - 1] ? dp[i - 1][j - 1] + 1 : [ dp[i - 1][j], dp[i][j - 1] ].max
-        end
-      end
-      dp
-    end
-
-    def build_diff(a, b, dp)
-      result = []
-      i, j = a.size, b.size
-      while i > 0 || j > 0
-        if i > 0 && j > 0 && a[i - 1] == b[j - 1]
-          result.unshift(Line.new(text: a[i - 1], type: :unchanged))
-          i -= 1
-          j -= 1
-        elsif j > 0 && (i.zero? || dp[i][j - 1] >= dp[i - 1][j])
-          result.unshift(Line.new(text: b[j - 1], type: :added))
-          j -= 1
-        else
-          result.unshift(Line.new(text: a[i - 1], type: :removed))
-          i -= 1
-        end
-      end
-      result
-    end
   end
 end

--- a/app/controllers/evaluation/metrics_controller.rb
+++ b/app/controllers/evaluation/metrics_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class MetricsController < ApplicationController
+    before_action :set_metric, only: [ :edit, :update ]
+
+    def index
+      @metrics_by_agent = Evaluation::Metric.order(:agent_name, :name).group_by(&:agent_name)
+    end
+
+    def edit
+    end
+
+    def update
+      if @metric.update(metric_params)
+        redirect_to evaluation_metrics_path, notice: "Metric updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def set_metric
+      @metric = Evaluation::Metric.find(params[:id])
+    end
+
+    def metric_params
+      params.require(:evaluation_metric).permit(:description, :weight, :active)
+    end
+  end
+end

--- a/app/controllers/evaluation/prompt_diffs_controller.rb
+++ b/app/controllers/evaluation/prompt_diffs_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class PromptDiffsController < ApplicationController
+    def show
+      @prompt = Leva::Prompt.find(params[:id])
+      @other_version = Leva::Prompt.where(name: @prompt.name).where.not(id: @prompt.id).order(:version).last
+    end
+  end
+end

--- a/app/controllers/evaluation/prompt_diffs_controller.rb
+++ b/app/controllers/evaluation/prompt_diffs_controller.rb
@@ -4,7 +4,7 @@ module Evaluation
   class PromptDiffsController < ApplicationController
     def show
       @prompt = Leva::Prompt.find(params[:id])
-      @other_version = Leva::Prompt.where(name: @prompt.name).where.not(id: @prompt.id).order(:version).last
+      @other_version = Leva::Prompt.where(name: @prompt.name).where.not(id: @prompt.id).order(version: :desc, id: :desc).first
     end
   end
 end

--- a/app/services/evaluation/prompt_differ.rb
+++ b/app/services/evaluation/prompt_differ.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class PromptDiffer
+    Line = Data.define(:text, :type)
+
+    def initialize(prompt_a, prompt_b)
+      @prompt_a = prompt_a
+      @prompt_b = prompt_b
+    end
+
+    def system_prompt_diff
+      diff_lines(@prompt_a.system_prompt.to_s, @prompt_b.system_prompt.to_s)
+    end
+
+    def user_prompt_diff
+      diff_lines(@prompt_a.user_prompt.to_s, @prompt_b.user_prompt.to_s)
+    end
+
+    private
+
+    def diff_lines(text_a, text_b)
+      Diffy::Diff.new(text_a, text_b).to_s.lines.filter_map do |line|
+        next if line.match?(/\A(@@|\\|---|\+\+\+)/)
+
+        Line.new(
+          text: line[1..].to_s.chomp,
+          type: case line[0]
+                when "+" then :added
+                when "-" then :removed
+                else          :unchanged
+                end
+        )
+      end
+    end
+  end
+end

--- a/app/views/evaluation/metrics/_form.html.erb
+++ b/app/views/evaluation/metrics/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with url: evaluation_metric_path(metric), method: :patch, class: "space-y-4" do |f| %>
+  <%= render UI::ErrorMessagesComponent.new(errors: metric.errors) %>
+
+  <div>
+    <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+    <p class="text-sm text-gray-900"><%= metric.name %></p>
+  </div>
+
+  <div>
+    <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+    <%= f.text_area :description, rows: 3, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" %>
+  </div>
+
+  <div>
+    <label class="block text-sm font-medium text-gray-700 mb-1">Weight</label>
+    <%= f.number_field :weight, step: 0.1, min: 0, class: "w-32 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" %>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <%= f.check_box :active, class: "h-4 w-4 rounded border-gray-300 text-indigo-600" %>
+    <label class="text-sm font-medium text-gray-700">Active</label>
+  </div>
+
+  <div class="flex gap-3">
+    <%= f.submit "Save", class: "px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700" %>
+    <%= link_to "Cancel", evaluation_metrics_path, class: "px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50" %>
+  </div>
+<% end %>

--- a/app/views/evaluation/metrics/_form.html.erb
+++ b/app/views/evaluation/metrics/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: evaluation_metric_path(metric), method: :patch, class: "space-y-4" do |f| %>
+<%= form_with model: metric, url: evaluation_metric_path(metric), method: :patch, class: "space-y-4" do |f| %>
   <%= render UI::ErrorMessagesComponent.new(errors: metric.errors) %>
 
   <div>
@@ -18,7 +18,7 @@
 
   <div class="flex items-center gap-2">
     <%= f.check_box :active, class: "h-4 w-4 rounded border-gray-300 text-indigo-600" %>
-    <label class="text-sm font-medium text-gray-700">Active</label>
+    <%= f.label :active, "Active", class: "text-sm font-medium text-gray-700" %>
   </div>
 
   <div class="flex gap-3">

--- a/app/views/evaluation/metrics/edit.html.erb
+++ b/app/views/evaluation/metrics/edit.html.erb
@@ -1,0 +1,5 @@
+<%= render UI::PageHeaderComponent.new(title: "Edit Metric: #{@metric.name}", parent: { label: "Metrics", url: evaluation_metrics_path }) %>
+
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 max-w-2xl">
+  <%= render "form", metric: @metric %>
+</div>

--- a/app/views/evaluation/metrics/index.html.erb
+++ b/app/views/evaluation/metrics/index.html.erb
@@ -1,12 +1,12 @@
 <%= render UI::PageHeaderComponent.new(title: "Metrics") %>
 
-<% @metrics_by_agent.each do |agent_name, metrics| %>
-  <div class="mb-8">
-    <h2 class="text-base font-semibold text-gray-700 mb-3"><%= agent_name %></h2>
-    <%= render Evaluation::MetricListComponent.new(metrics: metrics) %>
-  </div>
-<% end %>
-
-<% if @metrics_by_agent.empty? %>
+<% if @metrics_by_agent.any? %>
+  <% @metrics_by_agent.each do |agent_name, metrics| %>
+    <div class="mb-8">
+      <h2 class="text-base font-semibold text-gray-700 mb-3"><%= agent_name %></h2>
+      <%= render Evaluation::MetricListComponent.new(metrics: metrics) %>
+    </div>
+  <% end %>
+<% else %>
   <p class="text-gray-400 text-sm">No metrics found.</p>
 <% end %>

--- a/app/views/evaluation/metrics/index.html.erb
+++ b/app/views/evaluation/metrics/index.html.erb
@@ -1,0 +1,12 @@
+<%= render UI::PageHeaderComponent.new(title: "Metrics") %>
+
+<% @metrics_by_agent.each do |agent_name, metrics| %>
+  <div class="mb-8">
+    <h2 class="text-base font-semibold text-gray-700 mb-3"><%= agent_name %></h2>
+    <%= render Evaluation::MetricListComponent.new(metrics: metrics) %>
+  </div>
+<% end %>
+
+<% if @metrics_by_agent.empty? %>
+  <p class="text-gray-400 text-sm">No metrics found.</p>
+<% end %>

--- a/app/views/evaluation/prompt_diffs/show.html.erb
+++ b/app/views/evaluation/prompt_diffs/show.html.erb
@@ -1,5 +1,5 @@
 <%= render UI::PageHeaderComponent.new(
-  title: "Prompt Diff: #{@prompt.name}",
+  title: html_escape("Prompt Diff: #{@prompt.name}"),
   parent: { label: "Prompts", url: leva.prompts_path }
 ) %>
 

--- a/app/views/evaluation/prompt_diffs/show.html.erb
+++ b/app/views/evaluation/prompt_diffs/show.html.erb
@@ -1,0 +1,12 @@
+<%= render UI::PageHeaderComponent.new(
+  title: "Prompt Diff: #{@prompt.name}",
+  parent: { label: "Prompts", url: leva.prompts_path }
+) %>
+
+<% if @other_version %>
+  <div class="max-w-4xl">
+    <%= render Evaluation::PromptDiffComponent.new(prompt_a: @other_version, prompt_b: @prompt) %>
+  </div>
+<% else %>
+  <p class="text-sm text-gray-400">No other version available to compare.</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,11 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :evaluation do
+    resources :metrics, only: [ :index, :edit, :update ]
+    get "prompts/:id/diff", to: "prompt_diffs#show", as: :prompt_diff
+  end
+
   namespace :orchestration do
     resources :actions
     resources :pipelines do

--- a/sig/app/components/evaluation/metric_list_component.rbs
+++ b/sig/app/components/evaluation/metric_list_component.rbs
@@ -1,0 +1,6 @@
+module Evaluation
+  class MetricListComponent < ViewComponent::Base
+    def initialize: (metrics: untyped) -> void
+    def empty?: () -> bool
+  end
+end

--- a/sig/app/components/evaluation/metric_list_component.rbs
+++ b/sig/app/components/evaluation/metric_list_component.rbs
@@ -1,6 +1,5 @@
 module Evaluation
   class MetricListComponent < ViewComponent::Base
     def initialize: (metrics: untyped) -> void
-    def empty?: () -> bool
   end
 end

--- a/sig/app/components/evaluation/prompt_diff_component.rbs
+++ b/sig/app/components/evaluation/prompt_diff_component.rbs
@@ -1,0 +1,19 @@
+module Evaluation
+  class PromptDiffComponent < ViewComponent::Base
+    Line: Data
+
+    def initialize: (prompt_a: untyped, prompt_b: untyped) -> void
+    def system_prompt_diff: () -> Array[untyped]
+    def user_prompt_diff: () -> Array[untyped]
+    def line_class: (untyped line) -> String
+    def line_prefix: (untyped line) -> String
+    def version_a: () -> String
+    def version_b: () -> String
+
+    private
+
+    def diff_lines: (String text_a, String text_b) -> Array[untyped]
+    def longest_common_subsequence: (Array[String] a, Array[String] b) -> Array[Array[Integer]]
+    def build_diff: (Array[String] a, Array[String] b, Array[Array[Integer]] dp) -> Array[untyped]
+  end
+end

--- a/sig/app/components/evaluation/prompt_diff_component.rbs
+++ b/sig/app/components/evaluation/prompt_diff_component.rbs
@@ -1,19 +1,11 @@
 module Evaluation
   class PromptDiffComponent < ViewComponent::Base
-    Line: Data
-
     def initialize: (prompt_a: untyped, prompt_b: untyped) -> void
-    def system_prompt_diff: () -> Array[untyped]
-    def user_prompt_diff: () -> Array[untyped]
-    def line_class: (untyped line) -> String
-    def line_prefix: (untyped line) -> String
+    def system_prompt_diff: () -> Array[Evaluation::PromptDiffer::Line]
+    def user_prompt_diff: () -> Array[Evaluation::PromptDiffer::Line]
+    def line_class: (Evaluation::PromptDiffer::Line line) -> String
+    def line_prefix: (Evaluation::PromptDiffer::Line line) -> String
     def version_a: () -> String
     def version_b: () -> String
-
-    private
-
-    def diff_lines: (String text_a, String text_b) -> Array[untyped]
-    def longest_common_subsequence: (Array[String] a, Array[String] b) -> Array[Array[Integer]]
-    def build_diff: (Array[String] a, Array[String] b, Array[Array[Integer]] dp) -> Array[untyped]
   end
 end

--- a/sig/app/controllers/evaluation/metrics_controller.rbs
+++ b/sig/app/controllers/evaluation/metrics_controller.rbs
@@ -1,0 +1,12 @@
+module Evaluation
+  class MetricsController < ApplicationController
+    def index: () -> void
+    def edit: () -> void
+    def update: () -> void
+
+    private
+
+    def set_metric: () -> void
+    def metric_params: () -> ActionController::Parameters
+  end
+end

--- a/sig/app/controllers/evaluation/prompt_diffs_controller.rbs
+++ b/sig/app/controllers/evaluation/prompt_diffs_controller.rbs
@@ -1,0 +1,5 @@
+module Evaluation
+  class PromptDiffsController < ApplicationController
+    def show: () -> void
+  end
+end

--- a/sig/app/services/evaluation/prompt_differ.rbs
+++ b/sig/app/services/evaluation/prompt_differ.rbs
@@ -1,0 +1,17 @@
+module Evaluation
+  class PromptDiffer
+    class Line < Data
+      def self.new: (text: String, type: :added | :removed | :unchanged) -> Line
+      attr_reader text: String
+      attr_reader type: :added | :removed | :unchanged
+    end
+
+    def initialize: (untyped prompt_a, untyped prompt_b) -> void
+    def system_prompt_diff: () -> Array[Line]
+    def user_prompt_diff: () -> Array[Line]
+
+    private
+
+    def diff_lines: (String text_a, String text_b) -> Array[Line]
+  end
+end

--- a/spec/components/evaluation/metric_list_component_spec.rb
+++ b/spec/components/evaluation/metric_list_component_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::MetricListComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:metric_class) do
+    Data.define(:id, :name, :description, :weight, :active) do
+      def active? = active
+    end
+  end
+
+  let(:metrics) do
+    [
+      metric_class.new(id: 1, name: "clarity", description: "Response is clear", weight: 1.5, active: true),
+      metric_class.new(id: 2, name: "accuracy", description: "Answer is correct", weight: 2.0, active: false)
+    ]
+  end
+
+  context "with metrics" do
+    let(:component) { described_class.new(metrics: metrics) }
+
+    it "renders a table" do
+      expect(rendered.css("table")).to be_present
+    end
+
+    it "renders metric names" do
+      expect(rendered.text).to include("clarity")
+      expect(rendered.text).to include("accuracy")
+    end
+
+    it "renders metric descriptions" do
+      expect(rendered.text).to include("Response is clear")
+    end
+
+    it "renders weights" do
+      expect(rendered.text).to include("1.5")
+      expect(rendered.text).to include("2.0")
+    end
+
+    it "renders active status" do
+      expect(rendered.text).to include("Yes")
+      expect(rendered.text).to include("No")
+    end
+
+    it "renders edit links" do
+      expect(rendered.css("a[href*='edit']").size).to eq(2)
+    end
+  end
+
+  context "with empty collection" do
+    let(:component) { described_class.new(metrics: []) }
+
+    it "renders empty message" do
+      expect(rendered.text).to include("No metrics found.")
+    end
+  end
+end

--- a/spec/components/evaluation/prompt_diff_component_spec.rb
+++ b/spec/components/evaluation/prompt_diff_component_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::PromptDiffComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:prompt_class) { Data.define(:name, :version, :system_prompt, :user_prompt) }
+
+  let(:prompt_a) do
+    prompt_class.new(
+      name: "classify",
+      version: 1,
+      system_prompt: "You are an assistant.\nBe helpful.",
+      user_prompt: "Classify the email."
+    )
+  end
+
+  let(:prompt_b) do
+    prompt_class.new(
+      name: "classify",
+      version: 2,
+      system_prompt: "You are an expert assistant.\nBe concise.",
+      user_prompt: "Classify the email."
+    )
+  end
+
+  let(:component) { described_class.new(prompt_a: prompt_a, prompt_b: prompt_b) }
+
+  it "renders a diff container" do
+    expect(rendered.css("[data-diff]")).to be_present
+  end
+
+  it "renders removed lines with red highlight" do
+    removed = rendered.css(".bg-red-100")
+    expect(removed.map(&:text).join).to include("You are an assistant.")
+  end
+
+  it "renders added lines with green highlight" do
+    added = rendered.css(".bg-green-100")
+    expect(added.map(&:text).join).to include("You are an expert assistant.")
+  end
+
+  it "renders unchanged lines without color highlight" do
+    unchanged_text = rendered.css("[data-diff] span:not(.bg-red-100):not(.bg-green-100)")
+    expect(unchanged_text.map(&:text).join).to include("Be")
+  end
+
+  it "shows version labels for both prompts" do
+    expect(rendered.text).to include("v1")
+    expect(rendered.text).to include("v2")
+  end
+
+  context "with identical prompts" do
+    let(:component) { described_class.new(prompt_a: prompt_a, prompt_b: prompt_a) }
+
+    it "renders no added or removed lines" do
+      expect(rendered.css(".bg-red-100")).to be_empty
+      expect(rendered.css(".bg-green-100")).to be_empty
+    end
+  end
+end

--- a/spec/requests/evaluation/metrics_spec.rb
+++ b/spec/requests/evaluation/metrics_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Evaluation::Metrics" do
+  describe "GET /evaluation/metrics" do
+    it "returns 200 with empty state" do
+      get evaluation_metrics_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Metrics")
+    end
+
+    it "lists existing metrics" do
+      metric = create(:evaluation_metric)
+      get evaluation_metrics_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(metric.name)
+    end
+  end
+
+  describe "GET /evaluation/metrics/:id/edit" do
+    it "returns 200 with edit form" do
+      metric = create(:evaluation_metric)
+      get edit_evaluation_metric_path(metric)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(metric.name)
+    end
+  end
+
+  describe "PATCH /evaluation/metrics/:id" do
+    it "redirects to index on success" do
+      metric = create(:evaluation_metric)
+      patch evaluation_metric_path(metric), params: { evaluation_metric: { weight: 2.0 } }
+      expect(response).to redirect_to(evaluation_metrics_path)
+      expect(flash[:notice]).to eq("Metric updated.")
+    end
+
+    it "persists updated attributes" do
+      metric = create(:evaluation_metric)
+      patch evaluation_metric_path(metric), params: { evaluation_metric: { weight: 2.0, active: false } }
+      expect(metric.reload.weight).to eq(2.0)
+      expect(metric.reload.active).to be(false)
+    end
+
+    it "returns 422 with invalid params" do
+      metric = create(:evaluation_metric)
+      patch evaluation_metric_path(metric), params: {
+        evaluation_metric: { weight: nil }
+      }
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Evaluation::MetricsController` (index, edit, update) with routes under `/evaluation/metrics`
- Add `Evaluation::MetricListComponent` — table of metrics per agent with name, description, weight, and active toggle
- Add `Evaluation::PromptDiffComponent` — line-by-line diff between two `Leva::Prompt` versions with green/red highlights
- Add `Evaluation::PromptDiffsController` with standalone diff route at `/evaluation/prompts/:id/diff`

Closes #28

## Test plan

- [x] Request specs for `MetricsController` (index, edit, update success + 422)
- [x] Component spec for `MetricListComponent` (renders table, names, descriptions, weights, active status, edit links, empty state)
- [x] Component spec for `PromptDiffComponent` (added/removed/unchanged lines, version labels, identical prompts)
- [x] RBS signatures for all new controllers and components
- [x] Full suite passes: 1030 examples, 0 failures, 96.72% coverage
- [x] Rubocop passes with no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)