### PR TITLE
feat: create Orchestration::Agent library

### DIFF
--- a/app/controllers/concerns/json_params_parsing.rb
+++ b/app/controllers/concerns/json_params_parsing.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module JsonParamsParsing
+  extend ActiveSupport::Concern
+
+  private
+
+  def parse_json_field(permitted, key)
+    raw = permitted[key]
+    permitted[key] = JSON.parse(raw) if raw.present?
+  end
+end

--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -2,6 +2,8 @@
 
 module Orchestration
   class ActionsController < ApplicationController
+    include JsonParamsParsing
+
     before_action :set_action, only: [ :edit, :update, :destroy ]
 
     def index
@@ -61,11 +63,6 @@ module Orchestration
       permitted
     rescue JSON::ParserError
       permitted
-    end
-
-    def parse_json_field(permitted, key)
-      raw = permitted[key]
-      permitted[key] = JSON.parse(raw) if raw.present?
     end
   end
 end

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class AgentsController < ApplicationController
+    before_action :set_agent, only: [ :edit, :update, :destroy, :toggle ]
+
+    def index
+      @agents = Orchestration::Agent.order(:name)
+    end
+
+    def new
+      @agent = Orchestration::Agent.new
+    end
+
+    def create
+      @agent = Orchestration::Agent.new(agent_params)
+      if @agent.save
+        redirect_to orchestration_agents_path, notice: "Agent created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @agent.update(agent_params)
+        redirect_to orchestration_agents_path, notice: "Agent updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @agent.destroy
+      if @agent.errors.any?
+        redirect_to orchestration_agents_path, alert: "Cannot delete agent: #{@agent.errors.full_messages.to_sentence}."
+      else
+        redirect_to orchestration_agents_path, notice: "Agent deleted."
+      end
+    end
+
+    def toggle
+      @agent.update!(enabled: !@agent.enabled)
+      redirect_to orchestration_agents_path, notice: "Agent #{@agent.enabled? ? "enabled" : "disabled"}."
+    end
+
+    private
+
+    def set_agent
+      @agent = Orchestration::Agent.find(params[:id])
+    end
+
+    def agent_params
+      permitted = params.require(:orchestration_agent).permit(:name, :description, :model, :tools)
+      parse_json_field(permitted, :tools)
+      permitted
+    rescue JSON::ParserError
+      permitted
+    end
+
+    def parse_json_field(permitted, key)
+      raw = permitted[key]
+      permitted[key] = JSON.parse(raw) if raw.present?
+    end
+  end
+end

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -2,6 +2,8 @@
 
 module Orchestration
   class AgentsController < ApplicationController
+    include JsonParamsParsing
+
     before_action :set_agent, only: [ :edit, :update, :destroy, :toggle ]
 
     def index
@@ -33,16 +35,16 @@ module Orchestration
     end
 
     def destroy
-      @agent.destroy
-      if @agent.errors.any?
-        redirect_to orchestration_agents_path, alert: "Cannot delete agent: #{@agent.errors.full_messages.to_sentence}."
-      else
-        redirect_to orchestration_agents_path, notice: "Agent deleted."
-      end
+      @agent.destroy!
+      redirect_to orchestration_agents_path, notice: "Agent deleted."
+    rescue ActiveRecord::RecordNotDestroyed
+      redirect_to orchestration_agents_path, alert: "Cannot delete agent: it is referenced by one or more actions."
     end
 
     def toggle
-      @agent.update!(enabled: !@agent.enabled)
+      @agent.with_lock do
+        @agent.update(enabled: !@agent.enabled)
+      end
       redirect_to orchestration_agents_path, notice: "Agent #{@agent.enabled? ? "enabled" : "disabled"}."
     end
 
@@ -57,12 +59,8 @@ module Orchestration
       parse_json_field(permitted, :tools)
       permitted
     rescue JSON::ParserError
+      permitted[:tools] = []
       permitted
-    end
-
-    def parse_json_field(permitted, key)
-      raw = permitted[key]
-      permitted[key] = JSON.parse(raw) if raw.present?
     end
   end
 end

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -2,6 +2,8 @@
 
 module Orchestration
   class Agent < ApplicationRecord
+    ALLOWED_TOOL_NAMESPACES = %w[Records Emails].freeze
+
     self.table_name = "orchestration_agents"
 
     validates :name, presence: true, uniqueness: true
@@ -17,6 +19,12 @@ module Orchestration
       return if tools.blank?
 
       tools.each do |tool|
