### PR TITLE
feat: prompt improvement loop with auto-eval trigger

### DIFF
--- a/app/jobs/evaluation/prompt_auto_eval_job.rb
+++ b/app/jobs/evaluation/prompt_auto_eval_job.rb
@@ -1,0 +1,26 @@
+module Evaluation
+  class PromptAutoEvalJob < ApplicationJob
+    queue_as :default
+
+    def perform(prompt)
+      previous_experiment = Leva::Experiment
+        .joins(:prompt)
+        .where(leva_prompts: { name: prompt.name })
+        .where(status: :completed)
+        .order(id: :desc)
+        .first
+
+      return unless previous_experiment
+
+      experiment = Leva::Experiment.create!(
+        name: "Auto-eval for #{prompt.name} v#{prompt.version}",
+        dataset: previous_experiment.dataset,
+        prompt: prompt,
+        runner_class: "Evaluation::StubbedAgentRun",
+        evaluator_classes: [ "LLMJudgeEval" ]
+      )
+
+      Leva::ExperimentJob.perform_later(experiment)
+    end
+  end
+end

--- a/app/jobs/evaluation/prompt_auto_eval_job.rb
+++ b/app/jobs/evaluation/prompt_auto_eval_job.rb
@@ -2,7 +2,9 @@ module Evaluation
   class PromptAutoEvalJob < ApplicationJob
     queue_as :default
 
-    def perform(prompt)
+    def perform(prompt_id)
+      prompt = Leva::Prompt.find(prompt_id)
+
       previous_experiment = Leva::Experiment
         .joins(:prompt)
         .where(leva_prompts: { name: prompt.name })
@@ -10,7 +12,10 @@ module Evaluation
         .order(id: :desc)
         .first
 
-      return unless previous_experiment
+      unless previous_experiment
+        Rails.logger.info("[PromptAutoEvalJob] No completed experiment for '#{prompt.name}', skipping.")
+        return
+      end
 
       experiment = Leva::Experiment.create!(
         name: "Auto-eval for #{prompt.name} v#{prompt.version}",
@@ -21,6 +26,8 @@ module Evaluation
       )
 
       Leva::ExperimentJob.perform_later(experiment)
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error("[PromptAutoEvalJob] Experiment creation failed: #{e.message}")
     end
   end
 end

--- a/app/models/concerns/evaluation/auto_eval_triggerable.rb
+++ b/app/models/concerns/evaluation/auto_eval_triggerable.rb
@@ -1,0 +1,9 @@
+module Evaluation
+  module AutoEvalTriggerable
+    extend ActiveSupport::Concern
+
+    included do
+      after_create_commit { |record| Evaluation::PromptAutoEvalJob.perform_later(record.id) }
+    end
+  end
+end

--- a/app/services/evaluation/prompt_improver.rb
+++ b/app/services/evaluation/prompt_improver.rb
@@ -1,5 +1,9 @@
 module Evaluation
   class PromptImprover
+    Error = Class.new(StandardError)
+
+    EvaluationEntry = Data.define(:metric_name, :score, :justification)
+
     SYSTEM_PROMPT = <<~PROMPT.freeze
       You are an expert prompt engineer. You will be given a current agent system prompt,
       evaluation scores with justifications, and metric rubrics describing what each score measures.
@@ -9,8 +13,6 @@ module Evaluation
       - "system_prompt": the improved system prompt (string)
       - "user_prompt": the improved user prompt (string)
     PROMPT
-
-    DEFAULT_MODEL = ENV.fetch("EVALUATION_LLM_MODEL", "claude-sonnet-4-6")
 
     def self.call(experiment:)
       new(experiment:).call
@@ -24,7 +26,7 @@ module Evaluation
       current_prompt = @experiment.prompt
       raise ArgumentError, "Experiment has no associated prompt" if current_prompt.nil?
 
