### PR TITLE
feat: comparison view, improve button, and activate flow

### DIFF
--- a/app/components/evaluation/comparison_component.html.erb
+++ b/app/components/evaluation/comparison_component.html.erb
@@ -1,0 +1,31 @@
+<div class="space-y-6">
+  <div class="grid grid-cols-3 gap-4 text-sm font-semibold text-gray-500 border-b pb-2">
+    <div>Metric</div>
+    <div class="text-center"><%= @baseline_experiment.name %></div>
+    <div class="text-center"><%= @candidate_experiment.name %></div>
+  </div>
+
+  <% metric_names.each do |name| %>
+    <div class="grid grid-cols-3 gap-4 text-sm py-1 border-b border-gray-100">
+      <div class="font-medium text-gray-700"><%= name %></div>
+      <div class="text-center text-gray-600"><%= format_score(@result.baseline_metrics[name]) %></div>
+      <div class="text-center">
+        <span class="<%= delta_class(@result.metric_deltas[name]) %>">
+          <%= format_score(@result.candidate_metrics[name]) %>
+          <span class="text-xs ml-1">(<%= format_delta(@result.metric_deltas[name]) %>)</span>
+        </span>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="grid grid-cols-3 gap-4 text-sm font-semibold pt-2 border-t border-gray-300">
+    <div class="text-gray-700">Overall</div>
+    <div class="text-center text-gray-600"><%= format_score(@result.baseline_score) %></div>
+    <div class="text-center">
+      <span class="<%= delta_class(@result.overall_delta) %>">
+        <%= format_score(@result.candidate_score) %>
+        <span class="text-xs ml-1">(<%= format_delta(@result.overall_delta) %>)</span>
+      </span>
+    </div>
+  </div>
+</div>

--- a/app/components/evaluation/comparison_component.rb
+++ b/app/components/evaluation/comparison_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class ComparisonComponent < ViewComponent::Base
+    def initialize(result:, baseline_experiment:, candidate_experiment:)
+      @result = result
+      @baseline_experiment = baseline_experiment
+      @candidate_experiment = candidate_experiment
+    end
+
+    def metric_names
+      @result.metric_deltas.keys
+    end
+
+    def delta_class(delta)
+      return "text-gray-400" if delta.nil?
+      delta >= 0 ? "text-green-600 font-medium" : "text-red-600 font-medium"
+    end
+
+    def format_delta(delta)
+      return "—" if delta.nil?
+      prefix = delta >= 0 ? "+" : ""
+      "#{prefix}#{delta.round(1)}"
+    end
+
+    def format_score(score)
+      return "—" if score.nil?
+      score.round(1).to_s
+    end
+  end
+end

--- a/app/components/evaluation/comparison_component.rb
+++ b/app/components/evaluation/comparison_component.rb
@@ -9,7 +9,7 @@ module Evaluation
     end
 
     def metric_names
-      @result.metric_deltas.keys
+      @result.metric_deltas.keys.sort
     end
 
     def delta_class(delta)

--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -9,24 +9,44 @@ module Evaluation
     end
 
     def show
+      return unless @experiment.prompt
+
       @newer_experiment = Leva::Experiment
         .joins(:prompt)
-        .where(leva_prompts: { name: @experiment.prompt&.name })
+        .where(leva_prompts: { name: @experiment.prompt.name })
         .where("leva_experiments.id > ?", @experiment.id)
         .order(id: :desc)
+        .includes(:prompt)
         .first
     end
 
     def improve
+      unless @experiment.prompt
+        return redirect_to evaluation_experiment_path(@experiment), alert: "This experiment has no associated prompt."
+      end
+
       new_prompt = Evaluation::PromptImprover.call(experiment: @experiment)
       redirect_to evaluation_experiment_path(@experiment),
                   notice: "Prompt improvement triggered. Evaluating prompt v#{new_prompt.version}…"
     rescue Evaluation::PromptImprover::Error => e
