### PR TITLE
feat: preserve action run history with agent snapshots

### DIFF
--- a/app/models/orchestration/action_run.rb
+++ b/app/models/orchestration/action_run.rb
@@ -32,6 +32,7 @@ module Orchestration
         input: input,
         output: output,
         error: error,
+        agent_snapshot: agent_snapshot,
         started_at: started_at,
         finished_at: finished_at
       }

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -82,7 +82,7 @@ module Orchestration
         )
         agent = builder.build
         chat_id = agent.respond_to?(:chat) ? agent.chat&.id : agent.id
-        action_run.update_column(:chat_id, chat_id)
+        action_run.update_columns(chat_id: chat_id, agent_snapshot: builder.snapshot)
         result = agent.ask(input.to_json)
         output = parse_content(result.content)
         action.agent&.output_schema.present? ? output : { "result" => output }

--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -31,6 +31,16 @@ module Orchestration
       agent_record.output_schema.presence || @action.output_schema
     end
 
+    def snapshot
+      {
+        model: resolved_model,
+        prompt: resolved_prompt,
+        tools: resolved_tools&.map(&:to_s),
+        params: resolved_params,
+        output_schema: resolved_output_schema
+      }
+    end
+
     private
 
     def base_agent

--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -35,7 +35,7 @@ module Orchestration
       {
         model: resolved_model,
         prompt: resolved_prompt,
-        tools: resolved_tools&.map(&:to_s),
+        tools: resolved_tools&.map(&:to_s) || [],
         params: resolved_params,
         output_schema: resolved_output_schema
       }

--- a/db/migrate/20260504130000_add_agent_snapshot_to_action_runs.rb
+++ b/db/migrate/20260504130000_add_agent_snapshot_to_action_runs.rb
@@ -1,0 +1,5 @@
+class AddAgentSnapshotToActionRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :action_runs, :agent_snapshot, :json
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -69,7 +69,7 @@ CREATE INDEX "index_pipeline_runs_on_pipeline_id_and_created_at" ON "pipeline_ru
 CREATE TABLE IF NOT EXISTS "pipelines" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "cron_expression" varchar, "model" varchar /*application='ApplicationPipeline'*/, "initial_input_schema" json /*application='ApplicationPipeline'*/);
 CREATE INDEX "index_pipelines_on_enabled_and_cron_expression" ON "pipelines" ("enabled", "cron_expression") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "ruby_llm_monitoring_events" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "allocations" integer, "cost" float, "cpu_time" float, "duration" float, "end" float, "gc_time" float, "idle_time" float, "name" varchar, "payload" json, "time" float, "transaction_id" varchar, "provider" varchar GENERATED ALWAYS AS (payload->>'provider') STORED, "model" varchar GENERATED ALWAYS AS (payload->>'model') STORED, "input_tokens" integer GENERATED ALWAYS AS (CAST(payload->>'input_tokens' AS INTEGER)) STORED, "output_tokens" integer GENERATED ALWAYS AS (CAST(payload->>'output_tokens' AS INTEGER)) STORED, "exception_class" varchar GENERATED ALWAYS AS (json_extract(payload, '$.exception[0]')) STORED, "exception_message" varchar GENERATED ALWAYS AS (json_extract(payload, '$.exception[1]')) STORED, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "thinking_tokens" integer GENERATED ALWAYS AS (CAST(payload->>'thinking_tokens' AS INTEGER)) STORED);
-CREATE TABLE IF NOT EXISTS "action_runs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_run_id" integer NOT NULL, "step_action_id" integer NOT NULL, "status" varchar DEFAULT 'pending' NOT NULL, "input" json, "output" json, "error" text, "started_at" datetime(6), "finished_at" datetime(6), "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "chat_id" integer, CONSTRAINT "fk_rails_98c536e7ea"
+CREATE TABLE IF NOT EXISTS "action_runs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_run_id" integer NOT NULL, "step_action_id" integer NOT NULL, "status" varchar DEFAULT 'pending' NOT NULL, "input" json, "output" json, "error" text, "started_at" datetime(6), "finished_at" datetime(6), "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "chat_id" integer, "agent_snapshot" json /*application='ApplicationPipeline'*/, CONSTRAINT "fk_rails_98c536e7ea"
 FOREIGN KEY ("step_action_id")
   REFERENCES "step_actions" ("id")
 , CONSTRAINT "fk_rails_e54391b086"
@@ -153,6 +153,7 @@ FOREIGN KEY ("agent_id")
 CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_actions_on_agent_id" ON "actions" ("agent_id") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260504130000'),
 ('20260504120000'),
 ('20260503170000'),
 ('20260503160000'),

--- a/sig/app/models/orchestration/action_run.rbs
+++ b/sig/app/models/orchestration/action_run.rbs
@@ -10,6 +10,8 @@ module Orchestration
     def input=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def output: () -> Hash[String, untyped]?
     def output=: (Hash[String, untyped]?) -> Hash[String, untyped]?
+    def agent_snapshot: () -> Hash[String, untyped]?
+    def agent_snapshot=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def error: () -> String?
     def error=: (String?) -> String?
     def started_at: () -> Time?

--- a/sig/app/services/orchestration/runtime_agent_builder.rbs
+++ b/sig/app/services/orchestration/runtime_agent_builder.rbs
@@ -10,6 +10,7 @@ module Orchestration
     ) -> void
     def build: () -> untyped
     def resolved_output_schema: () -> Hash[String, untyped]?
