### PR TITLE
refactor: rename Leva::Prompt to Orchestration::Prompt

### DIFF
--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -61,8 +61,8 @@ module Evaluation
         return redirect_to evaluation_experiment_path(@experiment), alert: "This experiment has no associated prompt."
       end
 
-      Leva::Prompt.transaction do
-        Leva::Prompt.where(name: prompt.name).where.not(id: prompt.id).find_each do |p|
+      Orchestration::Prompt.transaction do
+        Orchestration::Prompt.where(name: prompt.name).where.not(id: prompt.id).find_each do |p|
           meta = begin
             JSON.parse(p.metadata || "{}")
           rescue JSON::ParserError => e

--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -56,10 +56,13 @@ module Evaluation
     end
 
     def activate
-      prompt = @experiment.prompt
-      unless prompt
+      leva_prompt = @experiment.prompt
+      unless leva_prompt
         return redirect_to evaluation_experiment_path(@experiment), alert: "This experiment has no associated prompt."
       end
+
+      # Reload as Orchestration::Prompt so update! calls go through our subclass
+      prompt = Orchestration::Prompt.find(leva_prompt.id)
 
       Orchestration::Prompt.transaction do
         Orchestration::Prompt.where(name: prompt.name).where.not(id: prompt.id).find_each do |p|

--- a/app/controllers/evaluation/prompt_diffs_controller.rb
+++ b/app/controllers/evaluation/prompt_diffs_controller.rb
@@ -3,8 +3,8 @@
 module Evaluation
   class PromptDiffsController < ApplicationController
     def show
-      @prompt = Leva::Prompt.find(params[:id])
-      @other_version = Leva::Prompt.where(name: @prompt.name).where.not(id: @prompt.id).order(version: :desc, id: :desc).first
+      @prompt = Orchestration::Prompt.find(params[:id])
+      @other_version = Orchestration::Prompt.where(name: @prompt.name).where.not(id: @prompt.id).order(version: :desc, id: :desc).first
     end
   end
 end

--- a/app/evals/llm_judge_eval.rb
+++ b/app/evals/llm_judge_eval.rb
@@ -73,7 +73,7 @@ class LLMJudgeEval < Leva::BaseEval
   end
 
   def fetch_instructions(agent_name)
-    Leva::Prompt
+    Orchestration::Prompt
       .where(name: agent_name)
       .order(version: :desc, id: :desc)
       .first

--- a/app/jobs/evaluation/prompt_auto_eval_job.rb
+++ b/app/jobs/evaluation/prompt_auto_eval_job.rb
@@ -3,7 +3,7 @@ module Evaluation
     queue_as :default
 
     def perform(prompt_id)
-      prompt = Leva::Prompt.find(prompt_id)
+      prompt = Orchestration::Prompt.find(prompt_id)
 
       previous_experiment = Leva::Experiment
         .joins(:prompt)

--- a/app/models/orchestration/prompt.rb
+++ b/app/models/orchestration/prompt.rb
@@ -1,0 +1,5 @@
+module Orchestration
+  class Prompt < Leva::Prompt
+    include Evaluation::AutoEvalTriggerable
+  end
+end

--- a/app/services/evaluation/metric_extractor.rb
+++ b/app/services/evaluation/metric_extractor.rb
@@ -19,7 +19,7 @@ module Evaluation
     end
 
     def call
-      prompt = Leva::Prompt.where(name: @agent_name).order(version: :desc, id: :desc).first
+      prompt = Orchestration::Prompt.where(name: @agent_name).order(version: :desc, id: :desc).first
       raise ArgumentError, "No prompt found for agent: #{@agent_name}" if prompt.nil?
 
       response = RubyLLM.chat(model: DEFAULT_MODEL)

--- a/app/services/evaluation/prompt_improver.rb
+++ b/app/services/evaluation/prompt_improver.rb
@@ -37,7 +37,7 @@ module Evaluation
 
       improved = call_llm(user_message)
 
