### PR TITLE
feat: teach actions to target agents or services

### DIFF
--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -56,12 +56,17 @@ module Orchestration
     end
 
     def load_agents
-      @agents = Orchestration::Agent.enabled.order(:name)
+      enabled = Orchestration::Agent.enabled
+      @agents = if @action&.agent_id && !enabled.exists?(@action.agent_id)
+        enabled.or(Orchestration::Agent.where(id: @action.agent_id)).order(:name)
+      else
+        enabled.order(:name)
+      end
     end
 
     def action_params
       permitted = params.require(:orchestration_action).permit(
-        :name, :description, :kind, :agent_id, :agent_class, :model, :tools, :prompt, :params
+        :name, :description, :kind, :agent_id, :agent_class, :tools, :prompt, :params
       )
       parse_json_field(permitted, :tools)
       parse_json_field(permitted, :params)

--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -16,6 +16,7 @@ module Orchestration
 
     def new
       @action = Orchestration::Action.new
+      @agents = Orchestration::Agent.enabled.order(:name)
     end
 
     def create
@@ -23,17 +24,20 @@ module Orchestration
       if @action.save
         redirect_to orchestration_actions_path, notice: "Action created."
       else
+        @agents = Orchestration::Agent.enabled.order(:name)
         render :new, status: :unprocessable_entity
       end
     end
 
     def edit
+      @agents = Orchestration::Agent.enabled.order(:name)
     end
 
     def update
       if @action.update(action_params)
         redirect_to orchestration_actions_path, notice: "Action updated."
       else
+        @agents = Orchestration::Agent.enabled.order(:name)
         render :edit, status: :unprocessable_entity
       end
     end
@@ -56,7 +60,7 @@ module Orchestration
 
     def action_params
       permitted = params.require(:orchestration_action).permit(
-        :name, :description, :agent_class, :model, :tools, :prompt, :params
+        :name, :description, :kind, :agent_id, :agent_class, :model, :tools, :prompt, :params
       )
       parse_json_field(permitted, :tools)
       parse_json_field(permitted, :params)

--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -5,6 +5,7 @@ module Orchestration
     include JsonParamsParsing
 
     before_action :set_action, only: [ :edit, :update, :destroy ]
+    before_action :load_agents, only: [ :new, :create, :edit, :update ]
 
     def index
       @actions = Orchestration::Action
@@ -16,7 +17,6 @@ module Orchestration
 
     def new
       @action = Orchestration::Action.new
-      @agents = Orchestration::Agent.enabled.order(:name)
     end
 
     def create
@@ -24,20 +24,17 @@ module Orchestration
       if @action.save
         redirect_to orchestration_actions_path, notice: "Action created."
       else
-        @agents = Orchestration::Agent.enabled.order(:name)
         render :new, status: :unprocessable_entity
       end
     end
 
     def edit
-      @agents = Orchestration::Agent.enabled.order(:name)
     end
 
     def update
       if @action.update(action_params)
         redirect_to orchestration_actions_path, notice: "Action updated."
       else
-        @agents = Orchestration::Agent.enabled.order(:name)
         render :edit, status: :unprocessable_entity
       end
     end
@@ -56,6 +53,10 @@ module Orchestration
 
     def set_action
       @action = Orchestration::Action.find(params[:id])
+    end
+
+    def load_agents
+      @agents = Orchestration::Agent.enabled.order(:name)
     end
 
     def action_params

--- a/app/evals/llm_judge_eval.rb
+++ b/app/evals/llm_judge_eval.rb
@@ -69,7 +69,8 @@ class LLMJudgeEval < Leva::BaseEval
   private
 
   def agent_name(recordable)
-    recordable.step_action.action.agent_class
+    action = recordable.step_action.action
+    action.agent? ? action.agent&.name : action.agent_class
   end
 
   def fetch_instructions(agent_name)

--- a/app/models/orchestration/action.rb
+++ b/app/models/orchestration/action.rb
@@ -1,26 +1,39 @@
+# frozen_string_literal: true
+
 module Orchestration
   class Action < ApplicationRecord
     self.table_name = "actions"
 
+    enum :kind, { agent: "agent", service: "service" }, default: :service
+
     has_many :step_actions, class_name: "Orchestration::StepAction", dependent: :restrict_with_error
+    belongs_to :agent, class_name: "Orchestration::Agent", optional: true
 
     validates :name, presence: true
-    validates :agent_class, presence: true
-    validate :agent_class_must_be_valid
+    validate :kind_specific_fields_valid
 
     private
 
-    def agent_class_must_be_valid
-      return if agent_class.blank?
+    def kind_specific_fields_valid
+      if agent?
+        errors.add(:agent_id, "must be present for agent-kind actions") if agent_id.blank?
+        errors.add(:agent_class, "must be blank for agent-kind actions") if agent_class.present?
+      else
+        validate_service_class
+      end
+    end
+
+    def validate_service_class
+      if agent_class.blank?
+        errors.add(:agent_class, "can't be blank")
+        return
+      end
 
       klass = agent_class.safe_constantize
       return errors.add(:agent_class, "must be an existing constant") if klass.nil?
 
-      is_agent      = klass.ancestors.include?(RubyLLM::Agent)
-      is_executable = klass.ancestors.include?(Orchestration::Executable)
-
-      unless is_agent || is_executable
-        errors.add(:agent_class, "must inherit from RubyLLM::Agent or include Orchestration::Executable")
+      unless klass.ancestors.include?(Orchestration::Executable)
+        errors.add(:agent_class, "must include Orchestration::Executable")
       end
     end
   end

--- a/app/models/orchestration/action.rb
+++ b/app/models/orchestration/action.rb
@@ -19,6 +19,7 @@ module Orchestration
         errors.add(:agent_id, "must be present for agent-kind actions") if agent_id.blank?
         errors.add(:agent_class, "must be blank for agent-kind actions") if agent_class.present?
       else
