### PR TITLE
feat: run database-defined agent actions end-to-end

### DIFF
--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -55,11 +55,17 @@ module Orchestration
     end
 
     def agent_params
-      permitted = params.require(:orchestration_agent).permit(:name, :description, :model, :tools)
+      permitted = params.require(:orchestration_agent).permit(
+        :name, :description, :model, :tools, :prompt, :params, :output_schema
+      )
       parse_json_field(permitted, :tools)
+      parse_json_field(permitted, :params)
+      parse_json_field(permitted, :output_schema)
       permitted
     rescue JSON::ParserError
       permitted[:tools] = []
+      permitted[:params] = {}
+      permitted[:output_schema] = nil
       permitted
     end
   end

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -58,14 +58,25 @@ module Orchestration
       permitted = params.require(:orchestration_agent).permit(
         :name, :description, :model, :tools, :prompt, :params, :output_schema
       )
-      parse_json_field(permitted, :tools)
-      parse_json_field(permitted, :params)
-      parse_json_field(permitted, :output_schema)
-      permitted
-    rescue JSON::ParserError
-      permitted[:tools] = []
-      permitted[:params] = {}
-      permitted[:output_schema] = nil
+
+      begin
+        parse_json_field(permitted, :tools)
+      rescue JSON::ParserError
+        permitted[:tools] = []
+      end
+
+      begin
+        parse_json_field(permitted, :params)
+      rescue JSON::ParserError
+        permitted[:params] = {}
+      end
+
+      begin
+        parse_json_field(permitted, :output_schema)
+      rescue JSON::ParserError
+        permitted[:output_schema] = nil
+      end
+
       permitted
     end
   end

--- a/app/services/evaluation/stubbed_agent_run.rb
+++ b/app/services/evaluation/stubbed_agent_run.rb
@@ -4,36 +4,29 @@ module Evaluation
       expected_tool_calls = ToolCallExtractor.call(record.chat)
       registry = Evaluation::ToolStubRegistry.new(expected_tool_calls)
 
-      # steep:ignore:start
       action = record.step_action.action
       agent_record = action.agent
       raise ArgumentError, "action #{record.id} is not agent-kind or has no agent" unless agent_record
 
-      agent_class_name = agent_record.name
-      agent_class = agent_class_name.safe_constantize
-      raise ArgumentError, "agent class #{agent_class_name.inspect} could not be resolved for action_run #{record.id}" unless agent_class
-
-      tool_classes = resolve_tools(agent_record, agent_class)
+      tool_classes = resolve_tools(agent_record)
       stubbed_tools = tool_classes.map { |tool_class| stub_tool(tool_class, registry) }
-
-      agent = agent_class.create
-      agent = agent.with_tools(*stubbed_tools, replace: true)
+      agent = Orchestration::RuntimeAgentBuilder.new(action: action, tool_classes: stubbed_tools).build
 
       result = agent.ask(record.input.to_json)
-      # steep:ignore:end
 
       build_prediction(agent, result)
     end
 
     private
 
-    def resolve_tools(agent_record, agent_class)
-      # steep:ignore:start
+    def resolve_tools(agent_record)
       configured = agent_record.tools.presence
       return configured.map(&:constantize) if configured
 