-      metrics        = Evaluation::Metric.where(agent_name: current_prompt.name, active: true)
+      metrics         = Evaluation::Metric.where(agent_name: current_prompt.name, active: true)
       evaluation_data = load_evaluation_data
 
       user_message = build_improvement_message(
@@ -44,30 +46,39 @@ module Evaluation
 
     private
 
+    def model
+      ENV.fetch("EVALUATION_LLM_MODEL", "claude-sonnet-4-6")
+    end
+
     def load_evaluation_data
       Evaluation::Justification
-        .joins(:evaluation_result)
-        .includes(:evaluation_result)
+        .eager_load(:evaluation_result)
         .where(leva_evaluation_results: { experiment_id: @experiment.id })
-        .map { |j| { metric_name: j.metric_name, score: j.evaluation_result.score, justification: j.justification } }
+        .map { |j| EvaluationEntry.new(metric_name: j.metric_name, score: j.evaluation_result.score, justification: j.justification) }
     end
 
     def build_improvement_message(current_prompt:, evaluation_data:, metrics:)
       rubrics = metrics.map { |m| "- #{m.name}: #{m.description}" }.join("\n")
 
       score_lines = evaluation_data.map do |r|
-        "- #{r[:metric_name]}: #{r[:score]}/5 — #{r[:justification]}"
+        "- #{r.metric_name}: #{r.score}/5 — #{r.justification}"
       end.join("\n")
 
       <<~MSG
         ## Current System Prompt
+        <current_system_prompt>
         #{current_prompt.system_prompt}
+        </current_system_prompt>
 
         ## Current User Prompt
+        <current_user_prompt>
         #{current_prompt.user_prompt}
+        </current_user_prompt>
 
         ## Evaluation Results
+        <evaluation_results>
         #{score_lines.presence || "(no evaluation results)"}
+        </evaluation_results>
 
         ## Metric Rubrics
         #{rubrics.presence || "(no metrics defined)"}
@@ -75,23 +86,26 @@ module Evaluation
     end
 
     def call_llm(user_message)
-      response = RubyLLM.chat(model: DEFAULT_MODEL)
+      response = RubyLLM.chat(model:)
                         .with_instructions(SYSTEM_PROMPT)
                         .ask(user_message)
 
       parse_response(response.content)
+    rescue Error
+      raise
     rescue StandardError => e
-      raise ArgumentError, "LLM call failed: #{e.message}"
+      Rails.logger.error("[PromptImprover] LLM call failed: #{e.message}")
+      raise Error, "LLM call failed"
     end
 
     def parse_response(content)
       parsed = JSON.parse(content)
-      raise ArgumentError, "Expected JSON object" unless parsed.is_a?(Hash)
-      raise ArgumentError, "Missing system_prompt in LLM response" if parsed["system_prompt"].blank?
+      raise Error, "Expected JSON object" unless parsed.is_a?(Hash)
+      raise Error, "Missing system_prompt in LLM response" if parsed["system_prompt"].blank?
 
       { system_prompt: parsed["system_prompt"], user_prompt: parsed["user_prompt"].to_s }
     rescue JSON::ParserError => e
-      raise ArgumentError, "Prompt improvement returned invalid JSON: #{e.message}"
+      raise Error, "Prompt improvement returned invalid JSON: #{e.message}"
     end
   end
 end

--- a/app/services/evaluation/prompt_improver.rb
+++ b/app/services/evaluation/prompt_improver.rb
@@ -1,0 +1,97 @@
+module Evaluation
+  class PromptImprover
+    SYSTEM_PROMPT = <<~PROMPT.freeze
+      You are an expert prompt engineer. You will be given a current agent system prompt,
+      evaluation scores with justifications, and metric rubrics describing what each score measures.
+
+      Your task: improve the system prompt to address weak areas (low scores) while preserving
+      behaviors that already score well. Return ONLY a JSON object with:
+      - "system_prompt": the improved system prompt (string)
+      - "user_prompt": the improved user prompt (string)
+    PROMPT
+
+    DEFAULT_MODEL = ENV.fetch("EVALUATION_LLM_MODEL", "claude-sonnet-4-6")
+
+    def self.call(experiment:)
+      new(experiment:).call
+    end
+
+    def initialize(experiment:)
+      @experiment = experiment
+    end
+
+    def call
+      current_prompt = @experiment.prompt
+      raise ArgumentError, "Experiment has no associated prompt" if current_prompt.nil?
+
+      metrics        = Evaluation::Metric.where(agent_name: current_prompt.name, active: true)
+      evaluation_data = load_evaluation_data
+
+      user_message = build_improvement_message(
+        current_prompt:,
+        evaluation_data:,
+        metrics:
+      )
+
+      improved = call_llm(user_message)
+
+      Leva::Prompt.create!(
+        name: current_prompt.name,
+        system_prompt: improved[:system_prompt],
+        user_prompt: improved[:user_prompt].presence || current_prompt.user_prompt
+      )
+    end
+
+    private
+
+    def load_evaluation_data
+      Evaluation::Justification
+        .joins(:evaluation_result)
+        .includes(:evaluation_result)
+        .where(leva_evaluation_results: { experiment_id: @experiment.id })
+        .map { |j| { metric_name: j.metric_name, score: j.evaluation_result.score, justification: j.justification } }
+    end
+
+    def build_improvement_message(current_prompt:, evaluation_data:, metrics:)
+      rubrics = metrics.map { |m| "- #{m.name}: #{m.description}" }.join("\n")
+
+      score_lines = evaluation_data.map do |r|
+        "- #{r[:metric_name]}: #{r[:score]}/5 — #{r[:justification]}"
+      end.join("\n")
+
+      <<~MSG
+        ## Current System Prompt
+        #{current_prompt.system_prompt}
+
+        ## Current User Prompt
+        #{current_prompt.user_prompt}
+
+        ## Evaluation Results
+        #{score_lines.presence || "(no evaluation results)"}
+
+        ## Metric Rubrics
+        #{rubrics.presence || "(no metrics defined)"}
+      MSG
+    end
+
+    def call_llm(user_message)
+      response = RubyLLM.chat(model: DEFAULT_MODEL)
+                        .with_instructions(SYSTEM_PROMPT)
+                        .ask(user_message)
+
+      parse_response(response.content)
+    rescue StandardError => e
+      raise ArgumentError, "LLM call failed: #{e.message}"
+    end
+
+    def parse_response(content)
+      parsed = JSON.parse(content)
+      raise ArgumentError, "Expected JSON object" unless parsed.is_a?(Hash)
+      raise ArgumentError, "Missing system_prompt in LLM response" if parsed["system_prompt"].blank?
+
+      { system_prompt: parsed["system_prompt"], user_prompt: parsed["user_prompt"].to_s }
+    rescue JSON::ParserError => e
+      raise ArgumentError, "Prompt improvement returned invalid JSON: #{e.message}"
+    end
+  end
+end

--- a/config/initializers/leva_prompt_hooks.rb
+++ b/config/initializers/leva_prompt_hooks.rb
@@ -1,0 +1,5 @@
+Rails.application.config.after_initialize do
+  Leva::Prompt.after_create_commit do |prompt|
+    Evaluation::PromptAutoEvalJob.perform_later(prompt)
+  end
+end

--- a/config/initializers/leva_prompt_hooks.rb
+++ b/config/initializers/leva_prompt_hooks.rb
@@ -1,5 +1,5 @@
 Rails.application.config.after_initialize do
-  Leva::Prompt.after_create_commit do |prompt|
-    Evaluation::PromptAutoEvalJob.perform_later(prompt)
+  unless Leva::Prompt.ancestors.include?(Evaluation::AutoEvalTriggerable)
+    Leva::Prompt.include(Evaluation::AutoEvalTriggerable)
   end
 end

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -85,4 +85,21 @@ namespace :evaluation do
     delta_str     = result.overall_delta   ? format("%+.2f", result.overall_delta)  : "n/a"
     puts format("%-30s %8s %8s %10s", "OVERALL", baseline_str, candidate_str, delta_str)
   end
+
+  desc "Improve prompt for an agent based on the latest completed experiment (e.g. rake evaluation:improve[Emails::ClassifyAgent])"
+  task :improve, [ :agent_name ] => :environment do |_, args|
+    agent_name = args[:agent_name] or raise ArgumentError, "Usage: rake evaluation:improve[AgentName]"
+
+    experiment = Leva::Experiment
+      .joins(:prompt)
+      .where(leva_prompts: { name: agent_name })
+      .where(status: :completed)
+      .order(id: :desc)
+      .first
+
+    raise ArgumentError, "No completed experiment found for #{agent_name}" unless experiment
+
+    prompt = Evaluation::PromptImprover.call(experiment: experiment)
+    puts "Created improved prompt v#{prompt.version} for #{agent_name} (id: #{prompt.id})"
+  end
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -169,6 +169,14 @@ gems:
     revision: 824a0009c676771836eb71685966a1b3326f7855
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: diffy
+  version: '3.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: digest
   version: '0'
   source:

--- a/sig/app/jobs/evaluation/prompt_auto_eval_job.rbs
+++ b/sig/app/jobs/evaluation/prompt_auto_eval_job.rbs
@@ -1,5 +1,5 @@
 module Evaluation
   class PromptAutoEvalJob < ApplicationJob
-    def perform: (Leva::Prompt prompt) -> void
+    def perform: (Integer prompt_id) -> void
   end
 end

--- a/sig/app/jobs/evaluation/prompt_auto_eval_job.rbs
+++ b/sig/app/jobs/evaluation/prompt_auto_eval_job.rbs
@@ -1,0 +1,5 @@
+module Evaluation
+  class PromptAutoEvalJob < ApplicationJob
+    def perform: (Leva::Prompt prompt) -> void
+  end
+end

--- a/sig/app/models/concerns/evaluation/auto_eval_triggerable.rbs
+++ b/sig/app/models/concerns/evaluation/auto_eval_triggerable.rbs
@@ -1,0 +1,5 @@
+module Evaluation
+  module AutoEvalTriggerable
+    extend ActiveSupport::Concern
+  end
+end

--- a/sig/app/models/evaluation/justification.rbs
+++ b/sig/app/models/evaluation/justification.rbs
@@ -1,5 +1,9 @@
 module Evaluation
   class Justification < ApplicationRecord
+    def self.joins: (*untyped) -> ActiveRecord::Relation
+    def self.includes: (*untyped) -> ActiveRecord::Relation
+    def self.where: (**untyped) -> ActiveRecord::Relation
+
     def evaluation_result: () -> Leva::EvaluationResult
     def metric_name: () -> String
     def justification: () -> String

--- a/sig/app/models/evaluation/justification.rbs
+++ b/sig/app/models/evaluation/justification.rbs
@@ -2,6 +2,7 @@ module Evaluation
   class Justification < ApplicationRecord
     def self.joins: (*untyped) -> ActiveRecord::Relation
     def self.includes: (*untyped) -> ActiveRecord::Relation
+    def self.eager_load: (*untyped) -> ActiveRecord::Relation
     def self.where: (**untyped) -> ActiveRecord::Relation
 
     def evaluation_result: () -> Leva::EvaluationResult

--- a/sig/app/services/evaluation/prompt_improver.rbs
+++ b/sig/app/services/evaluation/prompt_improver.rbs
@@ -1,0 +1,26 @@
+module Evaluation
+  class PromptImprover
+    SYSTEM_PROMPT: String
+    DEFAULT_MODEL: String
+
+    def self.call: (experiment: Leva::Experiment) -> Leva::Prompt
+
+    def initialize: (experiment: Leva::Experiment) -> void
+
+    def call: () -> Leva::Prompt
+
+    private
+
+    def load_evaluation_data: () -> Array[{ metric_name: String, score: Float, justification: String }]
+
+    def build_improvement_message: (
+      current_prompt: Leva::Prompt,
+      evaluation_data: Array[{ metric_name: String, score: Float, justification: String }],
+      metrics: ActiveRecord::Relation
+    ) -> String
+
+    def call_llm: (String user_message) -> { system_prompt: String, user_prompt: String }
+
+    def parse_response: (String content) -> { system_prompt: String, user_prompt: String }
+  end
+end

--- a/sig/app/services/evaluation/prompt_improver.rbs
+++ b/sig/app/services/evaluation/prompt_improver.rbs
@@ -1,7 +1,17 @@
 module Evaluation
   class PromptImprover
+    class Error < StandardError
+    end
+
+    class EvaluationEntry
+      attr_reader metric_name: String
+      attr_reader score: Float
+      attr_reader justification: String
+
+      def self.new: (metric_name: String, score: Float, justification: String) -> EvaluationEntry
+    end
+
     SYSTEM_PROMPT: String
-    DEFAULT_MODEL: String
 
     def self.call: (experiment: Leva::Experiment) -> Leva::Prompt
 
@@ -11,11 +21,13 @@ module Evaluation
 
     private
 
-    def load_evaluation_data: () -> Array[{ metric_name: String, score: Float, justification: String }]
+    def model: () -> String
+
+    def load_evaluation_data: () -> Array[EvaluationEntry]
 
     def build_improvement_message: (
       current_prompt: Leva::Prompt,
-      evaluation_data: Array[{ metric_name: String, score: Float, justification: String }],
+      evaluation_data: Array[EvaluationEntry],
       metrics: ActiveRecord::Relation
     ) -> String
 

--- a/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
+++ b/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
@@ -18,20 +18,20 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
 
   describe "#perform" do
     it "creates a new experiment with the new prompt" do
-      described_class.perform_now(new_prompt)
+      described_class.perform_now(new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp).to be_present
       expect(new_exp.prompt).to eq(new_prompt)
     end
 
     it "reuses the previous experiment's dataset" do
-      described_class.perform_now(new_prompt)
+      described_class.perform_now(new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp.dataset).to eq(dataset)
     end
 
     it "sets runner_class and evaluator_classes on the new experiment" do
-      described_class.perform_now(new_prompt)
+      described_class.perform_now(new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp.runner_class).to eq("Evaluation::StubbedAgentRun")
       expect(new_exp.evaluator_classes).to eq([ "LLMJudgeEval" ])
@@ -39,7 +39,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
 
     it "enqueues Leva::ExperimentJob for the new experiment" do
       allow(Leva::ExperimentJob).to receive(:perform_later)
-      described_class.perform_now(new_prompt)
+      described_class.perform_now(new_prompt.id)
       expect(Leva::ExperimentJob).to have_received(:perform_later).once
     end
 
@@ -49,12 +49,12 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       end
 
       it "does not create an experiment" do
-        expect { described_class.perform_now(new_prompt) }.not_to change(Leva::Experiment, :count)
+        expect { described_class.perform_now(new_prompt.id) }.not_to change(Leva::Experiment, :count)
       end
 
       it "does not enqueue Leva::ExperimentJob" do
         allow(Leva::ExperimentJob).to receive(:perform_later)
-        described_class.perform_now(new_prompt)
+        described_class.perform_now(new_prompt.id)
         expect(Leva::ExperimentJob).not_to have_received(:perform_later)
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       let(:new_prompt) { create(:leva_prompt, name: "Records::FillAgent") }
 
       it "does nothing" do
-        expect { described_class.perform_now(new_prompt) }.not_to change(Leva::Experiment, :count)
+        expect { described_class.perform_now(new_prompt.id) }.not_to change(Leva::Experiment, :count)
       end
     end
   end

--- a/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
+++ b/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Evaluation::PromptAutoEvalJob do
+  let(:agent_name) { "Emails::ClassifyAgent" }
+  let(:dataset) { create(:leva_dataset) }
+  let(:previous_prompt) { create(:leva_prompt, name: agent_name) }
+  let(:previous_experiment) do
+    create(:leva_experiment,
+      prompt: previous_prompt,
+      dataset: dataset,
+      status: :completed,
+      runner_class: "Evaluation::StubbedAgentRun",
+      evaluator_classes: [ "LLMJudgeEval" ])
+  end
+  let(:new_prompt) { create(:leva_prompt, name: agent_name) }
+
+  before { previous_experiment }
+
+  describe "#perform" do
+    it "creates a new experiment with the new prompt" do
+      described_class.perform_now(new_prompt)
+      new_exp = Leva::Experiment.where(prompt: new_prompt).first
+      expect(new_exp).to be_present
+      expect(new_exp.prompt).to eq(new_prompt)
+    end
+
+    it "reuses the previous experiment's dataset" do
+      described_class.perform_now(new_prompt)
+      new_exp = Leva::Experiment.where(prompt: new_prompt).first
+      expect(new_exp.dataset).to eq(dataset)
+    end
+
+    it "sets runner_class and evaluator_classes on the new experiment" do
+      described_class.perform_now(new_prompt)
+      new_exp = Leva::Experiment.where(prompt: new_prompt).first
+      expect(new_exp.runner_class).to eq("Evaluation::StubbedAgentRun")
+      expect(new_exp.evaluator_classes).to eq([ "LLMJudgeEval" ])
+    end
+
+    it "enqueues Leva::ExperimentJob for the new experiment" do
+      allow(Leva::ExperimentJob).to receive(:perform_later)
+      described_class.perform_now(new_prompt)
+      expect(Leva::ExperimentJob).to have_received(:perform_later).once
+    end
+
+    context "when no completed experiment exists for the prompt name" do
+      let(:previous_experiment) do
+        create(:leva_experiment, prompt: previous_prompt, dataset: dataset, status: :pending)
+      end
+
+      it "does not create an experiment" do
+        expect { described_class.perform_now(new_prompt) }.not_to change(Leva::Experiment, :count)
+      end
+
+      it "does not enqueue Leva::ExperimentJob" do
+        allow(Leva::ExperimentJob).to receive(:perform_later)
+        described_class.perform_now(new_prompt)
+        expect(Leva::ExperimentJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context "when no experiment exists for the prompt name at all" do
+      let(:new_prompt) { create(:leva_prompt, name: "Records::FillAgent") }
+
+      it "does nothing" do
+        expect { described_class.perform_now(new_prompt) }.not_to change(Leva::Experiment, :count)
+      end
+    end
+  end
+end

--- a/spec/models/leva_prompt_hooks_spec.rb
+++ b/spec/models/leva_prompt_hooks_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Leva::Prompt auto-eval hook" do # rubocop:disable RSpec/DescribeClass
+  it "enqueues PromptAutoEvalJob when a new prompt is created" do
+    prompt = create(:leva_prompt)
+    expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt)
+  end
+
+  it "does not enqueue PromptAutoEvalJob when an existing prompt is updated" do
+    prompt = create(:leva_prompt)
+    RSpec::Mocks.space.proxy_for(Evaluation::PromptAutoEvalJob).reset
+    allow(Evaluation::PromptAutoEvalJob).to receive(:perform_later)
+
+    prompt.update!(system_prompt: "Updated prompt text")
+
+    expect(Evaluation::PromptAutoEvalJob).not_to have_received(:perform_later)
+  end
+end

--- a/spec/models/leva_prompt_hooks_spec.rb
+++ b/spec/models/leva_prompt_hooks_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Leva::Prompt auto-eval hook" do # rubocop:disable RSpec/DescribeClass
   it "enqueues PromptAutoEvalJob when a new prompt is created" do
     prompt = create(:leva_prompt)
-    expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt)
+    expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt.id)
   end
 
   it "does not enqueue PromptAutoEvalJob when an existing prompt is updated" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,10 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
 