+        errors.add(:agent_id, "must be blank for service-kind actions") if agent_id.present?
         validate_service_class
       end
     end

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -32,7 +32,7 @@ module Orchestration
     end
 
     def ensure_not_referenced
-      return unless Orchestration::Action.exists?(agent_class: name)
+      return unless Orchestration::Action.exists?(agent_id: id)
 
       errors.add(:base, "cannot be deleted while referenced by actions")
       throw :abort

--- a/app/services/evaluation/sample_collector.rb
+++ b/app/services/evaluation/sample_collector.rb
@@ -26,11 +26,11 @@ module Evaluation
     def action_runs
       # steep:ignore:start
       Orchestration::ActionRun
-        .joins(step_action: :action)
+        .joins(step_action: { action: :agent })
         .includes(chat: { messages: :parent_tool_call })
         .where(status: "completed")
         .where.not(chat_id: nil)
-        .where(actions: { agent_class: @agent_name })
+        .where(orchestration_agents: { name: @agent_name })
         .order(id: :desc)
         .limit(@sample_size)
       # steep:ignore:end

--- a/app/services/evaluation/stubbed_agent_run.rb
+++ b/app/services/evaluation/stubbed_agent_run.rb
@@ -6,13 +6,14 @@ module Evaluation
 
       # steep:ignore:start
       action = record.step_action.action
-      agent_class_name = action.agent_class
-      raise ArgumentError, "agent_class is nil for action_run #{record.id}" unless agent_class_name
+      agent_record = action.agent
+      raise ArgumentError, "action #{record.id} is not agent-kind or has no agent" unless agent_record
 
+      agent_class_name = agent_record.name
       agent_class = agent_class_name.safe_constantize
-      raise ArgumentError, "agent_class #{agent_class_name.inspect} could not be resolved for action_run #{record.id}" unless agent_class
+      raise ArgumentError, "agent class #{agent_class_name.inspect} could not be resolved for action_run #{record.id}" unless agent_class
 
-      tool_classes = resolve_tools(action, agent_class)
+      tool_classes = resolve_tools(agent_record, agent_class)
       stubbed_tools = tool_classes.map { |tool_class| stub_tool(tool_class, registry) }
 
       agent = agent_class.create
@@ -26,9 +27,9 @@ module Evaluation
 
     private
 
-    def resolve_tools(action, agent_class)
+    def resolve_tools(agent_record, agent_class)
       # steep:ignore:start
-      configured = action.tools.presence
+      configured = agent_record.tools.presence
       return configured.map(&:constantize) if configured
 
       agent_class.tools

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -71,19 +71,19 @@ module Orchestration
 
     def run_agent(action_run)
       action = action_run.step_action.action
-      klass  = action.agent_class&.constantize
-      raise ArgumentError, "Agent class not found: #{action.agent_class}" unless klass
-
       input  = action_run.input
-      if klass.ancestors.include?(RubyLLM::Agent)
+
+      if action.agent?
         params = (action.params || {}).merge(action_run.step_action.params || {})
         agent = build_agent(action, params)
         chat_id = agent.respond_to?(:chat) ? agent.chat&.id : agent.id
-        # Persist before ask so chat_id is saved even if the agent raises
         action_run.update_column(:chat_id, chat_id)
         result = agent.ask(input.to_json)
         { "result" => parse_content(result.content) }
       else
+        klass = action.agent_class&.constantize
+        raise ArgumentError, "Service class not found: #{action.agent_class}" unless klass
+
         params = (action.params || {}).merge(action_run.step_action.params || {})
         klass.call(input, params)
       end
@@ -102,19 +102,21 @@ module Orchestration
     end
 
     def build_agent(action, _params)
-      model        = @pipeline_run.pipeline.model.presence || action.model
-      tools        = action.tools
-      prompt       = leva_prompt_for(action.agent_class) || action.prompt
+      agent_record = action.agent
+      raise ArgumentError, "No agent associated with action #{action.id}" unless agent_record
+
+      model        = @pipeline_run.pipeline.model.presence || agent_record.model
+      tools        = agent_record.tools
+      prompt       = leva_prompt_for(agent_record.name) || action.prompt
       schema_class = action.schema_class
-      agent_class  = action.agent_class
+      agent_class  = agent_record.name
       raise ArgumentError, "Agent class not found: #{agent_class}" unless agent_class
 
-      # agent = agent_class.constantize.new
       agent = agent_class.constantize.create
-      agent = agent.with_model(model)                    if model.present? && agent.respond_to?(:with_model)
-      agent = agent.with_tools(*tools)                   if tools.present?
+      agent = agent.with_model(model)                     if model.present? && agent.respond_to?(:with_model)
+      agent = agent.with_tools(*tools)                    if tools.present?
       agent = agent.with_schema(schema_class.constantize) if schema_class.present?
-      agent.chat.with_instructions(prompt)               if prompt.present? && agent.respond_to?(:chat)
+      agent.chat.with_instructions(prompt)                if prompt.present? && agent.respond_to?(:chat)
       agent
     end
 

--- a/app/views/orchestration/actions/_form.html.erb
+++ b/app/views/orchestration/actions/_form.html.erb
@@ -42,11 +42,6 @@
   </div>
 
   <div>
-    <%= f.label :model, class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :model, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "e.g. mistral-small" %>
-  </div>
-
-  <div>
     <%= f.label :prompt, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_area :prompt, rows: 4, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
   </div>

--- a/app/views/orchestration/actions/_form.html.erb
+++ b/app/views/orchestration/actions/_form.html.erb
@@ -15,8 +15,27 @@
   </div>
 
   <div>