-      Leva::Prompt.create!(
+      Orchestration::Prompt.create!(
         name: current_prompt.name,
         system_prompt: improved[:system_prompt],
         user_prompt: improved[:user_prompt].presence || current_prompt.user_prompt

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -122,7 +122,7 @@ module Orchestration
       @prompt_cache ||= {} # : Hash[String?, String?]
       return @prompt_cache[agent_class] if @prompt_cache.key?(agent_class)
 
-      @prompt_cache[agent_class] = Leva::Prompt
+      @prompt_cache[agent_class] = Orchestration::Prompt
         .where(name: agent_class)
         .order(version: :desc, id: :desc)
         .first

--- a/config/initializers/leva_prompt_hooks.rb
+++ b/config/initializers/leva_prompt_hooks.rb
@@ -1,5 +1,0 @@
-Rails.application.config.after_initialize do
-  unless Leva::Prompt.ancestors.include?(Evaluation::AutoEvalTriggerable)
-    Leva::Prompt.include(Evaluation::AutoEvalTriggerable)
-  end
-end

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -42,14 +42,14 @@ namespace :evaluation do
       klass = agent_class.constantize
       raise "#{agent_class} has no instructions" if klass.instructions.blank?
 
-      Leva::Prompt.find_or_initialize_by(name: agent_class).tap do |prompt|
+      Orchestration::Prompt.find_or_initialize_by(name: agent_class).tap do |prompt|
         prompt.system_prompt = klass.instructions
         # user_prompt is intentionally preserved on re-runs to avoid clobbering manual edits
         prompt.user_prompt = prompt.user_prompt.presence || "{{input}}"
         prompt.save!
       end
     end
-    Rails.logger.info "Migrated #{agent_classes.size} agent prompts to Leva::Prompt."
+    Rails.logger.info "Migrated #{agent_classes.size} agent prompts to Orchestration::Prompt."
   end
 
   desc "Compare two experiments and print per-metric deltas (e.g. rake evaluation:compare[1,2])"

--- a/sig/app/models/orchestration/prompt.rbs
+++ b/sig/app/models/orchestration/prompt.rbs
@@ -1,0 +1,5 @@
+module Orchestration
+  class Prompt < Leva::Prompt
+    include Evaluation::AutoEvalTriggerable
+  end
+end

--- a/spec/evals/llm_judge_eval_spec.rb
+++ b/spec/evals/llm_judge_eval_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe LLMJudgeEval do
       create(:evaluation_metric, agent_name: agent_name, name: "tool_call_accuracy", description: "Score tool call order.")
       create(:evaluation_metric, agent_name: agent_name, name: "output_quality", description: "Score output quality.")
 
-      prompt_double = instance_double(Leva::Prompt, system_prompt: "You are a classifier.")
+      prompt_double = instance_double(Orchestration::Prompt, system_prompt: "You are a classifier.")
       prompt_rel = instance_double(ActiveRecord::Relation)
-      allow(Leva::Prompt).to receive(:where).with(name: agent_name).and_return(prompt_rel)
+      allow(Orchestration::Prompt).to receive(:where).with(name: agent_name).and_return(prompt_rel)
       allow(prompt_rel).to receive(:order).with(version: :desc, id: :desc).and_return(prompt_rel)
       allow(prompt_rel).to receive(:first).and_return(prompt_double)
 
@@ -127,7 +127,7 @@ RSpec.describe LLMJudgeEval do
 
   describe "#evaluate_and_store" do
     let!(:leva_dataset) { Leva::Dataset.create!(name: "test_dataset") }
-    let!(:leva_prompt) { Leva::Prompt.create!(name: agent_name, system_prompt: "You are a classifier.", user_prompt: "Classify: {{input}}") }
+    let!(:leva_prompt) { Orchestration::Prompt.create!(name: agent_name, system_prompt: "You are a classifier.", user_prompt: "Classify: {{input}}") }
     let!(:leva_experiment) { Leva::Experiment.create!(name: "test_exp", dataset: leva_dataset, status: :pending, prompt: leva_prompt, runner_class: "Evaluation::StubbedAgentRun", evaluator_classes: [ "LLMJudgeEval" ]) }
     let!(:leva_dataset_record) { Leva::DatasetRecord.create!(dataset: leva_dataset, recordable: create(:orchestration_action_run, status: "completed")) }
     let!(:leva_runner_result) do

--- a/spec/factories/leva.rb
+++ b/spec/factories/leva.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "dataset_#{n}" }
   end
 
-  factory :leva_prompt, class: "Leva::Prompt" do
+  factory :orchestration_prompt, class: "Orchestration::Prompt" do
     sequence(:name) { |n| "agent_#{n}" }
     system_prompt { "System prompt" }
     user_prompt { "User prompt {{input}}" }
@@ -15,7 +15,7 @@ FactoryBot.define do
     runner_class { "Evaluation::StubbedAgentRun" }
     evaluator_classes { [ "LLMJudgeEval" ] }
     association :dataset, factory: :leva_dataset
-    association :prompt, factory: :leva_prompt
+    association :prompt, factory: :orchestration_prompt
   end
 
   factory :leva_dataset_record, class: "Leva::DatasetRecord" do
@@ -28,7 +28,7 @@ FactoryBot.define do
     runner_class { "Evaluation::StubbedAgentRun" }
     association :experiment, factory: :leva_experiment
     association :dataset_record, factory: :leva_dataset_record
-    association :prompt, factory: :leva_prompt
+    association :prompt, factory: :orchestration_prompt
   end
 
   factory :leva_evaluation_result, class: "Leva::EvaluationResult" do

--- a/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
+++ b/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Evaluation::PromptAutoEvalJob do
   let(:agent_name) { "Emails::ClassifyAgent" }
   let(:dataset) { create(:leva_dataset) }
-  let(:previous_prompt) { create(:leva_prompt, name: agent_name) }
+  let(:previous_prompt) { create(:orchestration_prompt, name: agent_name) }
   let(:previous_experiment) do
     create(:leva_experiment,
       prompt: previous_prompt,
@@ -12,7 +12,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       runner_class: "Evaluation::StubbedAgentRun",
       evaluator_classes: [ "LLMJudgeEval" ])
   end
-  let(:new_prompt) { create(:leva_prompt, name: agent_name) }
+  let(:new_prompt) { create(:orchestration_prompt, name: agent_name) }
 
   before { previous_experiment }
 
@@ -21,7 +21,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       described_class.perform_now(new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp).to be_present
-      expect(new_exp.prompt).to eq(new_prompt)
+      expect(new_exp.prompt.id).to eq(new_prompt.id)
     end
 
     it "reuses the previous experiment's dataset" do
@@ -60,7 +60,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
     end
 
     context "when no experiment exists for the prompt name at all" do
-      let(:new_prompt) { create(:leva_prompt, name: "Records::FillAgent") }
+      let(:new_prompt) { create(:orchestration_prompt, name: "Records::FillAgent") }
 
       it "does nothing" do
         expect { described_class.perform_now(new_prompt.id) }.not_to change(Leva::Experiment, :count)

--- a/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
+++ b/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       described_class.perform_now(new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp).to be_present
+      # Leva's belongs_to :prompt loads as Leva::Prompt; compare by id to avoid class mismatch
       expect(new_exp.prompt.id).to eq(new_prompt.id)
     end
 

--- a/spec/models/orchestration/prompt_spec.rb
+++ b/spec/models/orchestration/prompt_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "Leva::Prompt auto-eval hook" do # rubocop:disable RSpec/DescribeClass
+RSpec.describe Orchestration::Prompt do
   it "enqueues PromptAutoEvalJob when a new prompt is created" do
-    prompt = create(:leva_prompt)
+    prompt = create(:orchestration_prompt)
     expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt.id)
   end
 
   it "does not enqueue PromptAutoEvalJob when an existing prompt is updated" do