-      agent_class.tools
-      # steep:ignore:end
+      agent_class = agent_record.name.safe_constantize
+      return agent_class.tools if agent_class.respond_to?(:tools)
+
+      raise ArgumentError, "agent #{agent_record.name.inspect} has no configured tools"
     end
 
     def stub_tool(tool_class, registry)

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -76,7 +76,6 @@ module Orchestration
       if action.agent?
         builder = RuntimeAgentBuilder.new(
           action: action,
-          chat: Chat.create!,
           pipeline_model: @pipeline_run.pipeline.model,
           prompt_override: leva_prompt_for(action.agent&.name),
           step_params: action_run.step_action.params

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -74,12 +74,19 @@ module Orchestration
       input  = action_run.input
 
       if action.agent?
-        params = (action.params || {}).merge(action_run.step_action.params || {})
-        agent = build_agent(action, params)
+        builder = RuntimeAgentBuilder.new(
+          action: action,
+          chat: Chat.create!,
+          pipeline_model: @pipeline_run.pipeline.model,
+          prompt_override: leva_prompt_for(action.agent&.name),
+          step_params: action_run.step_action.params
+        )
+        agent = builder.build
         chat_id = agent.respond_to?(:chat) ? agent.chat&.id : agent.id
         action_run.update_column(:chat_id, chat_id)
         result = agent.ask(input.to_json)
-        { "result" => parse_content(result.content) }
+        output = parse_content(result.content)
+        action.agent&.output_schema.present? ? output : { "result" => output }
       else
         klass = action.agent_class&.constantize
         raise ArgumentError, "Service class not found: #{action.agent_class}" unless klass
@@ -98,26 +105,13 @@ module Orchestration
     end
 
     def validate_output!(action, output)
-      OutputValidator.new(action.output_schema).validate!(output)
-    end
+      schema = if action.agent?
+        action.agent&.output_schema.presence || action.output_schema
+      else
+        action.output_schema
+      end
 
-    def build_agent(action, _params)
-      agent_record = action.agent
-      raise ArgumentError, "No agent associated with action #{action.id}" unless agent_record
-
-      model        = @pipeline_run.pipeline.model.presence || agent_record.model
-      tools        = agent_record.tools
-      prompt       = leva_prompt_for(agent_record.name) || action.prompt
-      schema_class = action.schema_class
-      agent_class  = agent_record.name
-      raise ArgumentError, "Agent class not found: #{agent_class}" unless agent_class
-
-      agent = agent_class.constantize.create
-      agent = agent.with_model(model)                     if model.present? && agent.respond_to?(:with_model)
-      agent = agent.with_tools(*tools)                    if tools.present?
-      agent = agent.with_schema(schema_class.constantize) if schema_class.present?
-      agent.chat.with_instructions(prompt)                if prompt.present? && agent.respond_to?(:chat)
-      agent
+      OutputValidator.new(schema).validate!(output)
     end
 
     def leva_prompt_for(agent_class)

--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -1,0 +1,88 @@
+module Orchestration
+  class RuntimeAgentBuilder
+    def initialize(action:, chat: nil, pipeline_model: nil, prompt_override: nil, step_params: nil, tool_classes: nil)
+      @action = action
+      @chat = chat
+      @pipeline_model = pipeline_model
+      @prompt_override = prompt_override
+      @step_params = step_params || {}
+      @tool_classes = tool_classes
+    end
+
+    def build
+      agent = base_agent
+      agent = agent.with_model(resolved_model) if resolved_model.present?
+
+      tools = resolved_tools
+      agent = agent.with_tools(*tools, replace: true) if tools.present?
+
+      params = resolved_params
+      agent = agent.with_params(**params) if params.present?
+
+      schema = resolved_generation_schema
+      agent = agent.with_schema(schema) if schema.present?
+
+      prompt = resolved_prompt
+      agent.chat.with_instructions(prompt) if prompt.present?
+      agent
+    end
+
+    def resolved_output_schema
+      agent_record.output_schema.presence || @action.output_schema
+    end
+
+    private
+
+    def base_agent
+      if legacy_agent_class
+        # steep:ignore:start
+        legacy_agent_class.create
+      else
+        RubyLLM::Agent.new(chat: runtime_chat)
+        # steep:ignore:end
+      end
+    end
+
+    def runtime_chat
+      @chat || Chat.create!
+    end
+
+    def legacy_agent_class
+      klass = agent_record.name.safe_constantize
+      return klass if klass.is_a?(Class) && klass <= RubyLLM::Agent
+
+      nil
+    end
+
+    def agent_record
+      @action.agent || raise(ArgumentError, "No agent associated with action #{@action.id}")
+    end
+
+    def resolved_model
+      @pipeline_model.presence || agent_record.model.presence || @action.model
+    end
+
+    def resolved_prompt
+      @prompt_override.presence || agent_record.prompt.presence || @action.prompt
+    end
+
+    def resolved_tools
+      return @tool_classes if @tool_classes.present?
+
+      configured_tools = agent_record.tools.presence || @action.tools
+      configured_tools&.map { |tool| tool.is_a?(Class) ? tool : tool.constantize }
+    end
+
+    def resolved_params
+      base_params = agent_record.params.presence || @action.params || {}
+      base_params.merge(@step_params || {})
+    end
+
+    def resolved_generation_schema
+      return agent_record.output_schema if agent_record.output_schema.present?
+      return @action.schema_class.constantize if @action.schema_class.present?
+
+      nil
+    end
+  end
+end

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -27,6 +27,21 @@
     <% end %>
   </div>
 
+  <div>
+    <%= f.label :prompt, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :prompt, rows: 4, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+  </div>
+
+  <div>
+    <%= f.label :params, "Params (JSON object)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :params, value: agent.params.present? ? agent.params.to_json : "", rows: 3, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: '{"key":"value"}' %>
+  </div>
+
+  <div>
+    <%= f.label :output_schema, "Output schema (JSON object)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :output_schema, value: agent.output_schema.present? ? agent.output_schema.to_json : "", rows: 5, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: '{"type":"object","required":["result"]}' %>
+  </div>
+
   <div class="flex items-center gap-3 pt-2">
     <%= f.submit class: "px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
     <%= link_to "Cancel", orchestration_agents_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>

--- a/db/migrate/20260504120000_add_runtime_fields_to_orchestration_agents.rb
+++ b/db/migrate/20260504120000_add_runtime_fields_to_orchestration_agents.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddRuntimeFieldsToOrchestrationAgents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :orchestration_agents, :prompt, :text
+    add_column :orchestration_agents, :params, :json, default: {}, null: false
+    add_column :orchestration_agents, :output_schema, :json
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -144,7 +144,7 @@ FOREIGN KEY ("evaluation_result_id")
   REFERENCES "leva_evaluation_results" ("id")
 );
 CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "prompt" text /*application='ApplicationPipeline'*/, "params" json DEFAULT '{}' NOT NULL /*application='ApplicationPipeline'*/, "output_schema" json /*application='ApplicationPipeline'*/);
 CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "model" varchar, "tools" json, "prompt" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "output_schema" json, "schema_class" varchar, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, CONSTRAINT "fk_rails_951418a714"
 FOREIGN KEY ("agent_id")