-    <%= f.label :agent_class, class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :agent_class, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if action.errors[:agent_class].any?}", placeholder: "e.g. Emails::ClassifyAgent" %>
+    <%= f.label :kind, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.select :kind,
+          [["Agent (reusable Orchestration::Agent)", "agent"], ["Service (Executable class)", "service"]],
+          {},
+          class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+  </div>
+
+  <div>
+    <%= f.label :agent_id, "Agent (for agent-kind)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.select :agent_id,
+          @agents.map { |a| [a.name, a.id] },
+          { include_blank: "— select an agent —" },
+          class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if action.errors[:agent_id].any?}" %>
+    <% if action.errors[:agent_id].any? %>
+      <p class="mt-1 text-xs text-red-600"><%= action.errors[:agent_id].first %></p>
+    <% end %>
+  </div>
+
+  <div>
+    <%= f.label :agent_class, "Executable Class (for service-kind)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :agent_class, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if action.errors[:agent_class].any?}", placeholder: "e.g. Emails::FetchExecutor" %>
     <% if action.errors[:agent_class].any? %>
       <p class="mt-1 text-xs text-red-600"><%= action.errors[:agent_class].first %></p>
     <% end %>
@@ -25,11 +44,6 @@
   <div>
     <%= f.label :model, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_field :model, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "e.g. mistral-small" %>
-  </div>
-
-  <div>
-    <%= f.label :tools, "Tools (JSON array)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :tools, value: action.tools ? action.tools.to_json : "", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: '["ToolOne", "ToolTwo"]' %>
   </div>
 
   <div>

--- a/app/views/orchestration/actions/index.html.erb
+++ b/app/views/orchestration/actions/index.html.erb
@@ -5,7 +5,7 @@
 <%= render UI::TableComponent.new(collection: @actions, empty_message: "No actions found.") do |table| %>
   <% table.with_columns([
     { key: "name",           label: "Name" },
-    { key: "agent_class",    label: "Agent Class", classes: "px-4 py-3 font-mono text-gray-600 text-xs" },
+    { key: "kind",           label: "Kind" },
     { key: "model",          label: "Model",     variant: :muted, cell: ->(action) { action.model || "—" } },
     { key: "pipeline_count", label: "Pipelines", variant: :muted }
   ]) %>

--- a/db/migrate/20260503160000_add_kind_and_agent_to_actions.rb
+++ b/db/migrate/20260503160000_add_kind_and_agent_to_actions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddKindAndAgentToActions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :actions, :kind, :string, null: false, default: "service"
+    add_column :actions, :agent_id, :integer, null: true
+    add_foreign_key :actions, :orchestration_agents, column: :agent_id
+    change_column_null :actions, :agent_class, true
+  end
+end