-    prompt = create(:leva_prompt)
+    prompt = create(:orchestration_prompt)
     RSpec::Mocks.space.proxy_for(Evaluation::PromptAutoEvalJob).reset
     allow(Evaluation::PromptAutoEvalJob).to receive(:perform_later)
 

--- a/spec/models/orchestration/prompt_spec.rb
+++ b/spec/models/orchestration/prompt_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe Orchestration::Prompt do
 
   it "does not enqueue PromptAutoEvalJob when an existing prompt is updated" do
     prompt = create(:orchestration_prompt)
-    RSpec::Mocks.space.proxy_for(Evaluation::PromptAutoEvalJob).reset
-    allow(Evaluation::PromptAutoEvalJob).to receive(:perform_later)
 
     prompt.update!(system_prompt: "Updated prompt text")
 
-    expect(Evaluation::PromptAutoEvalJob).not_to have_received(:perform_later)
+    # Exactly 1 call total (from create); update must not have triggered another
+    expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).exactly(1).time
   end
 end

--- a/spec/requests/evaluation/experiments_spec.rb
+++ b/spec/requests/evaluation/experiments_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Evaluation::Experiments" do
 
   describe "POST /evaluation/experiments/:id/improve" do
     let(:experiment) { create(:leva_experiment) }
