### PR TITLE
feat: expose shared agent usage in pipeline operations

### DIFF
--- a/app/components/ui/detail_card_component.html.erb
+++ b/app/components/ui/detail_card_component.html.erb
@@ -10,6 +10,8 @@
             <%= status_badge %>
           <% elsif attr.type == :json %>
             <pre class="text-sm font-mono text-gray-900 whitespace-pre-wrap"><%= json_display(val) %></pre>
+          <% elsif attr.type == :multiline %>
+            <pre class="text-sm text-gray-900 whitespace-pre-wrap"><%= val || "—" %></pre>
           <% else %>
             <span class="<%= text_classes_for(attr) %>"><%= val || "—" %></span>
           <% end %>

--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -9,6 +9,7 @@ module Orchestration
 
     def index
       @actions = Orchestration::Action
+        .includes(:agent)
         .left_joins(step_actions: { step: :pipeline })
         .select("actions.*, COUNT(DISTINCT pipelines.id) AS pipeline_count")
         .group("actions.id")

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -4,10 +4,18 @@ module Orchestration
   class AgentsController < ApplicationController
     include JsonParamsParsing
 
-    before_action :set_agent, only: [ :edit, :update, :destroy, :toggle ]
+    before_action :set_agent, only: [ :show, :edit, :update, :destroy, :toggle ]
 
     def index
-      @agents = Orchestration::Agent.order(:name)
+      @agents = Orchestration::Agent
+        .left_joins(:actions)
+        .select("orchestration_agents.*, COUNT(DISTINCT actions.id) AS action_count")
+        .group("orchestration_agents.id")
+        .order("orchestration_agents.name")
+    end
+
+    def show
+      @using_actions = @agent.actions.includes(step_actions: { step: :pipeline }).order(:name)
     end
 
     def new

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -6,6 +6,8 @@ module Orchestration
 
     self.table_name = "orchestration_agents"
 
+    has_many :actions, class_name: "Orchestration::Action", foreign_key: :agent_id, dependent: :restrict_with_error, inverse_of: :agent
+
     validates :name, presence: true, uniqueness: true
     validate :tools_must_be_valid
 

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -6,7 +6,7 @@ module Orchestration
 
     self.table_name = "orchestration_agents"
 
-    has_many :actions, class_name: "Orchestration::Action", foreign_key: :agent_id, dependent: :restrict_with_error, inverse_of: :agent
+    has_many :actions, -> { where(kind: :agent) }, class_name: "Orchestration::Action", foreign_key: :agent_id, dependent: :restrict_with_error, inverse_of: :agent
 
     validates :name, presence: true, uniqueness: true
     validate :tools_must_be_valid

--- a/app/views/orchestration/actions/index.html.erb
+++ b/app/views/orchestration/actions/index.html.erb
@@ -5,7 +5,14 @@
 <%= render UI::TableComponent.new(collection: @actions, empty_message: "No actions found.") do |table| %>
   <% table.with_columns([
     { key: "name",           label: "Name" },
-    { key: "kind",           label: "Kind" },
+    { key: "kind", label: "Kind", cell: ->(action) {
+        if action.agent? && action.agent
+          link_to action.agent.name, orchestration_agent_path(action.agent), class: "font-mono text-xs hover:underline"
+        else
+          action.kind
+        end
+      }
+    },
     { key: "model",          label: "Model",     variant: :muted, cell: ->(action) { action.model || "—" } },
     { key: "pipeline_count", label: "Pipelines", variant: :muted }
   ]) %>