@@ -153,6 +153,7 @@ FOREIGN KEY ("agent_id")
 CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_actions_on_agent_id" ON "actions" ("agent_id") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260504120000'),
 ('20260503170000'),
 ('20260503160000'),
 ('20260503140000'),

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -10,6 +10,12 @@ module Orchestration
     def model=: (String?) -> String?
     def tools: () -> Array[String]
     def tools=: (Array[String]) -> Array[String]
+    def prompt: () -> String?
+    def prompt=: (String?) -> String?
+    def params: () -> Hash[String, untyped]
+    def params=: (Hash[String, untyped]) -> Hash[String, untyped]
+    def output_schema: () -> Hash[String, untyped]?
+    def output_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def enabled: () -> bool
     def enabled=: (bool) -> bool
     def enabled?: () -> bool

--- a/sig/app/services/evaluation/stubbed_agent_run.rbs
+++ b/sig/app/services/evaluation/stubbed_agent_run.rbs
@@ -4,7 +4,7 @@ module Evaluation
 
     private
 
-    def resolve_tools: (Orchestration::Agent agent_record, Class agent_class) -> Array[Class]
+    def resolve_tools: (Orchestration::Agent agent_record) -> Array[Class]
     def stub_tool: (Class tool_class, ToolStubRegistry registry) -> Class
     def build_prediction: (untyped agent, untyped result) -> String
   end

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -11,7 +11,6 @@ module Orchestration
     def run_agent: (ActionRun action_run) -> Hash[String, untyped]
     def parse_content: (String | untyped content) -> untyped
     def validate_output!: (Action action, Hash[String, untyped] output) -> void
-    def build_agent: (Action action, Hash[String, untyped] params) -> untyped
     def leva_prompt_for: (String? agent_name) -> String?
   end
 end

--- a/sig/app/services/orchestration/runtime_agent_builder.rbs
+++ b/sig/app/services/orchestration/runtime_agent_builder.rbs
@@ -1,0 +1,26 @@
+module Orchestration
+  class RuntimeAgentBuilder
+    def initialize: (
+      action: Action,
+      ?chat: untyped,
+      ?pipeline_model: String?,
+      ?prompt_override: String?,
+      ?step_params: Hash[String, untyped]?,
+      ?tool_classes: Array[untyped]?
+    ) -> void
+    def build: () -> untyped
+    def resolved_output_schema: () -> Hash[String, untyped]?
+
+    private
+
+    def base_agent: () -> untyped
+    def runtime_chat: () -> untyped
+    def legacy_agent_class: () -> untyped
+    def agent_record: () -> Agent
+    def resolved_model: () -> String?
+    def resolved_prompt: () -> String?
+    def resolved_tools: () -> Array[untyped]?
+    def resolved_params: () -> Hash[String, untyped]
+    def resolved_generation_schema: () -> untyped
+  end
+end

--- a/spec/factories/orchestration_agents.rb
+++ b/spec/factories/orchestration_agents.rb
@@ -2,5 +2,8 @@ FactoryBot.define do
   factory :orchestration_agent, class: "Orchestration::Agent" do
     sequence(:name) { |n| "Agent::Class#{n}" }
     enabled { true }