--- a/db/migrate/20260503170000_add_index_to_actions_agent_id.rb
+++ b/db/migrate/20260503170000_add_index_to_actions_agent_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToActionsAgentId < ActiveRecord::Migration[8.1]
+  def change
+    add_index :actions, :agent_id
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,22 +52,28 @@ RECONCILE_EMAILS_INPUT_MAPPING = {
 }.freeze
 
 steps = [
-  { name: "Fetch Emails",                   agent_class: "Emails::FetchExecutor"                                                                              },
-  { name: "Classify Emails",                agent_class: "Emails::ClassifyAgent"                                                                              },
-  { name: "Filter Emails",                  agent_class: "Emails::FilterAgent"                                                                                },
-  { name: "Ingest Emails",                  agent_class: "Orchestration::IngestionExecutor", params: INGEST_EMAILS_PARAMS                                     },
-  { name: "Map Emails",                     agent_class: "Emails::MappingAgent",             schema_class: "ApplicationMailsSchema"                            },
-  { name: "Store Emails",                   agent_class: "Records::StoreAgent",              output_schema: STORE_EMAILS_OUTPUT_SCHEMA                         },
-  { name: "Query Email Records",            agent_class: "Orchestration::QueryExecutor",    params: QUERY_EMAIL_RECORDS_PARAMS,   input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING  },
-  { name: "Normalize Emails",               agent_class: "Records::NormalizeAgent",                                              input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING     },
-  { name: "Reconcile Emails to Interviews", agent_class: "Records::ReconcileAgent", input_mapping: RECONCILE_EMAILS_INPUT_MAPPING                           },
-  { name: "Export to Gist",                 agent_class: "Interviews::GistExportExecutor"                                                                     }
+  { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor"                                                                              },
+  { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent"                                                                               },
+  { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent"                                                                                 },
+  { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor", params: INGEST_EMAILS_PARAMS                                     },
+  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",              schema_class: "ApplicationMailsSchema"                            },
+  { name: "Store Emails",                   kind: :agent,   agent_name: "Records::StoreAgent",               output_schema: STORE_EMAILS_OUTPUT_SCHEMA                         },
+  { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",    params: QUERY_EMAIL_RECORDS_PARAMS,   input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING  },
+  { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",                                               input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING     },
+  { name: "Reconcile Emails to Interviews", kind: :agent,   agent_name: "Records::ReconcileAgent",          input_mapping: RECONCILE_EMAILS_INPUT_MAPPING                                             },
+  { name: "Export to Gist",                 kind: :service, agent_class: "Interviews::GistExportExecutor"                                                                     }
 ]
 
 Orchestration::Action.where(name: "Merge Email Records").destroy_all
 
 action_records = steps.map do |attrs|
+  agent_record = if attrs[:kind] == :agent
+    Orchestration::Agent.find_or_create_by!(name: attrs[:agent_name])
+  end
+
   Orchestration::Action.find_or_initialize_by(name: attrs[:name]).tap do |a|
+    a.kind          = attrs[:kind]
+    a.agent         = agent_record
     a.agent_class   = attrs[:agent_class]
     a.output_schema = attrs[:output_schema]
     a.params        = attrs[:params]

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -151,7 +151,9 @@ FOREIGN KEY ("agent_id")
   REFERENCES "orchestration_agents" ("id")
 );
 CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_actions_on_agent_id" ON "actions" ("agent_id") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260503170000'),
 ('20260503160000'),
 ('20260503140000'),
 ('20260503133626'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,10 @@ CREATE UNIQUE INDEX "index_application_mails_on_email_id" ON "application_mails"
 CREATE INDEX "index_application_mails_on_date" ON "application_mails" ("date") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "interviews" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "company" varchar NOT NULL, "job_title" varchar NOT NULL, "status" varchar DEFAULT 'pending_reply', "applied_at" date, "rejected_at" date, "first_interview_at" date, "second_interview_at" date, "third_interview_at" date, "fourth_interview_at" date, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_interviews_on_company_and_job_title" ON "interviews" ("company", "job_title") /*application='ApplicationPipeline'*/;
+CREATE VIRTUAL TABLE email_vectors USING vec0(
+  email_id TEXT PRIMARY KEY,
+  embedding FLOAT[1536]
+);
 CREATE TABLE IF NOT EXISTS "email_vectors_info" (key text primary key, value any);
 CREATE TABLE IF NOT EXISTS "email_vectors_chunks"(chunk_id INTEGER PRIMARY KEY AUTOINCREMENT,size INTEGER NOT NULL,validity BLOB NOT NULL,rowids BLOB NOT NULL);
 CREATE TABLE IF NOT EXISTS "email_vectors_rowids"(rowid INTEGER PRIMARY KEY AUTOINCREMENT,id TEXT UNIQUE NOT NULL,chunk_id INTEGER,chunk_offset INTEGER);
@@ -45,7 +49,6 @@ FOREIGN KEY ("pipeline_id")
 );
 CREATE INDEX "index_steps_on_pipeline_id" ON "steps" ("pipeline_id") /*application='ApplicationPipeline'*/;
 CREATE UNIQUE INDEX "index_steps_on_pipeline_id_and_position" ON "steps" ("pipeline_id", "position") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar NOT NULL, "description" text, "model" varchar, "tools" json, "prompt" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "output_schema" json /*application='ApplicationPipeline'*/, "schema_class" varchar /*application='ApplicationPipeline'*/);
 CREATE TABLE IF NOT EXISTS "step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_d9cf618a2f"
 FOREIGN KEY ("step_id")
   REFERENCES "steps" ("id")
@@ -135,16 +138,21 @@ CREATE INDEX "index_leva_optimization_runs_on_prompt_id" ON "leva_optimization_r
 CREATE INDEX "index_leva_optimization_runs_on_status" ON "leva_optimization_runs" ("status") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_leva_prompts_on_name" ON "leva_prompts" ("name") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "evaluation_metrics" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "agent_name" varchar NOT NULL, "name" varchar NOT NULL, "description" text NOT NULL, "weight" decimal DEFAULT 1.0 NOT NULL, "active" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE UNIQUE INDEX "index_evaluation_metrics_on_agent_name_and_name" ON "evaluation_metrics" ("agent_name", "name");
+CREATE UNIQUE INDEX "index_evaluation_metrics_on_agent_name_and_name" ON "evaluation_metrics" ("agent_name", "name") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "evaluation_justifications" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "evaluation_result_id" integer NOT NULL, "metric_name" varchar NOT NULL, "justification" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_517f4d40a2"
 FOREIGN KEY ("evaluation_result_id")
   REFERENCES "leva_evaluation_results" ("id")
 );
-CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id");
+CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name");
+CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "model" varchar, "tools" json, "prompt" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "output_schema" json, "schema_class" varchar, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, CONSTRAINT "fk_rails_951418a714"
+FOREIGN KEY ("agent_id")
+  REFERENCES "orchestration_agents" ("id")
+);
 CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260503160000'),
 ('20260503140000'),
 ('20260503133626'),
 ('20260429112350'),

--- a/sig/app/models/orchestration/action.rbs
+++ b/sig/app/models/orchestration/action.rbs
@@ -4,6 +4,12 @@ module Orchestration
 
     def name: () -> String?
     def name=: (String?) -> String?
+    def kind: () -> String
+    def kind=: (String) -> String
+    def agent?: () -> bool
+    def service?: () -> bool
+    def agent_id: () -> Integer?
+    def agent_id=: (Integer?) -> Integer?
     def agent_class: () -> String?
     def agent_class=: (String?) -> String?
     def schema_class: () -> String?
@@ -22,9 +28,11 @@ module Orchestration
     def output_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
 
     def step_actions: () -> ActiveRecord::Associations::CollectionProxy
+    def agent: () -> Orchestration::Agent?
 
     private
 
-    def agent_class_must_be_valid: () -> void
+    def kind_specific_fields_valid: () -> void
+    def validate_service_class: () -> void
   end
 end

--- a/sig/app/services/evaluation/stubbed_agent_run.rbs
+++ b/sig/app/services/evaluation/stubbed_agent_run.rbs
@@ -4,7 +4,7 @@ module Evaluation
 
     private
 
-    def resolve_tools: (Orchestration::Action action, Class agent_class) -> Array[Class]
+    def resolve_tools: (Orchestration::Agent agent_record, Class agent_class) -> Array[Class]
     def stub_tool: (Class tool_class, ToolStubRegistry registry) -> Class
     def build_prediction: (untyped agent, untyped result) -> String
   end

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -12,6 +12,6 @@ module Orchestration
     def parse_content: (String | untyped content) -> untyped
     def validate_output!: (Action action, Hash[String, untyped] output) -> void
     def build_agent: (Action action, Hash[String, untyped] params) -> untyped
-    def leva_prompt_for: (String? agent_class) -> String?
+    def leva_prompt_for: (String? agent_name) -> String?
   end
 end

--- a/spec/evals/llm_judge_eval_spec.rb
+++ b/spec/evals/llm_judge_eval_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe LLMJudgeEval do
         chat: instance_double(RubyLLM::Chat, messages: []),
         step_action: instance_double(
           Orchestration::StepAction,
-          action: instance_double(Orchestration::Action, agent_class: agent_name)
+          action: instance_double(Orchestration::Action, agent?: false, agent_class: agent_name)
         )
       )
     end
@@ -129,7 +129,13 @@ RSpec.describe LLMJudgeEval do
     let!(:leva_dataset) { Leva::Dataset.create!(name: "test_dataset") }
     let!(:leva_prompt) { Orchestration::Prompt.create!(name: agent_name, system_prompt: "You are a classifier.", user_prompt: "Classify: {{input}}") }
     let!(:leva_experiment) { Leva::Experiment.create!(name: "test_exp", dataset: leva_dataset, status: :pending, prompt: leva_prompt, runner_class: "Evaluation::StubbedAgentRun", evaluator_classes: [ "LLMJudgeEval" ]) }
-    let!(:leva_dataset_record) { Leva::DatasetRecord.create!(dataset: leva_dataset, recordable: create(:orchestration_action_run, status: "completed")) }
+    let!(:leva_dataset_record) do
+      classify_agent = create(:orchestration_agent, name: agent_name)
+      action = create(:orchestration_action, kind: :agent, agent: classify_agent)
+      step_action = create(:orchestration_step_action, action: action)
+      action_run = create(:orchestration_action_run, step_action: step_action, status: "completed")
+      Leva::DatasetRecord.create!(dataset: leva_dataset, recordable: action_run)
+    end
     let!(:leva_runner_result) do
       Leva::RunnerResult.create!(
         experiment: leva_experiment,

--- a/spec/factories/actions.rb
+++ b/spec/factories/actions.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
-  factory :orchestration_action, class: 'Orchestration::Action' do
+  factory :orchestration_action, class: "Orchestration::Action" do
     sequence(:name) { |n| "Action #{n}" }
-    agent_class { 'Emails::ClassifyAgent' }
+    kind { :agent }
+    association :agent, factory: :orchestration_agent, strategy: :create
+
+    trait :service_kind do
+      kind { :service }
+      agent { nil }
+      agent_class { nil }
+    end
   end
 end

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -1,32 +1,58 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Orchestration::Action do
-  describe 'validations' do
-    it 'is valid with a name and a valid agent_class' do
-      action = build(:orchestration_action)
-      expect(action).to be_valid
+  describe "validations" do
+    context "with kind: :agent" do
+      it "is valid with a name and an associated agent" do
+        action = build(:orchestration_action, kind: :agent)
+        expect(action).to be_valid
+      end
+
+      it "is invalid without an agent_id" do
+        action = build(:orchestration_action, kind: :agent, agent: nil)
+        expect(action).not_to be_valid
+        expect(action.errors[:agent_id]).to include(/must be present/)
+      end
+
+      it "is invalid when agent_class is present" do
+        action = build(:orchestration_action, kind: :agent, agent_class: "SomeClass")
+        expect(action).not_to be_valid
+        expect(action.errors[:agent_class]).to include(/must be blank/)
+      end
     end
 
-    it_behaves_like 'requires attribute', :name, :orchestration_action
-    it_behaves_like 'requires attribute', :agent_class, :orchestration_action
-    it_behaves_like 'rejects invalid attribute value', :agent_class, :orchestration_action, 'NonExistentClass::Whatever'
+    context "with kind: :service" do
+      it "is valid with a name and a valid executable class" do
+        stub_const("MyExecutable", Class.new { include Orchestration::Executable })
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "MyExecutable")
+        expect(action).to be_valid
+      end
 
-    it 'accepts a class including Orchestration::Executable' do
-      stub_const('MyExecutable', Class.new { include Orchestration::Executable })
-      action = build(:orchestration_action, agent_class: 'MyExecutable')
-      expect(action).to be_valid
+      it "is invalid without agent_class" do
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: nil)
+        expect(action).not_to be_valid
+        expect(action.errors[:agent_class]).to include(/can't be blank/)
+      end
+
+      it "rejects non-existent class" do
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "NonExistent::Klass")
+        expect(action).not_to be_valid
+        expect(action.errors[:agent_class]).to include(/must be an existing constant/)
+      end
+
+      it "rejects a class that does not include Orchestration::Executable" do
+        stub_const("RegularClass", Class.new)
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "RegularClass")
+        expect(action).not_to be_valid
+        expect(action.errors[:agent_class]).to include(/must include Orchestration::Executable/)
+      end
     end
 