--- a/app/views/orchestration/actions/index.html.erb
+++ b/app/views/orchestration/actions/index.html.erb
@@ -7,7 +7,7 @@
     { key: "name",           label: "Name" },
     { key: "kind", label: "Kind", cell: ->(action) {
         if action.agent? && action.agent
-          link_to action.agent.name, orchestration_agent_path(action.agent), class: "font-mono text-xs hover:underline"
+          safe_join([ "Agent · ", link_to(action.agent.name, orchestration_agent_path(action.agent), class: "font-mono text-xs hover:underline") ])
         else
           action.kind
         end

--- a/app/views/orchestration/agents/index.html.erb
+++ b/app/views/orchestration/agents/index.html.erb
@@ -4,10 +4,12 @@
 
 <%= render UI::TableComponent.new(collection: @agents, empty_message: "No agents found.") do |table| %>
   <% table.with_columns([
-    { key: "name", label: "Name", classes: "px-4 py-3 font-mono text-xs" },
+    { key: "name",        label: "Name",        classes: "px-4 py-3 font-mono text-xs",
+      cell: ->(agent) { link_to agent.name, orchestration_agent_path(agent), class: "font-mono text-xs hover:underline" } },
     { key: "description", label: "Description", variant: :muted, cell: ->(agent) { agent.description.presence || "—" } },
-    { key: "model", label: "Model", variant: :muted, cell: ->(agent) { agent.model.presence || "—" } },
-    { key: "enabled", label: "Status", cell: ->(agent) { agent.enabled? ? "Enabled" : "Disabled" } }
+    { key: "model",       label: "Model",       variant: :muted, cell: ->(agent) { agent.model.presence || "—" } },
+    { key: "enabled",     label: "Status",      cell: ->(agent) { agent.enabled? ? "Enabled" : "Disabled" } },
+    { key: "action_count", label: "Used by",    variant: :muted, cell: ->(agent) { "#{agent.action_count} #{"action".pluralize(agent.action_count)}" } }
   ]) %>
   <% table.with_action_column(
     actions: ->(agent) {

--- a/app/views/orchestration/agents/show.html.erb
+++ b/app/views/orchestration/agents/show.html.erb
@@ -1,0 +1,37 @@
+<%= render UI::PageHeaderComponent.new(
+      title: @agent.name,
+      parent: { label: "Agent Library", url: orchestration_agents_path }
+    ) do |header| %>
+  <% header.with_badge(
+    label: @agent.enabled? ? "Enabled" : "Disabled",
+    variant: @agent.enabled? ? :success : :warning
+  ) %>
+  <% header.with_action(type: :link, label: "Edit", url: edit_orchestration_agent_path(@agent), variant: :primary) %>
+<% end %>
+
+<%= render UI::DetailCardComponent.new(
+      entity: @agent,
+      attributes: [
+        { label: "Description",   attribute: :description },
+        { label: "Model",         attribute: :model },
+        { label: "Tools",         attribute: :tools,         type: :json },
+        { label: "Prompt",        attribute: :prompt },
+        { label: "Params",        attribute: :params,        type: :json },
+        { label: "Output Schema", attribute: :output_schema, type: :json }
+      ]
+    ) %>
+
+<div class="mt-8">
+  <h2 class="text-lg font-semibold text-gray-900 mb-4">Using Actions</h2>
+
+  <%= render UI::TableComponent.new(collection: @using_actions, empty_message: "No actions use this agent.") do |table| %>
+    <% table.with_columns([
+      { key: "name",      label: "Action" },
+      { key: "pipelines", label: "Pipelines", cell: ->(action) {
+          names = action.step_actions.map { |sa| sa.step.pipeline.name }.uniq
+          names.any? ? names.join(", ") : "—"
+        }
+      }
+    ]) %>
+  <% end %>
+</div>

--- a/app/views/orchestration/agents/show.html.erb
+++ b/app/views/orchestration/agents/show.html.erb
@@ -15,7 +15,7 @@
         { label: "Description",   attribute: :description },
         { label: "Model",         attribute: :model },
         { label: "Tools",         attribute: :tools,         type: :json },
-        { label: "Prompt",        attribute: :prompt },
+        { label: "Prompt",        attribute: :prompt,        type: :multiline },
         { label: "Params",        attribute: :params,        type: :json },
         { label: "Output Schema", attribute: :output_schema, type: :json }
       ]

--- a/sig/app/controllers/orchestration/agents_controller.rbs
+++ b/sig/app/controllers/orchestration/agents_controller.rbs
@@ -3,6 +3,7 @@ module Orchestration
     include JsonParamsParsing
 
     def index: () -> void
+    def show: () -> void
     def new: () -> void
     def create: () -> void
     def edit: () -> void

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -2,6 +2,8 @@ module Orchestration
   class Agent < ApplicationRecord
     ALLOWED_TOOL_NAMESPACES: Array[String]
 
+    def actions: () -> ActiveRecord::Associations::CollectionProxy
+
     def name: () -> String
     def name=: (String) -> String
     def description: () -> String?

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe Orchestration::Agent do
     expect(agent).to be_valid
   end
 
+  describe "associations" do
+    it "exposes actions that reference it" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      action = create(:orchestration_action, kind: :agent, agent: agent)
+      expect(agent.actions).to include(action)
+    end
+
+    it "does not include actions for other agents" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      other_agent = create(:orchestration_agent, name: "Records::StoreAgent")
+      create(:orchestration_action, kind: :agent, agent: other_agent)
+      expect(agent.actions).to be_empty
+    end
+  end
+
   describe "validations" do
     it "requires name" do
       agent.name = nil

--- a/spec/requests/orchestration/actions_spec.rb
+++ b/spec/requests/orchestration/actions_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe "Orchestration::Actions" do
       expect(response.body).to include("agent")
     end
 
+    it "shows agent name for agent-kind actions" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      create(:orchestration_action, name: "My Action", kind: :agent, agent: agent)
+      get orchestration_actions_path
+      expect(response.body).to match(/href="#{orchestration_agent_path(agent)}"[^>]*>\s*Emails::ClassifyAgent/)
+    end
+
     it "shows pipeline usage count" do
       action = create(:orchestration_action)
       step_action = create(:orchestration_step_action, action: action)

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Orchestration::Agents" do
       create(:orchestration_action, name: "Action One", kind: :agent, agent: agent)
       create(:orchestration_action, name: "Action Two", kind: :agent, agent: agent)
       get orchestration_agents_path
-      expect(response.body).to include("Used by")
+      expect(response.body).to include("2 actions")
     end
 
     it "links agent name to show page" do
@@ -111,6 +111,18 @@ RSpec.describe "Orchestration::Agents" do
       step_action = create(:orchestration_step_action, action: action)
       get orchestration_agent_path(agent)
       expect(response.body).to include(step_action.step.pipeline.name)
+    end
+
+    it "deduplicates pipeline name when action appears in multiple steps of the same pipeline" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      action = create(:orchestration_action, name: "Classify Email Step", kind: :agent, agent: agent)
+      pipeline = create(:orchestration_pipeline)
+      step_a = create(:orchestration_step, pipeline: pipeline)
+      step_b = create(:orchestration_step, pipeline: pipeline)
+      create(:orchestration_step_action, action: action, step: step_a)
+      create(:orchestration_step_action, action: action, step: step_b)
+      get orchestration_agent_path(agent)
+      expect(response.body.scan(pipeline.name).size).to eq(1)
     end
 
     it "shows empty state when no actions reference the agent" do

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe "Orchestration::Agents" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Emails::ClassifyAgent")
     end
+
+    it "shows action usage count per agent" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      create(:orchestration_action, name: "Action One", kind: :agent, agent: agent)
+      create(:orchestration_action, name: "Action Two", kind: :agent, agent: agent)
+      get orchestration_agents_path
+      expect(response.body).to include("Used by")
+    end
+
+    it "links agent name to show page" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      get orchestration_agents_path
+      expect(response.body).to include("href=\"#{orchestration_agent_path(agent)}\"")
+      expect(response.body).to match(/href="#{orchestration_agent_path(agent)}"[^>]*>\s*Emails::ClassifyAgent/)
+    end
   end
 
   describe "GET /orchestration/agents/new" do
@@ -72,6 +87,37 @@ RSpec.describe "Orchestration::Agents" do
         expect(agent.params).to eq({ "mode" => "strict" })
         expect(agent.output_schema).to be_nil
       end
+    end
+  end
+
+  describe "GET /orchestration/agents/:id" do
+    it "returns 200 and shows agent name" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      get orchestration_agent_path(agent)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Emails::ClassifyAgent")
+    end
+
+    it "lists actions that reference this agent" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      create(:orchestration_action, name: "Classify Email Step", kind: :agent, agent: agent)
+      get orchestration_agent_path(agent)
+      expect(response.body).to include("Classify Email Step")
+    end
+
+    it "shows pipeline name for actions attached to pipelines" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      action = create(:orchestration_action, name: "Classify Email Step", kind: :agent, agent: agent)
+      step_action = create(:orchestration_step_action, action: action)
+      get orchestration_agent_path(agent)
+      expect(response.body).to include(step_action.step.pipeline.name)
+    end
+
+    it "shows empty state when no actions reference the agent" do
+      agent = create(:orchestration_agent, name: "Unused Agent")
+      get orchestration_agent_path(agent)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("No actions")
     end
   end
 


### PR DESCRIPTION
## Summary

- Add agent show page listing all actions that reference the agent and their pipeline memberships, so admins can see downstream impact before editing
- Add "Used by" count column and clickable name link to the agents index for quick usage overview
- Show agent name as a linked badge in the actions index Kind column for agent-kind rows

Closes #39

## Test plan
- [ ] New `GET /orchestration/agents/:id` show page tests pass (agent details, using-actions list, pipeline names, empty state)
- [ ] Agents index tests pass (action count column, name link to show page)
- [ ] Actions index test passes (agent name link in Kind column)
- [ ] Full suite: 1145 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)