-      redirect_to evaluation_experiment_path(@experiment), alert: e.message
+      logger.error("PromptImprover failed for experiment #{@experiment.id}: #{e.message}")
+      redirect_to evaluation_experiment_path(@experiment), alert: "Prompt improvement failed. Please try again later."
+    rescue ArgumentError => e
+      logger.error("PromptImprover argument error for experiment #{@experiment.id}: #{e.message}")
+      redirect_to evaluation_experiment_path(@experiment), alert: "Prompt improvement failed. Please try again later."
     end
 
     def compare
-      @candidate = Leva::Experiment.find(params[:candidate_id])
+      @candidate = Leva::Experiment
+        .joins(:prompt)
+        .where(leva_prompts: { name: @experiment.prompt&.name })
+        .where.not(id: @experiment.id)
+        .find_by(id: params[:candidate_id])
+
+      unless @candidate
+        return redirect_to evaluation_experiment_path(@experiment), alert: "Candidate experiment not found."
+      end
+
       return unless @candidate.completed?
 
       @result = Evaluation::Comparison.call(
@@ -37,14 +57,32 @@ module Evaluation
 
     def activate
       prompt = @experiment.prompt
-      Leva::Prompt.where(name: prompt.name).where.not(id: prompt.id).find_each do |p|
-        meta = JSON.parse(p.metadata || "{}") rescue {} # rubocop:disable Style/RescueModifier
-        meta.delete("active")
-        p.update!(metadata: meta.to_json)
+      unless prompt
+        return redirect_to evaluation_experiment_path(@experiment), alert: "This experiment has no associated prompt."
       end
-      meta = JSON.parse(prompt.metadata || "{}") rescue {} # rubocop:disable Style/RescueModifier
-      meta["active"] = true
-      prompt.update!(metadata: meta.to_json)
+
+      Leva::Prompt.transaction do
+        Leva::Prompt.where(name: prompt.name).where.not(id: prompt.id).find_each do |p|
+          meta = begin
+            JSON.parse(p.metadata || "{}")
+          rescue JSON::ParserError => e
+            logger.warn("Could not parse metadata for prompt #{p.id}: #{e.message}")
+            next
+          end
+          meta.delete("active")
+          p.update!(metadata: meta.to_json)
+        end
+
+        meta = begin
+          JSON.parse(prompt.metadata || "{}")
+        rescue JSON::ParserError => e
+          logger.warn("Could not parse metadata for prompt #{prompt.id}: #{e.message}")
+          raise ActiveRecord::Rollback
+        end
+        meta["active"] = true
+        prompt.update!(metadata: meta.to_json)
+      end
+
       redirect_to evaluation_experiment_path(@experiment),
                   notice: "Prompt v#{prompt.version} activated for #{prompt.name}."
     end

--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class ExperimentsController < ApplicationController
+    before_action :set_experiment, only: [ :show, :improve, :compare, :activate ]
+
+    def index
+      @experiments = Leva::Experiment.order(created_at: :desc).includes(:prompt)
+    end
+
+    def show
+      @newer_experiment = Leva::Experiment
+        .joins(:prompt)
+        .where(leva_prompts: { name: @experiment.prompt&.name })
+        .where("leva_experiments.id > ?", @experiment.id)
+        .order(id: :desc)
+        .first
+    end
+
+    def improve
+      new_prompt = Evaluation::PromptImprover.call(experiment: @experiment)
+      redirect_to evaluation_experiment_path(@experiment),
+                  notice: "Prompt improvement triggered. Evaluating prompt v#{new_prompt.version}…"
+    rescue Evaluation::PromptImprover::Error => e
+      redirect_to evaluation_experiment_path(@experiment), alert: e.message
+    end
+
+    def compare
+      @candidate = Leva::Experiment.find(params[:candidate_id])
+      return unless @candidate.completed?
+
+      @result = Evaluation::Comparison.call(
+        baseline_experiment: @experiment,
+        candidate_experiment: @candidate
+      )
+    end
+
+    def activate
+      prompt = @experiment.prompt
+      Leva::Prompt.where(name: prompt.name).where.not(id: prompt.id).find_each do |p|
+        meta = JSON.parse(p.metadata || "{}") rescue {} # rubocop:disable Style/RescueModifier
+        meta.delete("active")
+        p.update!(metadata: meta.to_json)
+      end
+      meta = JSON.parse(prompt.metadata || "{}") rescue {} # rubocop:disable Style/RescueModifier
+      meta["active"] = true
+      prompt.update!(metadata: meta.to_json)
+      redirect_to evaluation_experiment_path(@experiment),
+                  notice: "Prompt v#{prompt.version} activated for #{prompt.name}."
+    end
+
+    private
+
+    def set_experiment
+      @experiment = Leva::Experiment.find(params[:id])
+    end
+  end
+end

--- a/app/views/evaluation/experiments/compare.html.erb
+++ b/app/views/evaluation/experiments/compare.html.erb
@@ -1,0 +1,40 @@
+<% if @candidate.pending? || @candidate.running? %>
+  <meta name="turbo-refresh-interval" content="5000">
+  <meta name="turbo-refresh-method" content="replace">
+<% end %>
+
+<%= render UI::PageHeaderComponent.new(
+  title: "Comparison",
+  parent: { label: @experiment.name, url: evaluation_experiment_path(@experiment) }
+) do |header| %>
+  <% if @candidate.completed? %>
+    <% header.with_action(type: :button, label: "Activate Candidate", url: activate_evaluation_experiment_path(@candidate), method: :post, variant: :success) %>
+  <% end %>
+<% end %>
+
+<% if @candidate.completed? && @result %>
+  <div class="max-w-3xl space-y-8">
+    <div class="rounded-lg border border-gray-200 bg-white p-6">
+      <h2 class="text-sm font-semibold text-gray-700 mb-4">Score Comparison</h2>
+      <%= render Evaluation::ComparisonComponent.new(
+        result: @result,
+        baseline_experiment: @experiment,
+        candidate_experiment: @candidate
+      ) %>
+    </div>
+
+    <% if @experiment.prompt && @candidate.prompt %>
+      <div class="rounded-lg border border-gray-200 bg-white p-6">
+        <h2 class="text-sm font-semibold text-gray-700 mb-4">Prompt Diff</h2>
+        <%= render Evaluation::PromptDiffComponent.new(
+          prompt_a: @experiment.prompt,
+          prompt_b: @candidate.prompt
+        ) %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 max-w-xl">
+    Evaluation is pending. This page refreshes automatically when the evaluation completes.
+  </div>
+<% end %>

--- a/app/views/evaluation/experiments/index.html.erb
+++ b/app/views/evaluation/experiments/index.html.erb
@@ -1,0 +1,14 @@
+<%= render UI::PageHeaderComponent.new(title: "Experiments") %>
+
+<%= render UI::TableComponent.new(collection: @experiments, empty_message: "No experiments found.") do |table| %>
+  <% table.with_columns([
+    { key: "name",   label: "Name",    cell: ->(e) { e.name } },
+    { key: "status", label: "Status",  cell: ->(e) { e.status.to_s } },
+    { key: "prompt", label: "Prompt",  cell: ->(e) { e.prompt&.name.to_s } }
+  ]) %>
+  <% table.with_action_column(
+    actions: ->(experiment) {
+      [{ label: "Show", url: evaluation_experiment_path(experiment), variant: :primary }]
+    }
+  ) %>
+<% end %>

--- a/app/views/evaluation/experiments/show.html.erb
+++ b/app/views/evaluation/experiments/show.html.erb
@@ -1,0 +1,35 @@
+<% if @newer_experiment&.pending? || @newer_experiment&.running? %>
+  <meta name="turbo-refresh-interval" content="5000">
+  <meta name="turbo-refresh-method" content="replace">
+<% end %>
+
+<%= render UI::PageHeaderComponent.new(
+  title: @experiment.name,
+  parent: { label: "Experiments", url: evaluation_experiments_path }
+) do |header| %>
+  <% unless @newer_experiment %>
+    <% header.with_action(type: :button, label: "Improve Prompt", url: improve_evaluation_experiment_path(@experiment), method: :post, variant: :primary) %>
+  <% end %>
+  <% if @newer_experiment&.completed? %>
+    <% header.with_action(type: :link, label: "View Comparison", url: compare_evaluation_experiment_path(@experiment, candidate_id: @newer_experiment.id), variant: :success) %>
+  <% end %>
+<% end %>
+
+<div class="space-y-4 max-w-2xl">
+  <dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+    <dt class="font-medium text-gray-500">Status</dt>
+    <dd class="text-gray-700"><%= @experiment.status %></dd>
+    <dt class="font-medium text-gray-500">Prompt</dt>
+    <dd class="text-gray-700"><%= @experiment.prompt&.name %> v<%= @experiment.prompt&.version %></dd>
+    <dt class="font-medium text-gray-500">Dataset</dt>
+    <dd class="text-gray-700"><%= @experiment.dataset&.name %></dd>
+    <dt class="font-medium text-gray-500">Created</dt>
+    <dd class="text-gray-700"><%= @experiment.created_at.strftime("%Y-%m-%d %H:%M") %></dd>
+  </dl>
+
+  <% if @newer_experiment&.pending? || @newer_experiment&.running? %>
+    <div class="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
+      Evaluation for improved prompt is pending. This page refreshes automatically.
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,13 @@ Rails.application.routes.draw do
   namespace :evaluation do
     resources :metrics, only: [ :index, :edit, :update ]
     get "prompts/:id/diff", to: "prompt_diffs#show", as: :prompt_diff
+    resources :experiments, only: [ :index, :show ] do
+      member do
+        post :improve
+        post :activate
+        get "compare/:candidate_id", action: :compare, as: :compare
+      end
+    end
   end
 
   namespace :orchestration do

--- a/sig/app/components/evaluation/comparison_component.rbs
+++ b/sig/app/components/evaluation/comparison_component.rbs
@@ -1,9 +1,9 @@
 module Evaluation
   class ComparisonComponent < ViewComponent::Base
-    def initialize: (result: Evaluation::Comparison::ComparisonResult, baseline_experiment: untyped, candidate_experiment: untyped) -> void
+    def initialize: (result: Evaluation::Comparison::ComparisonResult, baseline_experiment: Leva::Experiment, candidate_experiment: Leva::Experiment) -> void
     def metric_names: () -> Array[String]
-    def delta_class: (Float? delta) -> String
-    def format_delta: (Float? delta) -> String
-    def format_score: (Float? score) -> String
+    def delta_class: (Numeric? delta) -> String
+    def format_delta: (Numeric? delta) -> String
+    def format_score: (Numeric? score) -> String
   end
 end

--- a/sig/app/components/evaluation/comparison_component.rbs
+++ b/sig/app/components/evaluation/comparison_component.rbs
@@ -1,0 +1,9 @@
+module Evaluation
+  class ComparisonComponent < ViewComponent::Base
+    def initialize: (result: Evaluation::Comparison::ComparisonResult, baseline_experiment: untyped, candidate_experiment: untyped) -> void
+    def metric_names: () -> Array[String]
+    def delta_class: (Float? delta) -> String
+    def format_delta: (Float? delta) -> String
+    def format_score: (Float? score) -> String
+  end
+end

--- a/sig/app/controllers/evaluation/experiments_controller.rbs
+++ b/sig/app/controllers/evaluation/experiments_controller.rbs
@@ -1,0 +1,13 @@
+module Evaluation
+  class ExperimentsController < ApplicationController
+    def index: () -> void
+    def show: () -> void
+    def improve: () -> void
+    def compare: () -> void
+    def activate: () -> void
+
+    private
+
+    def set_experiment: () -> void
+  end
+end

--- a/spec/components/evaluation/comparison_component_spec.rb
+++ b/spec/components/evaluation/comparison_component_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::ComparisonComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:result) do
+    Evaluation::Comparison::ComparisonResult.new(
+      baseline_score: 3.0,
+      candidate_score: 4.0,
+      baseline_metrics: { "clarity" => 3.0, "accuracy" => 3.0 },
+      candidate_metrics: { "clarity" => 4.5, "accuracy" => 3.5 },
+      metric_deltas: { "clarity" => 1.5, "accuracy" => 0.5 },
+      overall_delta: 1.0
+    )
+  end
+
+  let(:baseline) { build(:leva_experiment, name: "baseline") }
+  let(:candidate) { build(:leva_experiment, name: "candidate") }
+  let(:component) { described_class.new(result: result, baseline_experiment: baseline, candidate_experiment: candidate) }
+
+  it "renders metric names" do
+    expect(rendered.text).to include("clarity")
+    expect(rendered.text).to include("accuracy")
+  end
+
+  it "renders baseline and candidate scores" do
+    expect(rendered.text).to include("3.0")
+    expect(rendered.text).to include("4.0")
+  end
+
+  it "renders overall delta" do
+    expect(rendered.text).to include("+1.0")
+  end
+
+  it "renders per-metric deltas" do
+    expect(rendered.text).to include("+1.5")
+    expect(rendered.text).to include("+0.5")
+  end
+
+  it "applies green class for positive deltas" do
+    expect(rendered.css(".text-green-600")).to be_present
+  end
+
+  context "with negative delta" do
+    let(:result) do
+      Evaluation::Comparison::ComparisonResult.new(
+        baseline_score: 4.0,
+        candidate_score: 3.0,
+        baseline_metrics: { "clarity" => 4.0 },
+        candidate_metrics: { "clarity" => 3.0 },
+        metric_deltas: { "clarity" => -1.0 },
+        overall_delta: -1.0
+      )
+    end
+
+    it "applies red class for negative deltas" do
+      expect(rendered.css(".text-red-600")).to be_present
+    end
+
+    it "formats negative delta with minus sign" do
+      expect(rendered.text).to include("-1.0")
+    end
+  end
+
+  context "with nil score" do
+    let(:result) do
+      Evaluation::Comparison::ComparisonResult.new(
+        baseline_score: nil,
+        candidate_score: nil,
+        baseline_metrics: {},
+        candidate_metrics: {},
+        metric_deltas: {},
+        overall_delta: nil
+      )
+    end
+
+    it "renders em dash for nil scores" do
+      expect(rendered.text).to include("—")
+    end
+  end
+end