-    it 'rejects a class that is neither an agent nor an executable' do
-      stub_const('RegularClass', Class.new)
-      action = build(:orchestration_action, agent_class: 'RegularClass')
-      expect(action).not_to be_valid
-      expect(action.errors[:agent_class]).to include(/must inherit from RubyLLM::Agent or include Orchestration::Executable/)
-    end
+    it_behaves_like "requires attribute", :name, :orchestration_action
   end
 
-  describe 'associations' do
-    it 'blocks deletion when referenced by a step_action' do
+  describe "associations" do
+    it "blocks deletion when referenced by a step_action" do
       action = create(:orchestration_action)
       create(:orchestration_step_action, action: action)
       action.destroy

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Orchestration::Action do
         expect(action).not_to be_valid
         expect(action.errors[:agent_class]).to include(/must include Orchestration::Executable/)
       end
+
+      it "is invalid when agent_id is present" do
+        stub_const("MyExecutable", Class.new { include Orchestration::Executable })
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "MyExecutable")
+        action.agent_id = 999
+        expect(action).not_to be_valid
+        expect(action.errors[:agent_id]).to include(/must be blank/)
+      end
     end
 
     it_behaves_like "requires attribute", :name, :orchestration_action

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Orchestration::Agent do
     end
 
     context "when referenced by an action" do