+        namespace = tool.to_s.split("::").first
+        unless ALLOWED_TOOL_NAMESPACES.include?(namespace)
+          errors.add(:tools, "contains tool outside allowed namespaces: #{tool}")
+          next
+        end
+
         tool.constantize
       rescue NameError
         errors.add(:tools, "contains invalid tool: #{tool}")

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class Agent < ApplicationRecord
+    self.table_name = "orchestration_agents"
+
+    validates :name, presence: true, uniqueness: true
+    validate :tools_must_be_valid
+
+    scope :enabled, -> { where(enabled: true) }
+
+    before_destroy :ensure_not_referenced
+
+    private
+
+    def tools_must_be_valid
+      return if tools.blank?
+
+      tools.each do |tool|
+        tool.constantize
+      rescue NameError
+        errors.add(:tools, "contains invalid tool: #{tool}")
+      end
+    end
+
+    def ensure_not_referenced
+      return unless Orchestration::Action.exists?(agent_class: name)
+
+      errors.add(:base, "cannot be deleted while referenced by actions")
+      throw :abort
+    end
+  end
+end

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with model: agent, url: agent.new_record? ? orchestration_agents_path : orchestration_agent_path(agent), class: "space-y-6" do |f| %>
+  <%= render UI::ErrorMessagesComponent.new(errors: agent.errors) %>
+
+  <div>
+    <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :name, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if agent.errors[:name].any?}", placeholder: "e.g. Emails::ClassifyAgent" %>
+    <% if agent.errors[:name].any? %>
+      <p class="mt-1 text-xs text-red-600"><%= agent.errors[:name].first %></p>
+    <% end %>
+  </div>
+
+  <div>
+    <%= f.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :description, rows: 2, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+  </div>
+
+  <div>
+    <%= f.label :model, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :model, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "e.g. mistral-small" %>
+  </div>
+
+  <div>
+    <%= f.label :tools, "Tools (JSON array)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :tools, value: agent.tools.present? ? agent.tools.to_json : "", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if agent.errors[:tools].any?}", placeholder: '["ToolOne", "ToolTwo"]' %>
+    <% if agent.errors[:tools].any? %>
+      <p class="mt-1 text-xs text-red-600"><%= agent.errors[:tools].first %></p>
+    <% end %>
+  </div>
+
+  <div class="flex items-center gap-3 pt-2">
+    <%= f.submit class: "px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
+    <%= link_to "Cancel", orchestration_agents_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
+  </div>
+<% end %>

--- a/app/views/orchestration/agents/edit.html.erb
+++ b/app/views/orchestration/agents/edit.html.erb
@@ -1,0 +1,5 @@
+<%= render UI::PageHeaderComponent.new(title: "Edit Agent", parent: { label: "Agent Library", url: orchestration_agents_path }) %>
+
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 max-w-2xl">
+  <%= render "form", agent: @agent %>
+</div>

--- a/app/views/orchestration/agents/index.html.erb
+++ b/app/views/orchestration/agents/index.html.erb
@@ -1,0 +1,21 @@
+<%= render UI::PageHeaderComponent.new(title: "Agent Library", notice: notice, alert: alert) do |header| %>
+  <% header.with_action(type: :link, label: "New Agent", url: new_orchestration_agent_path) %>
+<% end %>
+
+<%= render UI::TableComponent.new(collection: @agents, empty_message: "No agents found.") do |table| %>
+  <% table.with_columns([
+    { key: "name", label: "Name", classes: "px-4 py-3 font-mono text-xs" },
+    { key: "description", label: "Description", variant: :muted, cell: ->(agent) { agent.description.presence || "—" } },
+    { key: "model", label: "Model", variant: :muted, cell: ->(agent) { agent.model.presence || "—" } },
+    { key: "enabled", label: "Status", cell: ->(agent) { agent.enabled? ? "Enabled" : "Disabled" } }
+  ]) %>
+  <% table.with_action_column(
+    actions: ->(agent) {
+      [
+        { label: agent.enabled? ? "Disable" : "Enable", url: toggle_orchestration_agent_path(agent), method: :patch, variant: :secondary },
+        { label: "Edit", url: edit_orchestration_agent_path(agent), variant: :primary },
+        { label: "Delete", url: orchestration_agent_path(agent), method: :delete, variant: :danger, confirm: "Delete agent \"#{agent.name}\"?" }
+      ]
+    }
+  ) %>
+<% end %>

--- a/app/views/orchestration/agents/new.html.erb
+++ b/app/views/orchestration/agents/new.html.erb
@@ -1,0 +1,5 @@
+<%= render UI::PageHeaderComponent.new(title: "New Agent", parent: { label: "Agent Library", url: orchestration_agents_path }) %>
+
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 max-w-2xl">
+  <%= render "form", agent: @agent %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,11 @@ Rails.application.routes.draw do
   end
 
   namespace :orchestration do
+    resources :agents do
+      member do
+        patch :toggle
+      end
+    end
     resources :actions
     resources :pipelines do
       member do