+  config.before do
+    allow(Evaluation::PromptAutoEvalJob).to receive(:perform_later)
+  end
+
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
   ]

--- a/spec/services/evaluation/prompt_improver_spec.rb
+++ b/spec/services/evaluation/prompt_improver_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe Evaluation::PromptImprover do
+  let(:agent_name) { "Emails::ClassifyAgent" }
+  let(:prompt) { create(:leva_prompt, name: agent_name, system_prompt: "You classify emails.", user_prompt: "{{input}}") }
+  let!(:experiment) { create(:leva_experiment, prompt: prompt, status: :completed) }
+
+  def stub_llm(system_prompt: "Improved system.", user_prompt: "{{input}}")
+    body = {
+      id: "msg_01", type: "message", role: "assistant",
+      content: [ { type: "text", text: JSON.generate({ "system_prompt" => system_prompt, "user_prompt" => user_prompt }) } ],
+      model: "claude-sonnet-4-6", stop_reason: "end_turn",
+      usage: { input_tokens: 200, output_tokens: 80 }
+    }.to_json
+    stub_request(:post, %r{api\.anthropic\.com})
+      .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
+  end
+
+  def make_eval_result(score:, metric_name:, justification: "Good job.")
+    runner_result = create(:leva_runner_result, experiment: experiment)
+    eval_result = create(:leva_evaluation_result,
+      experiment: experiment,
+      runner_result: runner_result,
+      dataset_record: runner_result.dataset_record,
+      score: score)
+    create(:evaluation_justification, evaluation_result: eval_result, metric_name: metric_name, justification: justification)
+    eval_result
+  end
+
+  before do
+    create(:evaluation_metric, agent_name: agent_name, name: "accuracy", description: "How accurate is it?")
+    stub_llm
+  end
+
+  describe ".call" do
+    it "returns a new Leva::Prompt" do
+      result = described_class.call(experiment: experiment)
+      expect(result).to be_a(Leva::Prompt)
+      expect(result).to be_persisted
+    end
+
+    it "creates a prompt with the same agent name" do
+      result = described_class.call(experiment: experiment)
+      expect(result.name).to eq(agent_name)
+    end
+
+    it "creates a new prompt record (does not mutate original)" do
+      expect { described_class.call(experiment: experiment) }.to change(Leva::Prompt, :count).by(1)
+    end
+
+    it "uses the improved system prompt from LLM" do
+      stub_llm(system_prompt: "Better classification prompt.")
+      result = described_class.call(experiment: experiment)
+      expect(result.system_prompt).to eq("Better classification prompt.")
+    end
+
+    it "uses the improved user prompt from LLM" do
+      stub_llm(user_prompt: "Improved {{input}}")
+      result = described_class.call(experiment: experiment)
+      expect(result.user_prompt).to eq("Improved {{input}}")
+    end
+
+    it "includes the current system prompt in the LLM request" do
+      described_class.call(experiment: experiment)
+      expect(WebMock).to have_requested(:post, %r{api\.anthropic\.com}).with { |req|
+        req.body.include?("You classify emails.")
+      }
+    end
+
+    it "includes evaluation scores and justifications in the LLM request" do
+      make_eval_result(score: 2.0, metric_name: "accuracy", justification: "Missed several emails.")
+      described_class.call(experiment: experiment)
+      expect(WebMock).to have_requested(:post, %r{api\.anthropic\.com}).with { |req|
+        req.body.include?("accuracy") && req.body.include?("Missed several emails.")
+      }
+    end
+
+    it "includes metric rubrics in the LLM request" do
+      described_class.call(experiment: experiment)
+      expect(WebMock).to have_requested(:post, %r{api\.anthropic\.com}).with { |req|
+        req.body.include?("How accurate is it?")
+      }
+    end
+
+    context "when experiment has no associated prompt" do
+      let(:experiment) { create(:leva_experiment, prompt: nil, status: :completed) }
+
+      it "raises ArgumentError" do
+        expect { described_class.call(experiment: experiment) }
+          .to raise_error(ArgumentError, /no.*prompt/i)
+      end
+    end
+
+    context "when LLM returns invalid JSON" do
+      before do
+        body = {
+          id: "msg_01", type: "message", role: "assistant",
+          content: [ { type: "text", text: "not json" } ],
+          model: "claude-sonnet-4-6", stop_reason: "end_turn",
+          usage: { input_tokens: 100, output_tokens: 10 }
+        }.to_json
+        stub_request(:post, %r{api\.anthropic\.com})
+          .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "raises ArgumentError" do
+        expect { described_class.call(experiment: experiment) }
+          .to raise_error(ArgumentError, /invalid json/i)
+      end
+    end
+  end
+end