-    let(:new_prompt) { build(:leva_prompt) }
+    let(:new_prompt) { build(:orchestration_prompt) }
 
     before do
       allow(Evaluation::PromptImprover).to receive(:call).and_return(new_prompt)

--- a/spec/services/evaluation/metric_extractor_spec.rb
+++ b/spec/services/evaluation/metric_extractor_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Evaluation::MetricExtractor do
       usage: { input_tokens: 100, output_tokens: 50 }
     }.to_json
   end
-  let(:prompt_double) { instance_double(Leva::Prompt, system_prompt: instructions) }
+  let(:prompt_double) { instance_double(Orchestration::Prompt, system_prompt: instructions) }
   let(:prompt_relation) { instance_double(ActiveRecord::Relation) }
 
   before do
-    allow(Leva::Prompt).to receive(:where).with(name: agent_name).and_return(prompt_relation)
+    allow(Orchestration::Prompt).to receive(:where).with(name: agent_name).and_return(prompt_relation)
     allow(prompt_relation).to receive(:order).with(version: :desc, id: :desc).and_return(prompt_relation)
     allow(prompt_relation).to receive(:first).and_return(prompt_double)
 

--- a/spec/services/evaluation/prompt_improver_spec.rb
+++ b/spec/services/evaluation/prompt_improver_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Evaluation::PromptImprover do
   let(:agent_name) { "Emails::ClassifyAgent" }
-  let(:prompt) { create(:leva_prompt, name: agent_name, system_prompt: "You classify emails.", user_prompt: "{{input}}") }
+  let(:prompt) { create(:orchestration_prompt, name: agent_name, system_prompt: "You classify emails.", user_prompt: "{{input}}") }
   let!(:experiment) { create(:leva_experiment, prompt: prompt, status: :completed) }
 
   def stub_llm(system_prompt: "Improved system.", user_prompt: "{{input}}")
@@ -33,9 +33,9 @@ RSpec.describe Evaluation::PromptImprover do
   end
 
   describe ".call" do
-    it "returns a new Leva::Prompt" do
+    it "returns a new Orchestration::Prompt" do
       result = described_class.call(experiment: experiment)
-      expect(result).to be_a(Leva::Prompt)
+      expect(result).to be_a(Orchestration::Prompt)
       expect(result).to be_persisted
     end
 
@@ -45,7 +45,7 @@ RSpec.describe Evaluation::PromptImprover do
     end
 
     it "creates a new prompt record (does not mutate original)" do
-      expect { described_class.call(experiment: experiment) }.to change(Leva::Prompt, :count).by(1)
+      expect { described_class.call(experiment: experiment) }.to change(Orchestration::Prompt, :count).by(1)
     end
 
     it "uses the improved system prompt from LLM" do

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -97,12 +97,12 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'when a Leva::Prompt exists for the agent class' do
+    context 'when an Orchestration::Prompt exists for the agent class' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
       before do
         allow(stub_agent).to receive(:chat).and_return(chat)