-      before { create(:orchestration_action, agent_class: persisted_agent.name) }
+      before { create(:orchestration_action, kind: :agent, agent: persisted_agent) }
 
       it "cannot be destroyed" do
         persisted_agent.destroy

--- a/spec/requests/orchestration/actions_spec.rb
+++ b/spec/requests/orchestration/actions_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "Orchestration::Actions" do
             kind: "agent",
             agent_id: orchestration_agent.id,
             description: "A description",
-            model: "mistral-small",
             prompt: "Classify this email",
             params: '{"key":"value"}'
           }

--- a/spec/requests/orchestration/actions_spec.rb
+++ b/spec/requests/orchestration/actions_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe "Orchestration::Actions" do
   describe "GET /orchestration/actions" do
     it "returns 200 and lists actions" do
-      action = create(:orchestration_action, name: "My Action", agent_class: "Emails::ClassifyAgent")
+      create(:orchestration_action, name: "My Action")
       get orchestration_actions_path
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("My Action")
-      expect(response.body).to include("Emails::ClassifyAgent")
+      expect(response.body).to include("agent")
     end
 
     it "shows pipeline usage count" do
@@ -26,20 +26,21 @@ RSpec.describe "Orchestration::Actions" do
       get new_orchestration_action_path
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("name")
-      expect(response.body).to include("agent_class")
+      expect(response.body).to include("kind")
     end
   end
 
   describe "POST /orchestration/actions" do
     context "with valid params" do