--- a/spec/services/evaluation/prompt_improver_spec.rb
+++ b/spec/services/evaluation/prompt_improver_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe Evaluation::PromptImprover do
           .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
       end
 
-      it "raises ArgumentError" do
+      it "raises PromptImprover::Error" do
         expect { described_class.call(experiment: experiment) }
-          .to raise_error(ArgumentError, /invalid json/i)
+          .to raise_error(Evaluation::PromptImprover::Error, /invalid json/i)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Adds `Evaluation::PromptImprover.call(experiment:)` which loads current prompt text, evaluation scores/justifications, and metric rubrics, then calls an LLM to generate an improved prompt as a new `Leva::Prompt` version
- Adds `Evaluation::PromptAutoEvalJob` which, when a new `Leva::Prompt` is created, finds the most recent completed experiment for the same agent and automatically creates and enqueues a new `Leva::Experiment` for evaluation
- Adds `rake evaluation:improve[AgentName]` task that finds the latest completed experiment for an agent and runs the improver
- Stubs `Evaluation::PromptAutoEvalJob.perform_later` globally in `rails_helper.rb` to prevent the async-job inline adapter from spawning fibers that lock SQLite during tests

Closes #29

## Test plan

- [x] `Evaluation::PromptImprover` spec: returns new prompt, uses LLM with current prompt text + scores + justifications + metric rubrics, handles missing prompt and invalid JSON
- [x] `Evaluation::PromptAutoEvalJob` spec: creates experiment with correct dataset/runner/evaluators, enqueues `Leva::ExperimentJob`, does nothing when no completed experiment exists
- [x] `Leva::Prompt auto-eval hook` spec: enqueues job on create, not on update
- [x] Full suite: 1049 examples, 0 failures
- [x] RuboCop: no offenses
- [x] Steep: no new errors (pre-existing `Diffy` warning in `prompt_differ.rb` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)