### PR TITLE
feat: backfill agent configs and remove legacy class fallback

### DIFF
--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -44,24 +44,13 @@ module Orchestration
     private
 
     def base_agent
-      if legacy_agent_class
-        # steep:ignore:start
-        legacy_agent_class.create
-      else
-        RubyLLM::Agent.new(chat: runtime_chat)
-        # steep:ignore:end
-      end
+      # steep:ignore:start
+      RubyLLM::Agent.new(chat: runtime_chat)
+      # steep:ignore:end
     end
 
     def runtime_chat
       @chat || Chat.create!
-    end
-
-    def legacy_agent_class
-      klass = agent_record.name.safe_constantize
-      return klass if klass.is_a?(Class) && klass <= RubyLLM::Agent
-
-      nil
     end
 
     def agent_record

--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -69,7 +69,18 @@ module Orchestration
       return @tool_classes if @tool_classes.present?
 
       configured_tools = agent_record.tools.presence || @action.tools
-      configured_tools&.map { |tool| tool.is_a?(Class) ? tool : tool.constantize }
+      configured_tools&.map do |tool|
+        next tool if tool.is_a?(Class)
+
+        namespace = tool.to_s.split("::").first
+        unless Orchestration::Agent::ALLOWED_TOOL_NAMESPACES.include?(namespace)
+          raise ArgumentError, "Tool '#{tool}' is outside allowed namespaces (#{Orchestration::Agent::ALLOWED_TOOL_NAMESPACES.join(', ')})"
+        end
+
+        tool.constantize
+      rescue NameError
+        raise ArgumentError, "Unknown tool class: #{tool}"
+      end
     end
 
     def resolved_params

--- a/db/migrate/20260504140000_backfill_agent_configs_from_legacy_classes.rb
+++ b/db/migrate/20260504140000_backfill_agent_configs_from_legacy_classes.rb
@@ -4,6 +4,10 @@ class BackfillAgentConfigsFromLegacyClasses < ActiveRecord::Migration[8.1]
   # Backfills model, tools, and prompt for agents that previously relied on hardcoded Ruby subclasses.
   # output_schema is intentionally omitted: the runner wraps agent output in { "result" => ... }
   # when agent.output_schema is nil, and downstream steps depend on that "result.*" path convention.