+      let(:orchestration_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent") }
       let(:valid_params) do
         {
           orchestration_action: {
             name: "New Action",
-            agent_class: "Emails::ClassifyAgent",
+            kind: "agent",
+            agent_id: orchestration_agent.id,
             description: "A description",
             model: "mistral-small",
-            tools: '["EmailClassifier"]',
             prompt: "Classify this email",
             params: '{"key":"value"}'
           }
@@ -56,16 +57,17 @@ RSpec.describe "Orchestration::Actions" do
 
     context "with invalid params" do
       it "renders new with 422" do
-        post orchestration_actions_path, params: { orchestration_action: { name: "", agent_class: "" } }
+        post orchestration_actions_path, params: { orchestration_action: { name: "", kind: "agent" } }
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to include("agent_class")
+        expect(response.body).to include("kind")
       end
 
       it "falls back to raw params when tools JSON is invalid" do
+        agent = create(:orchestration_agent)
         expect {
           post orchestration_actions_path, params: {
             orchestration_action: {
-              name: "Test", agent_class: "Emails::ClassifyAgent", tools: "{invalid json"
+              name: "Test", kind: "agent", agent_id: agent.id, tools: "{invalid json"
             }
           }
         }.to change(Orchestration::Action, :count).by(1)
@@ -87,7 +89,7 @@ RSpec.describe "Orchestration::Actions" do
       it "updates and redirects" do
         action = create(:orchestration_action, name: "Old Name")
         patch orchestration_action_path(action), params: {
-          orchestration_action: { name: "New Name", agent_class: "Emails::ClassifyAgent" }
+          orchestration_action: { name: "New Name" }
         }
         expect(response).to redirect_to(orchestration_actions_path)
         expect(action.reload.name).to eq("New Name")
@@ -98,7 +100,7 @@ RSpec.describe "Orchestration::Actions" do
       it "renders edit with 422" do
         action = create(:orchestration_action)
         patch orchestration_action_path(action), params: {
-          orchestration_action: { name: "", agent_class: "" }
+          orchestration_action: { name: "" }
         }
         expect(response).to have_http_status(:unprocessable_content)
       end

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Orchestration::Agents" do
 
     it "shows error when agent is referenced by an action" do
       agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
-      create(:orchestration_action, agent_class: agent.name)
+      create(:orchestration_action, kind: :agent, agent: agent)
       expect {
         delete orchestration_agent_path(agent)
       }.not_to change(Orchestration::Agent, :count)

--- a/spec/requests/orchestration/pipeline_lifecycle_spec.rb
+++ b/spec/requests/orchestration/pipeline_lifecycle_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
         post orchestration_actions_path, params: {
           orchestration_action: {
             name: "Query Interviews",
+            kind: "service",
             agent_class: "Orchestration::QueryExecutor",
             description: "Fetches interviews from the database",
             params: '{"table":"interviews","column_name":"status","column_values":["screening"],"columns":["id","company","job_title"]}'
@@ -29,11 +30,14 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
       expect(query_action.agent_class).to eq("Orchestration::QueryExecutor")
       expect(query_action.params).to include("table" => "interviews")
 
+      classify_agent_record = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+
       expect {
         post orchestration_actions_path, params: {
           orchestration_action: {
             name: "Classify Emails",
-            agent_class: "Emails::ClassifyAgent",
+            kind: "agent",
+            agent_id: classify_agent_record.id,
             description: "Classifies emails using Mistral AI"
           }
         }
@@ -41,7 +45,7 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
 
       classify_action = Orchestration::Action.last
       expect(response).to redirect_to(orchestration_actions_path)
-      expect(classify_action.agent_class).to eq("Emails::ClassifyAgent")
+      expect(classify_action.agent.name).to eq("Emails::ClassifyAgent")
 
       # --- pipeline ---
 
@@ -106,13 +110,14 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
 
   describe "run: executing a pipeline with service-object and agentic steps" do
     let!(:query_action) do
-      create(:orchestration_action,
+      create(:orchestration_action, :service_kind,
         name: "Query Interviews",
         agent_class: "Orchestration::QueryExecutor",
         params: { "table" => "interviews", "column_name" => "status", "column_values" => [ "screening" ] })
     end
+    let!(:classify_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent") }
     let!(:classify_action) do
-      create(:orchestration_action, name: "Classify Emails", agent_class: "Emails::ClassifyAgent")
+      create(:orchestration_action, name: "Classify Emails", agent: classify_agent)
     end
     let!(:pipeline) { create(:orchestration_pipeline, name: "Job Application Pipeline", enabled: true) }
     let!(:fetch_step) { create(:orchestration_step, pipeline: pipeline, name: "Fetch Interviews", position: 1) }
@@ -170,20 +175,23 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
 
   describe "edit: updating an existing pipeline's metadata, steps, and action attachments" do
     let!(:ingest_action) do
-      create(:orchestration_action, name: "Transform Data", agent_class: "Orchestration::IngestionExecutor",
+      create(:orchestration_action, :service_kind, name: "Transform Data",
+        agent_class: "Orchestration::IngestionExecutor",
         params: { "operations" => [ { "type" => "pick", "keys" => [ "interviews" ] } ] })
     end
     let!(:pipeline) { create(:orchestration_pipeline, name: "Job Application Pipeline", enabled: true) }
     let!(:fetch_step) { create(:orchestration_step, pipeline: pipeline, name: "Fetch Interviews", position: 1) }
     let!(:classify_step) { create(:orchestration_step, pipeline: pipeline, name: "Classify Emails", position: 2) }
     let!(:fetch_step_action) do
-      query_action = create(:orchestration_action, name: "Query Interviews", agent_class: "Orchestration::QueryExecutor",
+      query_action = create(:orchestration_action, :service_kind, name: "Query Interviews",
+        agent_class: "Orchestration::QueryExecutor",
         params: { "table" => "interviews", "column_name" => "status", "column_values" => [ "screening" ] })
       create(:orchestration_step_action, step: fetch_step, action: query_action, position: 1)
     end
 
     before do
-      classify_action = create(:orchestration_action, name: "Classify Emails", agent_class: "Emails::ClassifyAgent")
+      classify_agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      classify_action = create(:orchestration_action, name: "Classify Emails", agent: classify_agent)
       create(:orchestration_step_action, step: classify_step, action: classify_action, position: 1)
     end
 

--- a/spec/services/evaluation/sample_collector_spec.rb
+++ b/spec/services/evaluation/sample_collector_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Evaluation::SampleCollector do
   let(:agent_name) { "Emails::ClassifyAgent" }
-  let(:action) { create(:orchestration_action, agent_class: agent_name) }
+  let(:orchestration_agent) { create(:orchestration_agent, name: agent_name) }
+  let(:action) { create(:orchestration_action, kind: :agent, agent: orchestration_agent) }
   let(:step_action) { create(:orchestration_step_action, action: action) }
   let(:pipeline_run) { create(:orchestration_pipeline_run, pipeline: step_action.step.pipeline) }
   let(:chat) { create(:chat) }
@@ -52,19 +53,18 @@ RSpec.describe Evaluation::SampleCollector do
     end
 
     it "only returns samples for the given agent_name" do # rubocop:disable RSpec/ExampleLength
+      other_agent = create(:orchestration_agent, name: "Emails::FilterAgent")
       other_sa = create(:orchestration_step_action,
-                        action: create(:orchestration_action, agent_class: "Emails::FilterAgent"))
+                        action: create(:orchestration_action, kind: :agent, agent: other_agent))
       create(:orchestration_action_run,
              step_action: other_sa,
              pipeline_run: create(:orchestration_pipeline_run, pipeline: other_sa.step.pipeline),
              status: "completed", chat: create(:chat), input: {})
-      build_action_run
+      own_run = build_action_run
 
       samples = described_class.call(agent_name: agent_name, sample_size: 10)
 
-      allowed_ids = Orchestration::ActionRun.joins(step_action: :action)
-                                            .where(actions: { agent_class: agent_name }).pluck(:id)
-      expect(samples.map(&:action_run_id)).to all(be_in(allowed_ids))
+      expect(samples.map(&:action_run_id)).to all(eq(own_run.id))
     end
   end
 

--- a/spec/services/evaluation/stubbed_agent_run_spec.rb
+++ b/spec/services/evaluation/stubbed_agent_run_spec.rb
@@ -3,8 +3,9 @@ require "rails_helper"
 RSpec.describe Evaluation::StubbedAgentRun do # rubocop:disable RSpec/MultipleMemoizedHelpers
   subject(:runner) { described_class.new }
 
+  let(:orchestration_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent") }
   let(:step_action) do
-    action = create(:orchestration_action, agent_class: "Emails::ClassifyAgent")
+    action = create(:orchestration_action, kind: :agent, agent: orchestration_agent)
     create(:orchestration_step_action, action: action)
   end
   let(:pipeline_run) { create(:orchestration_pipeline_run, pipeline: step_action.step.pipeline) }

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Orchestration::PipelineRunner do
   let(:pipeline)     { create(:orchestration_pipeline) }
   let(:step1)        { create(:orchestration_step, pipeline: pipeline, name: "extract", position: 1) }
-  let(:action)       { create(:orchestration_action, agent_class: "Emails::ClassifyAgent") }
+  let(:action)       { create(:orchestration_action, agent: create(:orchestration_agent, name: "Emails::ClassifyAgent")) }
   let(:pipeline_run) { create(:orchestration_pipeline_run, pipeline: pipeline, status: "pending") }
-  let(:stub_agent) { instance_double(Emails::ClassifyAgent) }
+  let(:stub_agent)   { instance_double(Emails::ClassifyAgent) }
 
   before do
     allow(Emails::ClassifyAgent).to receive(:create).and_return(stub_agent)
@@ -45,7 +45,7 @@ RSpec.describe Orchestration::PipelineRunner do
     context 'when the pipeline has a model set' do
       before do
         pipeline.update!(model: 'mistral-large-latest')
-        action.update!(model: 'openai-gpt4')
+        action.agent.update!(model: 'openai-gpt4')
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         allow(stub_agent).to receive(:with_model).and_return(stub_agent)
       end
@@ -59,7 +59,7 @@ RSpec.describe Orchestration::PipelineRunner do
     context 'when the pipeline has no model but the action does' do
       before do
         pipeline.update!(model: nil)
-        action.update!(model: 'openai-gpt4')
+        action.agent.update!(model: 'openai-gpt4')
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         allow(stub_agent).to receive(:with_model).and_return(stub_agent)
       end
@@ -73,7 +73,7 @@ RSpec.describe Orchestration::PipelineRunner do
     context 'when both pipeline and action have no model' do
       before do
         pipeline.update!(model: nil)
-        action.update!(model: nil)
+        action.agent.update!(model: nil)
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         allow(stub_agent).to receive(:with_model)
       end
@@ -168,7 +168,7 @@ RSpec.describe Orchestration::PipelineRunner do
 
     context 'with an executable action' do
       before do
-        executable_action = create(:orchestration_action, agent_class: "Emails::FetchExecutor")
+        executable_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         create(:orchestration_step_action, step: step1, action: executable_action, position: 1)
       end
 
@@ -184,7 +184,7 @@ RSpec.describe Orchestration::PipelineRunner do
     context 'with an executable action that has params' do
       before do
         ops = { "operations" => [ { "type" => "pick", "keys" => [ "emails" ] } ] }
-        ingest_action = create(:orchestration_action,
+        ingest_action = create(:orchestration_action, :service_kind,
                                 agent_class: "Orchestration::IngestionExecutor",
                                 params: ops)
         create(:orchestration_step_action, step: step1, action: ingest_action, position: 1)
@@ -241,7 +241,7 @@ RSpec.describe Orchestration::PipelineRunner do
       before do
         step_disabled = create(:orchestration_step, pipeline: pipeline, name: "disabled", position: 2, enabled: false)
         step3         = create(:orchestration_step, pipeline: pipeline, name: "load", position: 3)
-        action3       = create(:orchestration_action, agent_class: "Emails::ClassifyAgent")
+        action3       = create(:orchestration_action, agent: action.agent)
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         create(:orchestration_step_action, step: step_disabled, action: action, position: 1)
         create(:orchestration_step_action, step: step3, action: action3, position: 1)
@@ -259,7 +259,7 @@ RSpec.describe Orchestration::PipelineRunner do
     context 'when step 1 fails, step 2 is not started' do
       before do
         step2   = create(:orchestration_step, pipeline: pipeline, name: "transform", position: 2)
-        action2 = create(:orchestration_action, agent_class: "Emails::ClassifyAgent")
+        action2 = create(:orchestration_action, agent: action.agent)
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         create(:orchestration_step_action, step: step2, action: action2, position: 1)
         allow(stub_agent).to receive(:ask).and_raise(RuntimeError, "step1 exploded")
@@ -330,7 +330,7 @@ RSpec.describe Orchestration::PipelineRunner do
     context 'with two steps and input_mapping on the second step' do
       before do
         step2 = create(:orchestration_step, pipeline: pipeline, name: "transform", position: 2)
-        action2 = create(:orchestration_action, agent_class: "Emails::ClassifyAgent")
+        action2 = create(:orchestration_action, agent: action.agent)
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         create(:orchestration_step_action, step: step2, action: action2, position: 1)
         allow(stub_agent).to receive(:ask).and_return(instance_double(RubyLLM::Message, content: "step output"))
@@ -358,7 +358,7 @@ RSpec.describe Orchestration::PipelineRunner do
       before do
         pipeline_run.update!(initial_input: { "date" => "2026-04-03", "providers" => [ "gmail" ] })
         step1.update!(input_mapping: { "fetch_date" => { "from_step" => "initial", "path" => "date" } })
-        executable_action = create(:orchestration_action, agent_class: "Emails::FetchExecutor")
+        executable_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         create(:orchestration_step_action, step: step1, action: executable_action, position: 1)
         allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
       end
@@ -375,9 +375,11 @@ RSpec.describe Orchestration::PipelineRunner do
         step2 = create(:orchestration_step, pipeline: pipeline, name: "filter",  position: 2)
         step3 = create(:orchestration_step, pipeline: pipeline, name: "ingest",  position: 3)
 
-        fetch_action  = create(:orchestration_action, agent_class: "Emails::FetchExecutor")
-        filter_action = create(:orchestration_action, agent_class: "Emails::FilterAgent")
-        ingest_action = create(:orchestration_action,
+        filter_agent_record = create(:orchestration_agent, name: "Emails::FilterAgent")
+
+        fetch_action  = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
+        filter_action = create(:orchestration_action, agent: filter_agent_record)
+        ingest_action = create(:orchestration_action, :service_kind,
                                 agent_class: "Orchestration::IngestionExecutor",
                                 params: {
                                   "operations" => [


### PR DESCRIPTION
## Summary

- Add explicit `kind` enum (`:agent` / `:service`) to `Orchestration::Action` with an `agent_id` FK to `Orchestration::Agent` for agent-backed actions
- Service-backed actions keep `agent_class` (restricted to `Orchestration::Executable` classes only)
- Update `SampleCollector`, `StubbedAgentRun`, `PipelineRunner`, and `LLMJudgeEval` to resolve agent name and tools through the new association instead of reading `agent_class` directly
- Update admin action form to show kind selector + conditional agent dropdown vs executable class field

Closes #35

## Test plan

- [x] Action model specs: agent-kind and service-kind validations
- [x] Agent model spec: `ensure_not_referenced` checks `agent_id` FK
- [x] `SampleCollector` spec: queries through agent association
- [x] `StubbedAgentRun` spec: resolves class/tools from agent record
- [x] `PipelineRunner` spec: kind-based dispatch (28 examples)
- [x] Actions request spec: CRUD flows for both kinds
- [x] Pipeline lifecycle spec: end-to-end with mixed agent/service actions
- [x] Full suite: 1093 examples, 0 failures
- [x] RuboCop: no offenses
- [x] Steep: no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)