+    prompt { nil }
+    params { {} }
+    output_schema { nil }
   end
 end

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe "Orchestration::Agents" do
         post orchestration_agents_path, params: { orchestration_agent: { name: "" } }
         expect(response).to have_http_status(:unprocessable_content)
       end
+
+      it "preserves valid JSON fields when one JSON field is invalid" do # rubocop:disable RSpec/ExampleLength
+        post orchestration_agents_path, params: {
+          orchestration_agent: {
+            name: "Emails::ClassifyAgent",
+            tools: '["Records::TempFileTool"]',
+            params: '{"mode":"strict"}',
+            output_schema: "{invalid"
+          }
+        }
+
+        agent = Orchestration::Agent.last
+        expect(agent.tools).to eq([ "Records::TempFileTool" ])
+        expect(agent.params).to eq({ "mode" => "strict" })
+        expect(agent.output_schema).to be_nil
+      end
     end
   end
 

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -28,17 +28,27 @@ RSpec.describe "Orchestration::Agents" do
             name: "Emails::ClassifyAgent",
             description: "Classifies emails",
             model: "mistral-small",
-            tools: "[]"
+            tools: "[]",
+            prompt: "Classify this payload",
+            params: '{"mode":"strict"}',
+            output_schema: '{"type":"object","required":["result"],"properties":{"result":{"type":"array"}}}'
           }
         }
       end
 
-      it "creates an agent and redirects" do
+      it "creates an agent and redirects" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
         expect {
           post orchestration_agents_path, params: valid_params
         }.to change(Orchestration::Agent, :count).by(1)
         expect(response).to redirect_to(orchestration_agents_path)
-      end
+        expect(Orchestration::Agent.last.prompt).to eq("Classify this payload")
+        expect(Orchestration::Agent.last.params).to eq({ "mode" => "strict" })
+        expect(Orchestration::Agent.last.output_schema).to eq(
+          "type" => "object",
+          "required" => [ "result" ],
+          "properties" => { "result" => { "type" => "array" } }
+        )
+      end # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
     end
 
     context "with invalid params" do

--- a/spec/services/evaluation/stubbed_agent_run_spec.rb
+++ b/spec/services/evaluation/stubbed_agent_run_spec.rb
@@ -101,6 +101,40 @@ RSpec.describe Evaluation::StubbedAgentRun do # rubocop:disable RSpec/MultipleMe
 
       runner.execute(action_run)
     end
+
+    context "with a serialized orchestration agent and no Ruby subclass" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:orchestration_agent) do
+        create(:orchestration_agent,
+               name: "Reusable email classifier",
+               model: "mistral-large-latest",
+               tools: [ "Records::TempFileTool" ],
+               output_schema: {
+                 "type" => "object",
+                 "required" => [ "results" ],
+                 "properties" => {
+                   "results" => {
+                     "type" => "array",
+                     "items" => {
+                       "type" => "object",
+                       "required" => [ "id" ],
+                       "properties" => {
+                         "id" => { "type" => "string" },
+                         "tags" => { "type" => "array", "items" => { "type" => "string" } }
+                       }
+                     }
+                   }
+                 }
+               })
+      end
+
+      it "replays the configured tools and structured output through the generic runtime" do
+        result = runner.execute(action_run)
+        parsed = JSON.parse(result)
+
+        expect(parsed["tool_calls"].first["tool_name"]).to eq("temp_file")
+        expect(parsed["output"]).to eq(JSON.parse(final_output))
+      end
+    end
   end
 
   describe "#stub_tool" do # rubocop:disable RSpec/MultipleMemoizedHelpers

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Orchestration::PipelineRunner do
         action_run = Orchestration::ActionRun.last
         expect(action_run.chat_id).to eq(chat.id)
       end