-        Leva::Prompt.create!(
+        Orchestration::Prompt.create!(
           name: "Emails::ClassifyAgent",
           system_prompt: "Custom Leva prompt for classifier",
           user_prompt: "{{input}}"
@@ -110,18 +110,18 @@ RSpec.describe Orchestration::PipelineRunner do
         create(:orchestration_step_action, step: step1, action: action, position: 1)
       end
 
-      it 'applies the Leva system_prompt as instructions' do
+      it 'applies the Orchestration::Prompt system_prompt as instructions' do
         described_class.new(pipeline_run).call
         expect(chat).to have_received(:with_instructions).with("Custom Leva prompt for classifier")
       end
     end
 
-    context 'when a Leva::Prompt exists and action also has a prompt' do
+    context 'when an Orchestration::Prompt exists and action also has a prompt' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
       before do
         allow(stub_agent).to receive(:chat).and_return(chat)
-        Leva::Prompt.create!(
+        Orchestration::Prompt.create!(
           name: "Emails::ClassifyAgent",
           system_prompt: "Leva wins over action prompt",
           user_prompt: "{{input}}"
@@ -130,13 +130,13 @@ RSpec.describe Orchestration::PipelineRunner do
         create(:orchestration_step_action, step: step1, action: action, position: 1)
       end
 
-      it 'prefers the Leva prompt over the action prompt' do
+      it 'prefers the Orchestration::Prompt over the action prompt' do
         described_class.new(pipeline_run).call
         expect(chat).to have_received(:with_instructions).with("Leva wins over action prompt")
       end
     end
 
-    context 'when no Leva::Prompt exists but the action has a prompt' do
+    context 'when no Orchestration::Prompt exists but the action has a prompt' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
       before do
@@ -151,7 +151,7 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'when no Leva::Prompt and no action prompt' do
+    context 'when no Orchestration::Prompt and no action prompt' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
       before do

--- a/spec/tasks/evaluation_migrate_prompts_spec.rb
+++ b/spec/tasks/evaluation_migrate_prompts_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe "evaluation:migrate_prompts rake task" do # rubocop:disable RSpec
     Rake::Task[task_name].reenable
   end
 
-  it "creates one Leva::Prompt per agent class" do
+  it "creates one Orchestration::Prompt per agent class" do
     expect { Rake::Task[task_name].invoke }
-      .to change(Leva::Prompt, :count).by(agent_classes.size)
+      .to change(Orchestration::Prompt, :count).by(agent_classes.size)
   end
 
   it "creates prompts named after each agent class" do
     Rake::Task[task_name].invoke
-    created_names = Leva::Prompt.pluck(:name)
+    created_names = Orchestration::Prompt.pluck(:name)
     expect(created_names).to match_array(agent_classes)
   end
 
@@ -35,7 +35,7 @@ RSpec.describe "evaluation:migrate_prompts rake task" do # rubocop:disable RSpec
     Rake::Task[task_name].invoke
     aggregate_failures do
       agent_classes.each do |agent_class|
-        prompt = Leva::Prompt.find_by!(name: agent_class)
+        prompt = Orchestration::Prompt.find_by!(name: agent_class)
         expected = agent_class.constantize.instructions
         expect(prompt.system_prompt).to eq(expected)
       end
@@ -46,12 +46,12 @@ RSpec.describe "evaluation:migrate_prompts rake task" do # rubocop:disable RSpec
     Rake::Task[task_name].invoke
     Rake::Task[task_name].reenable
     expect { Rake::Task[task_name].invoke }
-      .not_to change(Leva::Prompt, :count)
+      .not_to change(Orchestration::Prompt, :count)
   end
 
   it "updates system_prompt if instructions changed on re-run" do
     Rake::Task[task_name].invoke
-    original = Leva::Prompt.find_by!(name: "Emails::ClassifyAgent")
+    original = Orchestration::Prompt.find_by!(name: "Emails::ClassifyAgent")
     original.update!(system_prompt: "old instructions")
 
     Rake::Task[task_name].reenable


### PR DESCRIPTION
## Summary
- Introduce `Orchestration::Prompt < Leva::Prompt` as the canonical prompt model, uses the same `leva_prompts` table
- Include `Evaluation::AutoEvalTriggerable` natively in the model, removing the monkey-patch initializer (`config/initializers/leva_prompt_hooks.rb`)
- Update all evaluation services, controllers, jobs, rake tasks, and specs to reference `Orchestration::Prompt`

Closes #51

## Test plan
- [x] New `spec/models/orchestration/prompt_spec.rb` covers auto-eval trigger on create (not update)
- [x] Old `spec/models/leva_prompt_hooks_spec.rb` removed; behavior is covered by the new spec
- [x] All 1069 existing specs pass
- [x] Rubocop: no offenses
- [x] `spec/factories/leva.rb`: `:leva_prompt` factory renamed to `:orchestration_prompt` with correct class

🤖 Generated with [Claude Code](https://claude.com/claude-code)