--- a/db/migrate/20260503133626_create_orchestration_agents.rb
+++ b/db/migrate/20260503133626_create_orchestration_agents.rb
@@ -1,0 +1,14 @@
+class CreateOrchestrationAgents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :orchestration_agents do |t|
+      t.string :name, null: false
+      t.text :description
+      t.string :model
+      t.json :tools, default: []
+      t.boolean :enabled, null: false, default: true
+
+      t.timestamps
+    end
+    add_index :orchestration_agents, :name, unique: true
+  end
+end

--- a/db/migrate/20260503140000_add_index_to_actions_agent_class.rb
+++ b/db/migrate/20260503140000_add_index_to_actions_agent_class.rb
@@ -1,0 +1,5 @@
+class AddIndexToActionsAgentClass < ActiveRecord::Migration[8.1]
+  def change
+    add_index :actions, :agent_class
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -143,7 +143,9 @@ FOREIGN KEY ("evaluation_result_id")
 CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id");
 CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name");
+CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260503140000'),
 ('20260503133626'),
 ('20260429112350'),
 ('20260427135859'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -141,7 +141,10 @@ FOREIGN KEY ("evaluation_result_id")
   REFERENCES "leva_evaluation_results" ("id")
 );
 CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id");
+CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name");
 INSERT INTO "schema_migrations" (version) VALUES
+('20260503133626'),
 ('20260429112350'),
 ('20260427135859'),
 ('20260427000001'),

--- a/sig/app/controllers/concerns/json_params_parsing.rbs
+++ b/sig/app/controllers/concerns/json_params_parsing.rbs
@@ -1,0 +1,5 @@
+module JsonParamsParsing
+  private
+
+  def parse_json_field: (untyped permitted, Symbol key) -> void
+end

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -1,0 +1,22 @@
+module Orchestration
+  class Agent < ApplicationRecord
+    def self.table_name: () -> String
+
+    def name: () -> String?
+    def name=: (String?) -> String?
+    def description: () -> String?
+    def description=: (String?) -> String?
+    def model: () -> String?
+    def model=: (String?) -> String?
+    def tools: () -> Array[String]
+    def tools=: (Array[String]) -> Array[String]
+    def enabled: () -> bool
+    def enabled=: (bool) -> bool
+    def enabled?: () -> bool
+
+    private
+
+    def tools_must_be_valid: () -> void
+    def ensure_not_referenced: () -> void
+  end
+end

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -1,9 +1,9 @@
 module Orchestration
   class Agent < ApplicationRecord
-    def self.table_name: () -> String
+    ALLOWED_TOOL_NAMESPACES: Array[String]
 
-    def name: () -> String?
-    def name=: (String?) -> String?
+    def name: () -> String
+    def name=: (String) -> String
     def description: () -> String?
     def description=: (String?) -> String?
     def model: () -> String?