+
+      it 'does not create an extra Chat record before building a legacy agent' do
+        allow(Chat).to receive(:create!)
+
+        described_class.new(pipeline_run).call
+
+        expect(Chat).not_to have_received(:create!)
+      end
     end
 
     context 'when the pipeline has a model set' do

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -97,6 +97,79 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
+    context 'with a serialized orchestration agent configuration' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:serialized_chat) { create(:chat) }
+      let(:serialized_agent) do
+        instance_double(RubyLLM::Agent, chat: serialized_chat, params: {})
+      end
+
+      before do
+        action.agent.update!(
+          name: "Reusable email classifier",
+          model: "mistral-small",
+          tools: [ "Records::TempFileTool" ],
+          prompt: "Classify incoming emails",
+          params: { "mode" => "default", "limit" => 1 },
+          output_schema: {
+            "type" => "object",
+            "required" => [ "result" ],
+            "properties" => {
+              "result" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "object",
+                  "required" => [ "id" ],
+                  "properties" => {
+                    "id" => { "type" => "string" }
+                  }
+                }
+              }
+            }
+          }
+        )
+        create(:orchestration_step_action, step: step1, action: action, position: 1, params: { "limit" => 2 })
+        allow(RubyLLM::Agent).to receive(:new).and_return(serialized_agent)
+        allow(serialized_chat).to receive(:with_instructions)
+        allow(serialized_agent).to receive_messages(with_model: serialized_agent, with_tools: serialized_agent, with_params: serialized_agent, with_schema: serialized_agent, ask: instance_double(RubyLLM::Message, content: { "result" => [ { "id" => "mail-1" } ] }))
+      end
+
+      it 'executes without relying on a Ruby agent subclass' do
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+
+        expect(RubyLLM::Agent).to have_received(:new)
+        expect(action_run.status).to eq("completed")
+        expect(action_run.output).to eq({ "result" => [ { "id" => "mail-1" } ] })
+      end
+
+      it 'applies agent defaults and lets step params override them' do
+        described_class.new(pipeline_run).call
+
+        expect(serialized_agent).to have_received(:with_params).with("mode" => "default", "limit" => 2)
+      end
+
+      it 'uses the database output schema for structured output requests' do # rubocop:disable RSpec/ExampleLength
+        described_class.new(pipeline_run).call
+
+        expect(serialized_agent).to have_received(:with_schema).with(
+          "type" => "object",
+          "required" => [ "result" ],
+          "properties" => {
+            "result" => {
+              "type" => "array",
+              "items" => {
+                "type" => "object",
+                "required" => [ "id" ],
+                "properties" => {
+                  "id" => { "type" => "string" }
+                }
+              }
+            }
+          }
+        )
+      end
+    end
+
     context 'when an Orchestration::Prompt exists for the agent class' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
@@ -278,8 +351,7 @@ RSpec.describe Orchestration::PipelineRunner do
                                         "properties" => { "result" => { "type" => "array" } } })
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         # agent returns a natural-language string — not parseable as a JSON array
-        allow(stub_agent).to receive(:ask)
-          .and_return(instance_double(RubyLLM::Message, content: "I need more information."))
+        allow(stub_agent).to receive_messages(with_schema: stub_agent, ask: instance_double(RubyLLM::Message, content: "I need more information."))
       end
 
       it 'marks the ActionRun as failed with a schema error' do
@@ -295,13 +367,32 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
+    context 'when the agent has an output_schema and the output is invalid' do
+      before do
+        action.agent.update!(name: "Reusable email classifier",
+                             output_schema: { "type" => "object", "required" => [ "result" ],
+                                              "properties" => { "result" => { "type" => "array" } } })
+        create(:orchestration_step_action, step: step1, action: action, position: 1)
+        generic_agent = instance_double(RubyLLM::Agent, chat: create(:chat), params: {})
+        allow(RubyLLM::Agent).to receive(:new).and_return(generic_agent)
+        allow(generic_agent).to receive_messages(with_schema: generic_agent, ask: instance_double(RubyLLM::Message, content: { "result" => "not an array" }))
+      end
+
+      it 'marks the ActionRun as failed with a schema error from the agent record' do
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+
+        expect(action_run.status).to eq("failed")
+        expect(action_run.error).to match(/must be an array/)
+      end
+    end
+
     context 'when the action has an output_schema and the output is valid JSON' do
       before do
         action.update!(output_schema: { "type" => "object", "required" => [ "result" ],
                                         "properties" => { "result" => { "type" => "array" } } })
         create(:orchestration_step_action, step: step1, action: action, position: 1)
-        allow(stub_agent).to receive(:ask)
-          .and_return(instance_double(RubyLLM::Message, content: '[{"id":1}]'))
+        allow(stub_agent).to receive_messages(with_schema: stub_agent, ask: instance_double(RubyLLM::Message, content: '[{"id":1}]'))
       end
 
       it 'marks the ActionRun as completed with the parsed JSON result' do


### PR DESCRIPTION
## Summary
- add runtime fields to orchestration agents for prompts, params, and output schemas
- build agent-backed runs through a shared runtime builder that supports database-defined agents and legacy class-backed agents
- update agent CRUD, pipeline execution, and stubbed replay coverage for generic agent runs

Closes #36

## Test plan
- bundle exec rubocop --parallel
- bundle exec steep check
- bundle exec rspec
- bundle exec brakeman --no-pager