--- a/spec/requests/evaluation/experiments_spec.rb
+++ b/spec/requests/evaluation/experiments_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Evaluation::Experiments" do
+  describe "GET /evaluation/experiments" do
+    it "returns 200" do
+      get evaluation_experiments_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists experiments" do
+      experiment = create(:leva_experiment)
+      get evaluation_experiments_path
+      expect(response.body).to include(experiment.name)
+    end
+  end
+
+  describe "GET /evaluation/experiments/:id" do
+    let(:experiment) { create(:leva_experiment) }
+
+    it "returns 200" do
+      get evaluation_experiment_path(experiment)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "shows experiment name" do
+      get evaluation_experiment_path(experiment)
+      expect(response.body).to include(experiment.name)
+    end
+  end
+
+  describe "POST /evaluation/experiments/:id/improve" do
+    let(:experiment) { create(:leva_experiment) }
+    let(:new_prompt) { build(:leva_prompt) }
+
+    before do
+      allow(Evaluation::PromptImprover).to receive(:call).and_return(new_prompt)
+    end
+
+    it "redirects to show with notice" do
+      post improve_evaluation_experiment_path(experiment)
+      expect(response).to redirect_to(evaluation_experiment_path(experiment))
+      expect(flash[:notice]).to be_present
+    end
+
+    it "calls PromptImprover" do
+      post improve_evaluation_experiment_path(experiment)
+      expect(Evaluation::PromptImprover).to have_received(:call).with(experiment: experiment)
+    end
+
+    context "when PromptImprover raises an error" do
+      before do
+        allow(Evaluation::PromptImprover).to receive(:call)
+          .and_raise(Evaluation::PromptImprover::Error, "LLM call failed")
+      end
+
+      it "redirects with alert" do
+        post improve_evaluation_experiment_path(experiment)
+        expect(response).to redirect_to(evaluation_experiment_path(experiment))
+        expect(flash[:alert]).to include("LLM call failed")
+      end
+    end
+  end
+
+  describe "GET /evaluation/experiments/:id/compare/:candidate_id" do
+    let(:baseline) { create(:leva_experiment, status: :completed) }
+    let(:prompt) { baseline.prompt }
+
+    context "when candidate is completed" do
+      let(:candidate) { create(:leva_experiment, status: :completed, prompt: prompt) }
+
+      before do
+        allow(Evaluation::Comparison).to receive(:call).and_return(
+          Evaluation::Comparison::ComparisonResult.new(
+            baseline_score: 3.0,
+            candidate_score: 4.0,
+            baseline_metrics: { "clarity" => 3.0 },
+            candidate_metrics: { "clarity" => 4.0 },
+            metric_deltas: { "clarity" => 1.0 },
+            overall_delta: 1.0
+          )
+        )
+      end
+
+      it "returns 200" do
+        get compare_evaluation_experiment_path(baseline, candidate_id: candidate.id)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders comparison component" do
+        get compare_evaluation_experiment_path(baseline, candidate_id: candidate.id)
+        expect(response.body).to include("clarity")
+      end
+    end
+
+    context "when candidate is pending" do
+      let(:candidate) { create(:leva_experiment, status: :pending, prompt: prompt) }
+
+      it "returns 200 with loading state" do
+        get compare_evaluation_experiment_path(baseline, candidate_id: candidate.id)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("pending")
+      end
+    end
+  end
+
+  describe "POST /evaluation/experiments/:id/activate" do
+    let(:experiment) { create(:leva_experiment) }
+
+    it "redirects to show with notice" do
+      post activate_evaluation_experiment_path(experiment)
+      expect(response).to redirect_to(evaluation_experiment_path(experiment))
+      expect(flash[:notice]).to be_present
+    end
+
+    it "marks the prompt as active in metadata" do
+      post activate_evaluation_experiment_path(experiment)
+      meta = JSON.parse(experiment.prompt.reload.metadata || "{}")
+      expect(meta["active"]).to be(true)
+    end
+  end
+end

--- a/spec/requests/evaluation/experiments_spec.rb
+++ b/spec/requests/evaluation/experiments_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Evaluation::Experiments" do
       it "redirects with alert" do
         post improve_evaluation_experiment_path(experiment)
         expect(response).to redirect_to(evaluation_experiment_path(experiment))
-        expect(flash[:alert]).to include("LLM call failed")
+        expect(flash[:alert]).to include("Prompt improvement failed")
       end
     end
   end


### PR DESCRIPTION
## Summary
- Adds `ComparisonComponent` with color-coded per-metric score deltas (green/red)
- Adds `Evaluation::ExperimentsController` with `index`, `show`, `improve`, `compare`, and `activate` actions
- Improve button triggers `PromptImprover`, auto-eval fires via existing job; compare view uses Turbo 8 auto-refresh while candidate experiment is pending

Closes #30

## Test plan
- [x] `ComparisonComponent` spec (8 examples)
- [x] Request spec for all 5 controller actions (12 examples)
- [x] Full suite: 1069 examples, 0 failures, 96.36% coverage
- [x] RuboCop: no offenses
- [x] RBS signatures added for component and controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)