--- a/spec/factories/orchestration_agents.rb
+++ b/spec/factories/orchestration_agents.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :orchestration_agent, class: "Orchestration::Agent" do
+    sequence(:name) { |n| "Agent::Class#{n}" }
+    enabled { true }
+  end
+end

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::Agent do
+  subject(:agent) { build(:orchestration_agent) }
+
+  it "is valid with valid attributes" do
+    expect(agent).to be_valid
+  end
+
+  describe "validations" do
+    it "requires name" do
+      agent.name = nil
+      expect(agent).not_to be_valid
+      expect(agent.errors[:name]).to be_present
+    end
+
+    it "requires unique name" do
+      create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      duplicate = build(:orchestration_agent, name: "Emails::ClassifyAgent")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:name]).to be_present
+    end
+
+    it "accepts blank tools" do
+      agent.tools = []
+      expect(agent).to be_valid
+    end
+
+    it "validates tools are valid constants" do
+      agent.tools = [ "NonExistent::ToolClass" ]
+      expect(agent).not_to be_valid
+      expect(agent.errors[:tools]).to be_present
+    end
+
+    it "accepts valid tool constants" do
+      agent.tools = [ "Emails::ClassifyAgent" ]
+      expect(agent).to be_valid
+    end
+  end
+
+  describe "defaults" do
+    it "defaults enabled to true" do
+      expect(agent.enabled).to be true
+    end
+  end
+
+  describe "scopes" do
+    let!(:enabled_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent", enabled: true) }
+    let!(:disabled_agent) { create(:orchestration_agent, name: "Records::StoreAgent", enabled: false) }
+
+    it "returns only enabled agents" do
+      expect(described_class.enabled).to include(enabled_agent)
+      expect(described_class.enabled).not_to include(disabled_agent)
+    end
+  end
+
+  describe "#destroy" do
+    let!(:persisted_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent") }
+
+    context "when not referenced by any action" do
+      it "can be destroyed" do
+        expect { persisted_agent.destroy }.to change(described_class, :count).by(-1)
+      end
+    end
+
+    context "when referenced by an action" do
+      before { create(:orchestration_action, agent_class: persisted_agent.name) }
+
+      it "cannot be destroyed" do
+        persisted_agent.destroy
+        expect(persisted_agent.errors[:base]).to be_present
+      end
+
+      it "is not deleted from the database" do
+        expect { persisted_agent.destroy }.not_to change(described_class, :count)
+      end
+    end
+  end
+end

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -28,8 +28,14 @@ RSpec.describe Orchestration::Agent do
       expect(agent).to be_valid
     end
 
-    it "validates tools are valid constants" do
-      agent.tools = [ "NonExistent::ToolClass" ]
+    it "rejects tools outside allowed namespaces" do
+      agent.tools = [ "File" ]
+      expect(agent).not_to be_valid
+      expect(agent.errors[:tools].first).to include("outside allowed namespaces")
+    end
+
+    it "rejects unknown constants within allowed namespaces" do
+      agent.tools = [ "Records::DoesNotExist" ]
       expect(agent).not_to be_valid
       expect(agent.errors[:tools]).to be_present
     end

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Orchestration::Agents" do
+  describe "GET /orchestration/agents" do
+    it "returns 200 and lists agents" do
+      create(:orchestration_agent, name: "Emails::ClassifyAgent", enabled: true)
+      get orchestration_agents_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Emails::ClassifyAgent")
+    end
+  end
+
+  describe "GET /orchestration/agents/new" do
+    it "returns 200 with form" do
+      get new_orchestration_agent_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("name")
+    end
+  end
+
+  describe "POST /orchestration/agents" do
+    context "with valid params" do
+      let(:valid_params) do
+        {
+          orchestration_agent: {
+            name: "Emails::ClassifyAgent",
+            description: "Classifies emails",
+            model: "mistral-small",
+            tools: "[]"
+          }
+        }
+      end
+
+      it "creates an agent and redirects" do
+        expect {
+          post orchestration_agents_path, params: valid_params
+        }.to change(Orchestration::Agent, :count).by(1)
+        expect(response).to redirect_to(orchestration_agents_path)
+      end
+    end
+
+    context "with invalid params" do
+      it "renders new with 422" do
+        post orchestration_agents_path, params: { orchestration_agent: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "GET /orchestration/agents/:id/edit" do
+    it "returns 200 with form populated" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      get edit_orchestration_agent_path(agent)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Emails::ClassifyAgent")
+    end
+  end
+
+  describe "PATCH /orchestration/agents/:id" do
+    context "with valid params" do
+      it "updates and redirects" do
+        agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+        patch orchestration_agent_path(agent), params: {
+          orchestration_agent: { name: "Emails::ClassifyAgent", description: "Updated" }
+        }
+        expect(response).to redirect_to(orchestration_agents_path)
+        expect(agent.reload.description).to eq("Updated")
+      end
+    end
+
+    context "with invalid params" do
+      it "renders edit with 422" do
+        agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+        patch orchestration_agent_path(agent), params: { orchestration_agent: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "DELETE /orchestration/agents/:id" do
+    it "destroys unreferenced agent and redirects" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      expect {
+        delete orchestration_agent_path(agent)
+      }.to change(Orchestration::Agent, :count).by(-1)
+      expect(response).to redirect_to(orchestration_agents_path)
+    end
+
+    it "shows error when agent is referenced by an action" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      create(:orchestration_action, agent_class: agent.name)
+      expect {
+        delete orchestration_agent_path(agent)
+      }.not_to change(Orchestration::Agent, :count)
+      expect(response).to redirect_to(orchestration_agents_path)
+      follow_redirect!
+      expect(response.body).to include("Cannot delete")
+    end
+  end
+
+  describe "PATCH /orchestration/agents/:id/toggle" do
+    it "toggles enabled state and redirects" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent", enabled: true)
+      patch toggle_orchestration_agent_path(agent)
+      expect(response).to redirect_to(orchestration_agents_path)
+      expect(agent.reload.enabled).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Introduces `Orchestration::Agent` as a database-backed catalog of reusable agent definitions with `name`, `description`, `model`, `tools`, and `enabled` fields
- The `name` field uses the same convention as `Evaluation::Metric#agent_name` and `Orchestration::Action#agent_class`, serving as the shared identity key across systems
- Agents validate tool references (each tool must be a valid constant), prevent deletion while referenced by actions, and can be disabled without removal

Closes #34

## Test plan
- [x] Model spec: validations, uniqueness, tool validation, enabled scope, referential integrity guard
- [x] Request spec: full CRUD + toggle endpoint
- [x] 1090 examples, 0 failures (full suite)
- [x] RuboCop: no offenses
- [x] Steep: no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)