+  #
+  # IMPORTANT: Keep these configs in sync with AGENT_DEFINITIONS in db/seeds.rb.
+  # Prompt or tool changes must be applied in both places: seeds.rb controls fresh installs,
+  # this migration covers existing installations.
   AGENT_CONFIGS = {
     "Emails::ClassifyAgent" => {
       model:  "mistral-large-latest",
@@ -171,7 +175,7 @@ class BackfillAgentConfigsFromLegacyClasses < ActiveRecord::Migration[8.1]
     AGENT_CONFIGS.each_key do |name|
       execute(<<~SQL)
         UPDATE orchestration_agents
-        SET model = NULL, tools = '[]', prompt = NULL
+        SET model = NULL, tools = NULL, prompt = NULL
         WHERE name = #{quote(name)}
       SQL
     end

--- a/db/migrate/20260504140000_backfill_agent_configs_from_legacy_classes.rb
+++ b/db/migrate/20260504140000_backfill_agent_configs_from_legacy_classes.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+class BackfillAgentConfigsFromLegacyClasses < ActiveRecord::Migration[8.1]
+  # Backfills model, tools, and prompt for agents that previously relied on hardcoded Ruby subclasses.
+  # output_schema is intentionally omitted: the runner wraps agent output in { "result" => ... }
+  # when agent.output_schema is nil, and downstream steps depend on that "result.*" path convention.
+  AGENT_CONFIGS = {
+    "Emails::ClassifyAgent" => {
+      model:  "mistral-large-latest",
+      tools:  [ "Records::TempFileTool" ],
+      prompt: <<~PROMPT
+        You are an email classifier. Your job is to tag a list of emails by their subject lines and return suggested tags.
+
+        Input:
+        {
+          "emails": [
+            {"id": "id of email", "subject": "Email subject line"}
+          ]
+        }
+
+        Steps:
+        1. For each email, analyze the subject line and suggest short lowercase classification tags that are relevant to the content of the email.
+          Tags should be concise and descriptive (e.g. "job", "application", "interview", "offer").
+      PROMPT
+    },
+    "Emails::FilterAgent" => {
+      model:  "mistral-large-latest",
+      tools:  [ "Records::TempFileTool" ],
+      prompt: <<~PROMPT
+        You are an email filtering expert. Your job is to identify <emails> from a list related to a <topic>.
+
+        Input:
+        {
+          "topic": "The topic to filter by (e.g. 'job applications')",
+          "emails": [
+            {"id": "id of email", "subject": "Email subject line", "tags": ["list", "of", "classification", "tags"] }
+          ]
+        }
+
+        Steps:
+        3. Return ONLY emails tagged with ANY of tags related to the <topic>
+          (e.g. for "job applications" topic, tags might include "job", "application", "interview", "offer", etc.).
+
+        If no emails related to the <topic> are found, return an empty JSON array: []
+      PROMPT
+    },
+    "Emails::MappingAgent" => {
+      model:  "mistral-large-latest",
+      tools:  [ "Emails::GetTool", "Records::TempFileTool" ],
+      prompt: <<~PROMPT
+        Your task is to map raw email data to a structured format for database insertion.
+
+        Input:
+        {
+          "emails": ["list", "of", "emails", "to", "process"],
+        }
+
+        Steps:
+        1. For each email in <emails>, call get_email to fetch its full content — this is mandatory before mapping any field.
+        2. After reading the full email content, extract and map all required fields.
+        3. Base the "action" field strictly on the email body text, not just the subject line.
+      PROMPT
+    },
+    "Records::StoreAgent" => {
+      model:  "mistral-large-latest",
+      tools:  [ "Emails::GetLabelsTool", "Emails::CreateLabelTool", "Emails::AddLabelsTool",
+                "Records::InsertRowsTool", "Records::ReadSchemaTool", "Emails::GetTool" ],
+      prompt: <<~PROMPT
+        You are a emails processor. For each email you receive:
+
+        Input:
+        {
+          "label": "The label to add to the email in its provider (e.g. 'applications')",
+          "table": "The name of the database table to insert a row into (e.g. 'application_mails')",
+          "emails": [ "list", "of", "emails", "to", "process" ]
+        }
+
+        Steps:
+        1. Check if <label> already exists in the email provider using get_labels tool.
+          If not, create it using create_label tool.
+
+        2. Call add_labels to label the email in its provider:
+           If add_labels fails, skip labeling but continue processing.
+
+        3. Store a new row in the <table> with the mapped data using insert_rows.
+      PROMPT
+    },
+    "Records::NormalizeAgent" => {
+      model:  "gpt-5.1",
+      tools:  [ "Records::ListRowsTool", "Records::ReadRowsTool", "Records::UpdateRowsTool",
+                "Records::ReadSchemaTool", "Records::SearchSimilarTool" ],
+      prompt: <<~PROMPT
+        You are a database record normalizer. Your task is to unify the format of the data in the <destination_table> and propagate known values to records where they are missing.
+
+        Input:
+          {
+            "records_to_normalize": ["list", "of", "records", "to", "process"],
+            "destination_table": "The name of the database table for normalization.",
+            "columns_to_normalize": ["list", "of", "columns", "to", "normalize"] (e.g. ["company", "job_title"]),
+          }
+
+        A field is considered missing if its value is null, an empty string, "unknown", "n/a", or any other placeholder.
+
+        Steps:
+        1. Read the schema of the <destination_table> to understand its structure.
+        2. For each record in <records_to_normalize>, for each column in <columns_to_normalize>:
+           a. If the field is populated: use search_similar to find all variant spellings of that value in the table.
+              Choose the most canonical form among the variants (e.g. shortest non-abbreviated, non-suffixed form).
+              (e.g. "Google Inc." → "Google", "SWE" → "Software Engineer").
+           b. If the field is missing: look at the record's other populated columns (e.g. company when job_title is missing, or vice versa)
+              and call search_similar on those to find sibling records that share the same context and DO have the missing field populated.
+              Use the most common or canonical value found among those siblings to fill in the gap.
+        3. Update all rows where a normalized or propagated value was determined using update_rows, matching on row ID and updating only the affected columns.
+           Skip rows where no new value could be determined.
+      PROMPT
+    },
+    "Records::ReconcileAgent" => {
+      model:  "gpt-5.1",
+      tools:  [ "Records::ReadSchemaTool", "Records::TempFileTool", "Records::SearchSimilarTool",
+                "Records::InsertRowsTool", "Records::UpdateRowsTool", "Records::ReadRowsTool" ],
+      prompt: <<~PROMPT
+        You are a job application lifecycle tracker. Update the <destination_table> records based on <emailsto_reconcile>.
+        For each of the given <emailsto_reconcile>.
+
+        Input:
+          {
+            "statuses": ["list", "of", "allowed", "status", "values"],
+            "initial_status"": "The status to set for new records",
+            "destination_table": "The name of the database table for normalization.",
+            "matching_columns": ["list", "of", "columns", "to", "match"] (e.g. ["company", "job_title"]),
+            "emailsto_reconcile": ["list", "of", "columns", "to", "normalize"] (e.g. ["company", "job_title"]),
+          }
+
+        Steps:
+        2. Read the schema of the <destination_table> to understand its structure.
+        3. Read the rows from <destination_table>.
+        4. Match <emailsto_reconcile> to existing records in <destination_table> based on the <matching_logic>.
+        5. Skip <emailsto_reconcile> that have already been processed.
+        6. Set 'unknown' for any blank or missing fields.
+        7. For each unique <matching_columns> in the new rows:
+
+            If NOT in <destination_table> → add_rows with:
+              status=<initial_status>.
+
+            If ALREADY in <destination_table> → update_rows (match on <matching_columns> via
+              column_name: "<matching_columns>", then use data to set fields in schema, and update status based on changes
+
+        Date fallback rule:
+          If applied_at is missing or blank for a record, but any other date column is set
+          (e.g. rejected_at, first_interview_at, second_interview_at, etc.), set applied_at
+          to the earliest non-null date among those columns.
+      PROMPT
+    }
+  }.freeze
+
+  def up
+    AGENT_CONFIGS.each do |name, config|
+      execute(<<~SQL)
+        UPDATE orchestration_agents
+        SET
+          model  = #{quote(config[:model])},
+          tools  = #{quote(config[:tools].to_json)},
+          prompt = #{quote(config[:prompt])}
+        WHERE name = #{quote(name)}
+          AND (model IS NULL OR model = '')
+      SQL
+    end
+  end
+
+  def down
+    AGENT_CONFIGS.each_key do |name|
+      execute(<<~SQL)
+        UPDATE orchestration_agents
+        SET model = NULL, tools = '[]', prompt = NULL
+        WHERE name = #{quote(name)}
+      SQL
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,6 +51,158 @@ RECONCILE_EMAILS_INPUT_MAPPING = {
   "initial_status"      => { "value" => "pending_reply" }
 }.freeze
 
+# Agent runtime configs — model, tools, and prompt only.
+# output_schema is intentionally omitted here: the runner wraps agent output in { "result" => ... }
+# when agent.output_schema is nil, and downstream steps depend on that "result.*" path convention.
+AGENT_DEFINITIONS = {
+  "Emails::ClassifyAgent" => {
+    model:  "mistral-large-latest",
+    tools:  [ "Records::TempFileTool" ],
+    prompt: <<~PROMPT
+      You are an email classifier. Your job is to tag a list of emails by their subject lines and return suggested tags.
+
+      Input:
+      {
+        "emails": [
+          {"id": "id of email", "subject": "Email subject line"}
+        ]
+      }
+
+      Steps:
+      1. For each email, analyze the subject line and suggest short lowercase classification tags that are relevant to the content of the email.
+        Tags should be concise and descriptive (e.g. "job", "application", "interview", "offer").
+    PROMPT
+  },
+  "Emails::FilterAgent" => {
+    model:  "mistral-large-latest",
+    tools:  [ "Records::TempFileTool" ],
+    prompt: <<~PROMPT
+      You are an email filtering expert. Your job is to identify <emails> from a list related to a <topic>.
+
+      Input:
+      {
+        "topic": "The topic to filter by (e.g. 'job applications')",
+        "emails": [
+          {"id": "id of email", "subject": "Email subject line", "tags": ["list", "of", "classification", "tags"] }
+        ]
+      }
+
+      Steps:
+      3. Return ONLY emails tagged with ANY of tags related to the <topic>
+        (e.g. for "job applications" topic, tags might include "job", "application", "interview", "offer", etc.).
+
+      If no emails related to the <topic> are found, return an empty JSON array: []
+    PROMPT
+  },
+  "Emails::MappingAgent" => {
+    model:  "mistral-large-latest",
+    tools:  [ "Emails::GetTool", "Records::TempFileTool" ],
+    prompt: <<~PROMPT
+      Your task is to map raw email data to a structured format for database insertion.
+
+      Input:
+      {
+        "emails": ["list", "of", "emails", "to", "process"],
+      }
+
+      Steps:
+      1. For each email in <emails>, call get_email to fetch its full content — this is mandatory before mapping any field.
+      2. After reading the full email content, extract and map all required fields.
+      3. Base the "action" field strictly on the email body text, not just the subject line.
+    PROMPT
+  },
+  "Records::StoreAgent" => {
+    model:  "mistral-large-latest",
+    tools:  [ "Emails::GetLabelsTool", "Emails::CreateLabelTool", "Emails::AddLabelsTool",
+              "Records::InsertRowsTool", "Records::ReadSchemaTool", "Emails::GetTool" ],
+    prompt: <<~PROMPT
+      You are a emails processor. For each email you receive:
+
+      Input:
+      {
+        "label": "The label to add to the email in its provider (e.g. 'applications')",
+        "table": "The name of the database table to insert a row into (e.g. 'application_mails')",
+        "emails": [ "list", "of", "emails", "to", "process" ]
+      }
+
+      Steps:
+      1. Check if <label> already exists in the email provider using get_labels tool.
+        If not, create it using create_label tool.
+
+      2. Call add_labels to label the email in its provider:
+         If add_labels fails, skip labeling but continue processing.
+
+      3. Store a new row in the <table> with the mapped data using insert_rows.
+    PROMPT
+  },
+  "Records::NormalizeAgent" => {
+    model:  "gpt-5.1",
+    tools:  [ "Records::ListRowsTool", "Records::ReadRowsTool", "Records::UpdateRowsTool",
+              "Records::ReadSchemaTool", "Records::SearchSimilarTool" ],
+    prompt: <<~PROMPT
+      You are a database record normalizer. Your task is to unify the format of the data in the <destination_table> and propagate known values to records where they are missing.
+
+      Input:
+        {
+          "records_to_normalize": ["list", "of", "records", "to", "process"],
+          "destination_table": "The name of the database table for normalization.",
+          "columns_to_normalize": ["list", "of", "columns", "to", "normalize"] (e.g. ["company", "job_title"]),
+        }
+
+      A field is considered missing if its value is null, an empty string, "unknown", "n/a", or any other placeholder.
+
+      Steps:
+      1. Read the schema of the <destination_table> to understand its structure.
+      2. For each record in <records_to_normalize>, for each column in <columns_to_normalize>:
+         a. If the field is populated: use search_similar to find all variant spellings of that value in the table.
+            Choose the most canonical form among the variants (e.g. shortest non-abbreviated, non-suffixed form).
+            (e.g. "Google Inc." → "Google", "SWE" → "Software Engineer").
+         b. If the field is missing: look at the record's other populated columns (e.g. company when job_title is missing, or vice versa)
+            and call search_similar on those to find sibling records that share the same context and DO have the missing field populated.
+            Use the most common or canonical value found among those siblings to fill in the gap.
+      3. Update all rows where a normalized or propagated value was determined using update_rows, matching on row ID and updating only the affected columns.
+         Skip rows where no new value could be determined.
+    PROMPT
+  },
+  "Records::ReconcileAgent" => {
+    model:  "gpt-5.1",
+    tools:  [ "Records::ReadSchemaTool", "Records::TempFileTool", "Records::SearchSimilarTool",
+              "Records::InsertRowsTool", "Records::UpdateRowsTool", "Records::ReadRowsTool" ],
+    prompt: <<~PROMPT
+      You are a job application lifecycle tracker. Update the <destination_table> records based on <emailsto_reconcile>.
+      For each of the given <emailsto_reconcile>.
+
+      Input:
+        {
+          "statuses": ["list", "of", "allowed", "status", "values"],
+          "initial_status"": "The status to set for new records",
+          "destination_table": "The name of the database table for normalization.",
+          "matching_columns": ["list", "of", "columns", "to", "match"] (e.g. ["company", "job_title"]),
+          "emailsto_reconcile": ["list", "of", "columns", "to", "normalize"] (e.g. ["company", "job_title"]),
+        }
+
+      Steps:
+      2. Read the schema of the <destination_table> to understand its structure.
+      3. Read the rows from <destination_table>.
+      4. Match <emailsto_reconcile> to existing records in <destination_table> based on the <matching_logic>.
+      5. Skip <emailsto_reconcile> that have already been processed.
+      6. Set 'unknown' for any blank or missing fields.
+      7. For each unique <matching_columns> in the new rows:
+
+          If NOT in <destination_table> → add_rows with:
+            status=<initial_status>.
+
+          If ALREADY in <destination_table> → update_rows (match on <matching_columns> via
+            column_name: "<matching_columns>", then use data to set fields in schema, and update status based on changes
+
+      Date fallback rule:
+        If applied_at is missing or blank for a record, but any other date column is set
+        (e.g. rejected_at, first_interview_at, second_interview_at, etc.), set applied_at
+        to the earliest non-null date among those columns.
+    PROMPT
+  }
+}.freeze
+
 steps = [
   { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor"                                                                              },
   { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent"                                                                               },
@@ -68,7 +220,13 @@ Orchestration::Action.where(name: "Merge Email Records").destroy_all
 
 action_records = steps.map do |attrs|
   agent_record = if attrs[:kind] == :agent
-    Orchestration::Agent.find_or_create_by!(name: attrs[:agent_name])
+    agent_config = AGENT_DEFINITIONS[attrs[:agent_name]] || {}
+    Orchestration::Agent.find_or_initialize_by(name: attrs[:agent_name]).tap do |a|
+      a.model  = agent_config[:model]  if agent_config[:model].present?
+      a.tools  = agent_config[:tools]  if agent_config[:tools].present?
+      a.prompt = agent_config[:prompt] if agent_config[:prompt].present?
+      a.save!
+    end
   end
 
   Orchestration::Action.find_or_initialize_by(name: attrs[:name]).tap do |a|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,6 +54,10 @@ RECONCILE_EMAILS_INPUT_MAPPING = {
 # Agent runtime configs — model, tools, and prompt only.
 # output_schema is intentionally omitted here: the runner wraps agent output in { "result" => ... }
 # when agent.output_schema is nil, and downstream steps depend on that "result.*" path convention.
+#
+# IMPORTANT: Keep these configs in sync with AGENT_CONFIGS in
+# db/migrate/20260504140000_backfill_agent_configs_from_legacy_classes.rb.
+# Seeds cover fresh installs; the migration covers existing installations.
 AGENT_DEFINITIONS = {
   "Emails::ClassifyAgent" => {
     model:  "mistral-large-latest",

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -153,6 +153,7 @@ FOREIGN KEY ("agent_id")
 CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_actions_on_agent_id" ON "actions" ("agent_id") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260504140000'),
 ('20260504130000'),
 ('20260504120000'),
 ('20260503170000'),

--- a/sig/app/controllers/orchestration/agents_controller.rbs
+++ b/sig/app/controllers/orchestration/agents_controller.rbs
@@ -1,0 +1,21 @@
+module Orchestration
+  class AgentsController < ApplicationController
+    include JsonParamsParsing
+
+    def index: () -> void
+    def new: () -> void
+    def create: () -> void
+    def edit: () -> void
+    def update: () -> void
+    def destroy: () -> void
+    def toggle: () -> void
+
+    private
+
+    def set_agent: () -> void
+    def agent_params: () -> ActionController::Parameters
+    def persist_agent: (Agent agent) -> bool
+    def parse_agent_json_field: (ActionController::Parameters permitted, Symbol key, expected: String) -> void
+    def attach_json_parse_errors: (Agent agent) -> void
+  end
+end

--- a/sig/app/services/orchestration/runtime_agent_builder.rbs
+++ b/sig/app/services/orchestration/runtime_agent_builder.rbs
@@ -17,7 +17,6 @@ module Orchestration
 
     def base_agent: () -> untyped
     def runtime_chat: () -> untyped
-    def legacy_agent_class: () -> untyped
     def agent_record: () -> Agent
     def resolved_model: () -> String?
     def resolved_prompt: () -> String?

--- a/spec/db/seeds_agent_backfill_spec.rb
+++ b/spec/db/seeds_agent_backfill_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe "Seeds: agent config backfill" do # rubocop:disable RSpec/Describ
     "Emails::ClassifyAgent"  => { model: "mistral-large-latest", tools: [ "Records::TempFileTool" ] },
     "Emails::FilterAgent"    => { model: "mistral-large-latest", tools: [ "Records::TempFileTool" ] },
     "Emails::MappingAgent"   => { model: "mistral-large-latest", tools: [ "Emails::GetTool", "Records::TempFileTool" ] },
-    "Records::StoreAgent"    => { model: "mistral-large-latest", tools: [ "Records::InsertRowsTool" ] },
-    "Records::NormalizeAgent" => { model: "gpt-5.1",            tools: [ "Records::SearchSimilarTool" ] },
-    "Records::ReconcileAgent" => { model: "gpt-5.1",            tools: [ "Records::ReadSchemaTool" ] }
+    "Records::StoreAgent"    => { model: "mistral-large-latest", tools: [ "Emails::GetLabelsTool", "Emails::CreateLabelTool", "Emails::AddLabelsTool",
+                                                                           "Records::InsertRowsTool", "Records::ReadSchemaTool", "Emails::GetTool" ] },
+    "Records::NormalizeAgent" => { model: "gpt-5.1",            tools: [ "Records::ListRowsTool", "Records::ReadRowsTool", "Records::UpdateRowsTool",
+                                                                          "Records::ReadSchemaTool", "Records::SearchSimilarTool" ] },
+    "Records::ReconcileAgent" => { model: "gpt-5.1",            tools: [ "Records::ReadSchemaTool", "Records::TempFileTool", "Records::SearchSimilarTool",
+                                                                          "Records::InsertRowsTool", "Records::UpdateRowsTool", "Records::ReadRowsTool" ] }
   }.each do |agent_name, expected|
     describe agent_name do
       subject(:agent) { Orchestration::Agent.find_by!(name: agent_name) }
@@ -20,8 +23,8 @@ RSpec.describe "Seeds: agent config backfill" do # rubocop:disable RSpec/Describ
         expect(agent.model).to eq(expected[:model])
       end
 
-      it "has tools including #{expected[:tools].first}" do
-        expect(agent.tools).to include(expected[:tools].first)
+      it "has exactly the expected tools" do
+        expect(agent.tools).to match_array(expected[:tools])
       end
 
       it "has prompt set" do

--- a/spec/db/seeds_agent_backfill_spec.rb
+++ b/spec/db/seeds_agent_backfill_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Seeds: agent config backfill" do # rubocop:disable RSpec/DescribeClass
+  before { load Rails.root.join("db/seeds.rb") }
+
+  {
+    "Emails::ClassifyAgent"  => { model: "mistral-large-latest", tools: [ "Records::TempFileTool" ] },
+    "Emails::FilterAgent"    => { model: "mistral-large-latest", tools: [ "Records::TempFileTool" ] },
+    "Emails::MappingAgent"   => { model: "mistral-large-latest", tools: [ "Emails::GetTool", "Records::TempFileTool" ] },
+    "Records::StoreAgent"    => { model: "mistral-large-latest", tools: [ "Records::InsertRowsTool" ] },
+    "Records::NormalizeAgent" => { model: "gpt-5.1",            tools: [ "Records::SearchSimilarTool" ] },
+    "Records::ReconcileAgent" => { model: "gpt-5.1",            tools: [ "Records::ReadSchemaTool" ] }
+  }.each do |agent_name, expected|
+    describe agent_name do
+      subject(:agent) { Orchestration::Agent.find_by!(name: agent_name) }
+
+      it "has model set to #{expected[:model]}" do
+        expect(agent.model).to eq(expected[:model])
+      end
+
+      it "has tools including #{expected[:tools].first}" do
+        expect(agent.tools).to include(expected[:tools].first)
+      end
+
+      it "has prompt set" do
+        expect(agent.prompt).to be_present
+      end
+
+      it "does not set output_schema (preserves result-wrapper output convention)" do
+        expect(agent.output_schema).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/orchestration/pipeline_lifecycle_spec.rb
+++ b/spec/requests/orchestration/pipeline_lifecycle_spec.rb
@@ -115,7 +115,12 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
         agent_class: "Orchestration::QueryExecutor",
         params: { "table" => "interviews", "column_name" => "status", "column_values" => [ "screening" ] })
     end
-    let!(:classify_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent") }
+    let!(:classify_agent) do
+      create(:orchestration_agent,
+             name: "Emails::ClassifyAgent",
+             model: "mistral-large-latest",
+             tools: [ "Records::TempFileTool" ])
+    end
     let!(:classify_action) do
       create(:orchestration_action, name: "Classify Emails", agent: classify_agent)
     end

--- a/spec/services/evaluation/stubbed_agent_run_spec.rb
+++ b/spec/services/evaluation/stubbed_agent_run_spec.rb
@@ -3,7 +3,27 @@ require "rails_helper"
 RSpec.describe Evaluation::StubbedAgentRun do # rubocop:disable RSpec/MultipleMemoizedHelpers
   subject(:runner) { described_class.new }
 
-  let(:orchestration_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent") }
+  let(:orchestration_agent) do
+    create(:orchestration_agent,
+           name: "Emails::ClassifyAgent",
+           model: "mistral-large-latest",
+           tools: [ "Records::TempFileTool" ],
+           output_schema: {
+             "type" => "object",
+             "properties" => {
+               "results" => {
+                 "type" => "array",
+                 "items" => {
+                   "type" => "object",
+                   "properties" => {
+                     "id"   => { "type" => "string" },
+                     "tags" => { "type" => "array", "items" => { "type" => "string" } }
+                   }
+                 }
+               }
+             }
+           })
+  end
   let(:step_action) do
     action = create(:orchestration_action, kind: :agent, agent: orchestration_agent)
     create(:orchestration_step_action, action: action)

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Orchestration::PipelineRunner do
   let(:step1)        { create(:orchestration_step, pipeline: pipeline, name: "extract", position: 1) }
   let(:action)       { create(:orchestration_action, agent: create(:orchestration_agent, name: "Emails::ClassifyAgent")) }
   let(:pipeline_run) { create(:orchestration_pipeline_run, pipeline: pipeline, status: "pending") }
-  let(:stub_agent)   { instance_double(Emails::ClassifyAgent) }
+  let(:stub_agent)   { instance_double(RubyLLM::Agent) }
 
   before do
-    allow(Emails::ClassifyAgent).to receive(:create).and_return(stub_agent)
+    allow(RubyLLM::Agent).to receive(:new).and_return(stub_agent)
     allow(stub_agent).to receive_messages(ask: instance_double(RubyLLM::Message, content: "classification result"), chat: instance_double(Chat, id: nil))
   end
 
@@ -39,14 +39,6 @@ RSpec.describe Orchestration::PipelineRunner do
         described_class.new(pipeline_run).call
         action_run = Orchestration::ActionRun.last
         expect(action_run.chat_id).to eq(chat.id)
-      end
-
-      it 'does not create an extra Chat record before building a legacy agent' do
-        allow(Chat).to receive(:create!)
-
-        described_class.new(pipeline_run).call
-
-        expect(Chat).not_to have_received(:create!)
       end
     end
 
@@ -549,9 +541,7 @@ RSpec.describe Orchestration::PipelineRunner do
         create(:orchestration_step_action, step: step2, action: filter_action, position: 1)
         create(:orchestration_step_action, step: step3, action: ingest_action, position: 1)
 
-        # filter_content is what the LLM returns before run_agent wraps it in { "result" => ... }
         allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [ { "id" => "e1" } ] })
-        allow(Emails::FilterAgent).to receive(:create).and_return(stub_agent)
         allow(stub_agent).to receive(:ask)
           .and_return(instance_double(RubyLLM::Message, content: { "results" => [ { "id" => "e1" } ] }))
       end

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -20,6 +20,25 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
   end
   let(:action) { create(:orchestration_action, agent: agent_record) }
 
+  describe '#build' do
+    it 'does not delegate to a legacy RubyLLM::Agent subclass even when the agent name matches one' do # rubocop:disable RSpec/ExampleLength
+      legacy_agent_record = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      legacy_action = create(:orchestration_action, agent: legacy_agent_record)
+      allow(Emails::ClassifyAgent).to receive(:create)
+
+      generic_agent = instance_double(RubyLLM::Agent)
+      allow(RubyLLM::Agent).to receive(:new).and_return(generic_agent)
+      allow(generic_agent).to receive_messages(with_model: generic_agent, with_tools: generic_agent,
+                                               with_params: generic_agent, with_schema: generic_agent,
+                                               chat: instance_double(Chat, with_instructions: nil))
+
+      described_class.new(action: legacy_action).build
+
+      expect(Emails::ClassifyAgent).not_to have_received(:create)
+      expect(RubyLLM::Agent).to have_received(:new)
+    end
+  end
+
   describe '#snapshot' do
     it 'returns a hash with the resolved model' do
       expect(builder.snapshot[:model]).to eq("mistral-large")

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -39,6 +39,28 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
     end
   end
 
+  describe '#resolved_tools (via #snapshot)' do
+    it 'raises ArgumentError when a tool is outside allowed namespaces' do
+      bad_agent = create(:orchestration_agent, name: "Bad Agent", tools: [])
+      bad_action = create(:orchestration_action, agent: bad_agent)
+      allow(bad_agent).to receive(:tools).and_return([ "Kernel::Exec" ])
+      allow(bad_action).to receive(:agent).and_return(bad_agent)
+
+      expect { described_class.new(action: bad_action).snapshot }
+        .to raise_error(ArgumentError, /outside allowed namespaces/)
+    end
+
+    it 'raises ArgumentError with the tool name when constantize fails' do
+      bad_agent = create(:orchestration_agent, name: "Bad Agent 2", tools: [])
+      bad_action = create(:orchestration_action, agent: bad_agent)
+      allow(bad_agent).to receive(:tools).and_return([ "Records::NonExistentTool" ])
+      allow(bad_action).to receive(:agent).and_return(bad_agent)
+
+      expect { described_class.new(action: bad_action).snapshot }
+        .to raise_error(ArgumentError, /NonExistentTool/)
+    end
+  end
+
   describe '#snapshot' do
     it 'returns a hash with the resolved model' do
       expect(builder.snapshot[:model]).to eq("mistral-large")


### PR DESCRIPTION
## Summary

- Removes the `legacy_agent_class` fallback from `RuntimeAgentBuilder` so the orchestration runtime no longer depends on hardcoded `RubyLLM::Agent` subclasses
- Adds a data migration that backfills model, tools, and prompt for the six pipeline agents (ClassifyAgent, FilterAgent, MappingAgent, StoreAgent, NormalizeAgent, ReconcileAgent) from their former Ruby class definitions
- Updates `db/seeds.rb` to populate all agent fields on create/update rather than relying on class-level DSL

Closes #38

## Test plan

- [x] New `#build` spec asserts legacy class is never called even when agent name matches a subclass
- [x] New seeds spec asserts all pipeline agents have model, tools, and prompt after seeding
- [x] Pipeline runner spec updated to stub `RubyLLM::Agent.new` instead of legacy class
- [x] Pipeline lifecycle and stubbed agent run specs updated to set model/tools on agent records directly
- [x] Full suite: 1134 examples, 0 failures
- [x] RuboCop: no offenses
- [x] Steep: no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)