+    def snapshot: () -> Hash[Symbol, untyped]
 
     private
 

--- a/sig/app/services/orchestration/runtime_agent_builder.rbs
+++ b/sig/app/services/orchestration/runtime_agent_builder.rbs
@@ -10,6 +10,7 @@ module Orchestration
     ) -> void
     def build: () -> untyped
     def resolved_output_schema: () -> Hash[String, untyped]?
+    # Returns symbol-keyed hash at runtime; keys become strings after JSON round-trip on ActionRun#agent_snapshot.
     def snapshot: () -> Hash[Symbol, untyped]
 
     private

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -178,6 +178,56 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
+    context 'with agent snapshot persistence' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:agent_record) do
+        action.agent.tap do |a|
+          a.update!(
+            name: "Reusable email classifier",
+            model: "mistral-small",
+            tools: [ "Records::TempFileTool" ],
+            prompt: "Classify incoming emails",
+            params: { "mode" => "default" }
+          )
+        end
+      end
+      let(:snapshot_agent) { instance_double(RubyLLM::Agent, chat: create(:chat), params: {}) }
+
+      before do
+        agent_record
+        create(:orchestration_step_action, step: step1, action: action, position: 1, params: { "limit" => 2 })
+        allow(RubyLLM::Agent).to receive(:new).and_return(snapshot_agent)
+        allow(snapshot_agent).to receive_messages(
+          with_model: snapshot_agent, with_tools: snapshot_agent,
+          with_params: snapshot_agent, with_schema: snapshot_agent,
+          ask: instance_double(RubyLLM::Message, content: "result")
+        )
+        allow(snapshot_agent.chat).to receive(:with_instructions)
+      end
+
+      it 'persists a resolved agent_snapshot on the action_run' do
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+
+        expect(action_run.agent_snapshot).to include(
+          "model" => "mistral-small",
+          "prompt" => "Classify incoming emails",
+          "tools" => [ "Records::TempFileTool" ],
+          "params" => { "mode" => "default", "limit" => 2 }
+        )
+      end
+
+      it 'does not mutate historical snapshots when the agent is later edited' do
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+        original_snapshot = action_run.agent_snapshot.dup
+
+        agent_record.update!(model: "mistral-large", prompt: "Updated prompt")
+        action_run.reload
+
+        expect(action_run.agent_snapshot).to eq(original_snapshot)
+      end
+    end
+
     context 'when an Orchestration::Prompt exists for the agent class' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
@@ -259,6 +309,13 @@ RSpec.describe Orchestration::PipelineRunner do
         action_run = Orchestration::ActionRun.last
         expect(action_run.status).to eq("completed")
         expect(action_run.output).to eq({ "emails" => [] })
+      end
+
+      it 'does not persist an agent_snapshot for service-backed runs' do
+        allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+        expect(action_run.agent_snapshot).to be_nil
       end
     end
 

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Orchestration::RuntimeAgentBuilder do
+  subject(:builder) do
+    described_class.new(
+      action: action,
+      pipeline_model: "mistral-large",
+      step_params: { "limit" => 5 }
+    )
+  end
+
+  let(:agent_record) do
+    create(:orchestration_agent,
+           name: "Reusable Classifier",
+           model: "mistral-small",
+           tools: [ "Records::TempFileTool" ],
+           prompt: "Classify this email",
+           params: { "mode" => "fast" },
+           output_schema: { "type" => "object" })
+  end
+  let(:action) { create(:orchestration_action, agent: agent_record) }
+
+
+  describe '#snapshot' do
+    it 'returns a hash with the resolved model' do
+      expect(builder.snapshot[:model]).to eq("mistral-large")
+    end
+
+    it 'falls back to the agent model when pipeline model is absent' do
+      builder_no_pipeline_model = described_class.new(action: action)
+      expect(builder_no_pipeline_model.snapshot[:model]).to eq("mistral-small")
+    end
+
+    it 'returns the resolved prompt' do
+      expect(builder.snapshot[:prompt]).to eq("Classify this email")
+    end
+
+    it 'returns tools as an array of strings' do
+      expect(builder.snapshot[:tools]).to eq([ "Records::TempFileTool" ])
+    end
+
+    it 'returns merged params (agent defaults overridden by step params)' do
+      expect(builder.snapshot[:params]).to eq({ "mode" => "fast", "limit" => 5 })
+    end
+
+    it 'returns the output schema' do
+      expect(builder.snapshot[:output_schema]).to eq({ "type" => "object" })
+    end
+  end
+end

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
   end
   let(:action) { create(:orchestration_action, agent: agent_record) }
 
-
   describe '#snapshot' do
     it 'returns a hash with the resolved model' do
       expect(builder.snapshot[:model]).to eq("mistral-large")


### PR DESCRIPTION
## Summary
- Adds `agent_snapshot` JSON column to `action_runs` to store resolved config at run time
- `RuntimeAgentBuilder#snapshot` captures model, prompt, tools, params, and output_schema
- `PipelineRunner` persists the snapshot on every agent-backed run; service-backed runs leave it nil

Closes #37

## Test plan
- [x] `RuntimeAgentBuilder#snapshot` returns all resolved fields (6 new examples)
- [x] `PipelineRunner` persists `agent_snapshot` on agent-backed action runs
- [x] Historical snapshot is immutable after agent edits
- [x] Service-backed runs have nil `agent_snapshot`
- [x] All existing tests still pass (319 service/model examples, 0 failures)
- [x] RuboCop, Steep type check, and Brakeman pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)