### PR TITLE
feat: evaluation rake tasks for manual run, run_all, and status

### DIFF
--- a/app/runners/stubbed_agent_run.rb
+++ b/app/runners/stubbed_agent_run.rb
@@ -13,7 +13,8 @@ class StubbedAgentRun < Leva::BaseRun
 
     tool_classes = resolve_tools(agent_record)
     stubbed_tools = tool_classes.map { |tool_class| stub_tool(tool_class, registry) }
-    agent = Orchestration::RuntimeAgentBuilder.new(action: action, tool_classes: stubbed_tools).build
+    pipeline_model = @experiment&.metadata&.dig("pipeline_model")
+    agent = Orchestration::RuntimeAgentBuilder.new(action: action, tool_classes: stubbed_tools, pipeline_model: pipeline_model).build
 
     result = agent.ask(record.input.to_json)
 

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -101,7 +101,7 @@ namespace :evaluation do
   task :run, [ :agent_name, :model ] => :environment do |_, args|
     agent_name = args[:agent_name] or raise ArgumentError, "Usage: rake evaluation:run[agent_name,model]"
 
-    prompt = Orchestration::Prompt.where(name: agent_name).order(version: :desc).first
+    prompt = Orchestration::Prompt.where(name: agent_name).order(version: :desc, id: :desc).first
     raise ArgumentError, "No active prompt found for #{agent_name}" unless prompt
 
     dataset = Leva::Dataset.find_by!(name: agent_name)
@@ -112,7 +112,8 @@ namespace :evaluation do
       dataset: dataset,
       prompt: prompt,
       runner_class: "StubbedAgentRun",
-      evaluator_classes: [ "LLMJudgeEval" ]
+      evaluator_classes: [ "LLMJudgeEval" ],
+      metadata: args[:model].presence ? { "pipeline_model" => args[:model] } : nil
     )
 
     Leva::ExperimentJob.perform_later(experiment)
@@ -124,7 +125,7 @@ namespace :evaluation do
     model = args[:model].presence
 
     Orchestration::Agent.pluck(:name).each do |agent_name|
-      prompt = Orchestration::Prompt.where(name: agent_name).order(version: :desc).first
+      prompt = Orchestration::Prompt.where(name: agent_name).order(version: :desc, id: :desc).first
       unless prompt
         puts "#{agent_name}: skipped (no prompt)"
         next
@@ -142,7 +143,8 @@ namespace :evaluation do
         dataset: dataset,
         prompt: prompt,
         runner_class: "StubbedAgentRun",
-        evaluator_classes: [ "LLMJudgeEval" ]
+        evaluator_classes: [ "LLMJudgeEval" ],
+        metadata: model ? { "pipeline_model" => model } : nil
       )
 
       Leva::ExperimentJob.perform_later(experiment)
@@ -154,31 +156,44 @@ namespace :evaluation do
   task status: :environment do
     agent_names = Orchestration::Agent.pluck(:name)
 
+    # steep:ignore:start
+    sample_counts = Orchestration::ActionRun
+      .joins(step_action: { action: :agent })
+      .where(status: "completed")
+      .where.not(chat_id: nil)
+      .group("orchestration_agents.name")
+      .count
+    # steep:ignore:end
+
+    latest_exp_ids = Leva::Experiment
+      .joins(:prompt)
+      .where(leva_prompts: { name: agent_names })
+      .group("leva_prompts.name")
+      .maximum(:id)
+
+    experiments_by_id = Leva::Experiment.where(id: latest_exp_ids.values).index_by(&:id)
+    exp_by_agent      = latest_exp_ids.transform_values { |id| experiments_by_id[id] }
+
+    avg_scores = latest_exp_ids.any? ?
+      Leva::EvaluationResult.where(experiment_id: latest_exp_ids.values).group(:experiment_id).average(:score) :
+      {}
+
+    prompt_versions = Orchestration::Prompt
+      .where(name: agent_names)
+      .group(:name)
+      .maximum(:version)
+
     puts format("%-35s %10s %10s %8s %7s", "Agent", "Samples", "Exp ID", "Score", "Prompt")
     puts "-" * 75
 
     agent_names.each do |agent_name|
-      samples = Orchestration::ActionRun
-        # steep:ignore:start
-        .joins(step_action: { action: :agent })
-        # steep:ignore:end
-        .where(status: "completed")
-        .where.not(chat_id: nil)
-        .where(orchestration_agents: { name: agent_name })
-        .count
-
-      experiment = Leva::Experiment
-        .joins(:prompt)
-        .where(leva_prompts: { name: agent_name })
-        .order(id: :desc)
-        .first
-
-      exp_id    = experiment ? "##{experiment.id}" : "n/a"
-      avg_score = experiment ? Leva::EvaluationResult.where(experiment: experiment).average(:score) : nil
-      score_str = avg_score ? format("%.2f", avg_score) : "n/a"
-
-      prompt_version = Orchestration::Prompt.where(name: agent_name).order(version: :desc).pick(:version)
-      version_str    = prompt_version ? "v#{prompt_version}" : "n/a"
+      samples     = sample_counts[agent_name] || 0
+      experiment  = exp_by_agent[agent_name]
+      exp_id      = experiment ? "##{experiment.id}" : "n/a"
+      avg_score   = experiment ? avg_scores[experiment.id] : nil
+      score_str   = avg_score ? format("%.2f", avg_score) : "n/a"
+      version     = prompt_versions[agent_name]
+      version_str = version ? "v#{version}" : "n/a"
 
       puts format("%-35s %10s %10s %8s %7s", agent_name, samples, exp_id, score_str, version_str)
     end

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -97,6 +97,93 @@ namespace :evaluation do
     puts format("%-30s %8s %8s %10s", "OVERALL", baseline_str, candidate_str, delta_str)
   end
 
+  desc "Run an evaluation for a specific agent (e.g. rake evaluation:run[Emails::ClassifyAgent,mistral-large-latest])"
+  task :run, [ :agent_name, :model ] => :environment do |_, args|
+    agent_name = args[:agent_name] or raise ArgumentError, "Usage: rake evaluation:run[agent_name,model]"
+
+    prompt = Orchestration::Prompt.where(name: agent_name).order(version: :desc).first
+    raise ArgumentError, "No active prompt found for #{agent_name}" unless prompt
+
+    dataset = Leva::Dataset.find_by!(name: agent_name)
+
+    model_label = args[:model].presence || "default"
+    experiment = Leva::Experiment.create!(
+      name: "#{agent_name} eval w/ #{model_label} (#{Date.today})",
+      dataset: dataset,
+      prompt: prompt,
+      runner_class: "StubbedAgentRun",
+      evaluator_classes: [ "LLMJudgeEval" ]
+    )
+
+    Leva::ExperimentJob.perform_later(experiment)
+    puts "Created experiment ##{experiment.id} for #{agent_name}"
+  end
+
+  desc "Run evaluations for all agents (e.g. rake evaluation:run_all[mistral-large-latest])"
+  task :run_all, [ :model ] => :environment do |_, args|
+    model = args[:model].presence
+
+    Orchestration::Agent.pluck(:name).each do |agent_name|
+      prompt = Orchestration::Prompt.where(name: agent_name).order(version: :desc).first
+      unless prompt
+        puts "#{agent_name}: skipped (no prompt)"
+        next
+      end
+
+      dataset = Leva::Dataset.find_by(name: agent_name)
+      unless dataset
+        puts "#{agent_name}: skipped (no dataset)"
+        next
+      end
+
+      model_label = model || "default"
+      experiment = Leva::Experiment.create!(
+        name: "#{agent_name} eval w/ #{model_label} (#{Date.today})",
+        dataset: dataset,
+        prompt: prompt,
+        runner_class: "StubbedAgentRun",
+        evaluator_classes: [ "LLMJudgeEval" ]
+      )
+
+      Leva::ExperimentJob.perform_later(experiment)
+      puts "#{agent_name}: created experiment ##{experiment.id}"
+    end
+  end
+
+  desc "Print evaluation readiness status per agent"
+  task status: :environment do
+    agent_names = Orchestration::Agent.pluck(:name)
+
+    puts format("%-35s %10s %10s %8s %7s", "Agent", "Samples", "Exp ID", "Score", "Prompt")
+    puts "-" * 75
+
+    agent_names.each do |agent_name|
+      samples = Orchestration::ActionRun
+        # steep:ignore:start
+        .joins(step_action: { action: :agent })
+        # steep:ignore:end
+        .where(status: "completed")
+        .where.not(chat_id: nil)
+        .where(orchestration_agents: { name: agent_name })
+        .count
+
+      experiment = Leva::Experiment
+        .joins(:prompt)
+        .where(leva_prompts: { name: agent_name })
+        .order(id: :desc)
+        .first
+
+      exp_id    = experiment ? "##{experiment.id}" : "n/a"
+      avg_score = experiment ? Leva::EvaluationResult.where(experiment: experiment).average(:score) : nil
+      score_str = avg_score ? format("%.2f", avg_score) : "n/a"
+
+      prompt_version = Orchestration::Prompt.where(name: agent_name).order(version: :desc).pick(:version)
+      version_str    = prompt_version ? "v#{prompt_version}" : "n/a"
+
+      puts format("%-35s %10s %10s %8s %7s", agent_name, samples, exp_id, score_str, version_str)
+    end
+  end
+
   desc "Improve prompt for an agent based on the latest completed experiment (e.g. rake evaluation:improve[Emails::ClassifyAgent])"
   task :improve, [ :agent_name ] => :environment do |_, args|
     agent_name = args[:agent_name] or raise ArgumentError, "Usage: rake evaluation:improve[AgentName]"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "application_pipeline",
   "version": "1.0.0",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "esbuild app/javascript/application.ts --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets",
     "build:watch": "esbuild app/javascript/application.ts --bundle --sourcemap --outdir=app/assets/builds --public-path=/assets --watch"

--- a/spec/runners/stubbed_agent_run_spec.rb
+++ b/spec/runners/stubbed_agent_run_spec.rb
@@ -131,6 +131,23 @@ RSpec.describe StubbedAgentRun do # rubocop:disable RSpec/MultipleMemoizedHelper
       runner.execute(action_run)
     end
 
+    context "when experiment metadata contains pipeline_model" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:experiment) do
+        create(:leva_experiment,
+               runner_class: "StubbedAgentRun",
+               metadata: { "pipeline_model" => "mistral-small-latest" })
+      end
+
+      before { runner.instance_variable_set(:@experiment, experiment) }
+
+      it "passes pipeline_model to RuntimeAgentBuilder" do
+        allow(Orchestration::RuntimeAgentBuilder).to receive(:new).and_call_original
+        runner.execute(action_run)
+        expect(Orchestration::RuntimeAgentBuilder).to have_received(:new)
+          .with(hash_including(pipeline_model: "mistral-small-latest"))
+      end
+    end
+
     context "with a serialized orchestration agent and no Ruby subclass" do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:orchestration_agent) do
         create(:orchestration_agent,

--- a/spec/tasks/evaluation_run_all_spec.rb
+++ b/spec/tasks/evaluation_run_all_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "evaluation:run_all rake task" do # rubocop:disable RSpec/DescribeClass
+  let(:task_name) { "evaluation:run_all" }
+
+  let(:classify_agent_name) { "Emails::ClassifyAgent" }
+  let(:filter_agent_name)   { "Emails::FilterAgent" }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task[task_name].reenable
+    allow(Leva::ExperimentJob).to receive(:perform_later)
+
+    create(:orchestration_agent, name: classify_agent_name)
+    create(:orchestration_agent, name: filter_agent_name)
+    create(:orchestration_prompt, name: classify_agent_name)
+    create(:orchestration_prompt, name: filter_agent_name)
+    create(:leva_dataset, name: classify_agent_name)
+    create(:leva_dataset, name: filter_agent_name)
+  end
+
+  def run_task(model = nil)
+    output = StringIO.new
+    $stdout = output
+    Rake::Task[task_name].invoke(model)
+    output.string
+  ensure
+    $stdout = STDOUT
+  end
+
+  it "creates one experiment per agent" do
+    expect { run_task }.to change(Leva::Experiment, :count).by(2)
+  end
+
+  it "prints a summary line for each agent" do
+    output = run_task
+    expect(output).to include(classify_agent_name)
+    expect(output).to include(filter_agent_name)
+  end
+
+  context "when an agent has no prompt" do
+    before { Orchestration::Prompt.where(name: classify_agent_name).delete_all }
+
+    it "skips that agent with a message" do
+      output = run_task
+      expect(output).to match(/#{Regexp.escape(classify_agent_name)}.*skipped/i)
+    end
+
+    it "still creates an experiment for the other agent" do
+      expect { run_task }.to change(Leva::Experiment, :count).by(1)
+    end
+  end
+
+  context "when an agent has no dataset" do
+    before { Leva::Dataset.where(name: classify_agent_name).delete_all }
+
+    it "skips that agent with a message" do
+      output = run_task
+      expect(output).to match(/#{Regexp.escape(classify_agent_name)}.*skipped/i)
+    end
+
+    it "still creates an experiment for the other agent" do
+      expect { run_task }.to change(Leva::Experiment, :count).by(1)
+    end
+  end
+end

--- a/spec/tasks/evaluation_run_all_spec.rb
+++ b/spec/tasks/evaluation_run_all_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe "evaluation:run_all rake task" do # rubocop:disable RSpec/Describ
     expect(output).to include(filter_agent_name)
   end
 
+  context "when model is provided" do
+    it "stores the model in each experiment metadata" do
+      run_task("mistral-large-latest")
+      expect(Leva::Experiment.all.map { |e| e.metadata&.dig("pipeline_model") }.uniq)
+        .to eq([ "mistral-large-latest" ])
+    end
+
+    it "includes the model in each experiment name" do
+      run_task("mistral-large-latest")
+      expect(Leva::Experiment.all.map(&:name)).to all(include("mistral-large-latest"))
+    end
+  end
+
   context "when an agent has no prompt" do
     before { Orchestration::Prompt.where(name: classify_agent_name).delete_all }
 

--- a/spec/tasks/evaluation_run_spec.rb
+++ b/spec/tasks/evaluation_run_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "evaluation:run rake task" do # rubocop:disable RSpec/DescribeClass
+  let(:task_name) { "evaluation:run" }
+  let(:agent_name) { "Emails::ClassifyAgent" }
+  let!(:prompt)  { create(:orchestration_prompt, name: agent_name, version: 1) }
+  let!(:dataset) { create(:leva_dataset, name: agent_name) }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task[task_name].reenable
+  end
+
+  context "when agent_name, prompt, and dataset exist" do
+    it "creates a Leva::Experiment" do
+      expect { Rake::Task[task_name].invoke(agent_name, nil) }
+        .to change(Leva::Experiment, :count).by(1)
+    end
+
+    it "sets runner_class to StubbedAgentRun" do
+      Rake::Task[task_name].invoke(agent_name, nil)
+      expect(Leva::Experiment.last.runner_class).to eq("StubbedAgentRun")
+    end
+
+    it "sets evaluator_classes to LLMJudgeEval" do
+      Rake::Task[task_name].invoke(agent_name, nil)
+      expect(Leva::Experiment.last.evaluator_classes).to eq([ "LLMJudgeEval" ])
+    end
+
+    it "links the experiment to the active prompt" do
+      Rake::Task[task_name].invoke(agent_name, nil)
+      expect(Leva::Experiment.last.prompt_id).to eq(prompt.id)
+    end
+
+    it "links the experiment to the agent dataset" do
+      Rake::Task[task_name].invoke(agent_name, nil)
+      expect(Leva::Experiment.last.dataset).to eq(dataset)
+    end
+
+    it "enqueues Leva::ExperimentJob" do
+      allow(Leva::ExperimentJob).to receive(:perform_later)
+      Rake::Task[task_name].invoke(agent_name, nil)
+      expect(Leva::ExperimentJob).to have_received(:perform_later).once
+    end
+
+    it "prints the experiment id" do
+      expect { Rake::Task[task_name].invoke(agent_name, nil) }
+        .to output(/#\d+/).to_stdout
+    end
+
+    context "when multiple prompt versions exist" do
+      let!(:newer_prompt) { create(:orchestration_prompt, name: agent_name, version: 2) }
+
+      it "uses the highest version" do
+        Rake::Task[task_name].invoke(agent_name, nil)
+        expect(Leva::Experiment.last.prompt_id).to eq(newer_prompt.id)
+      end
+    end
+  end
+
+  context "when agent_name is missing" do
+    it "raises ArgumentError with usage message" do
+      expect { Rake::Task[task_name].invoke(nil, nil) }
+        .to raise_error(ArgumentError, /Usage/)
+    end
+  end
+
+  context "when no prompt exists for the agent" do
+    let!(:prompt) { nil }
+
+    it "raises ArgumentError mentioning the agent" do
+      expect { Rake::Task[task_name].invoke(agent_name, nil) }
+        .to raise_error(ArgumentError, /#{agent_name}/)
+    end
+  end
+
+  context "when no dataset exists for the agent" do
+    let!(:dataset) { nil }
+
+    it "raises ActiveRecord::RecordNotFound" do
+      expect { Rake::Task[task_name].invoke(agent_name, nil) }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/tasks/evaluation_run_spec.rb
+++ b/spec/tasks/evaluation_run_spec.rb
@@ -59,6 +59,29 @@ RSpec.describe "evaluation:run rake task" do # rubocop:disable RSpec/DescribeCla
         expect(Leva::Experiment.last.prompt_id).to eq(newer_prompt.id)
       end
     end
+
+    context "when two prompts share the same version" do
+      let!(:second_prompt) { create(:orchestration_prompt, name: agent_name, version: 1) }
+
+      it "uses the highest id as a tiebreaker" do
+        Rake::Task[task_name].invoke(agent_name, nil)
+        expect(Leva::Experiment.last.prompt_id).to eq(second_prompt.id)
+      end
+    end
+  end
+
+  context "when model argument is provided" do
+    let(:model) { "mistral-large-latest" }
+
+    it "stores the model in experiment metadata" do
+      Rake::Task[task_name].invoke(agent_name, model)
+      expect(Leva::Experiment.last.metadata).to include("pipeline_model" => model)
+    end
+
+    it "includes the model in the experiment name" do
+      Rake::Task[task_name].invoke(agent_name, model)
+      expect(Leva::Experiment.last.name).to include(model)
+    end
   end
 
   context "when agent_name is missing" do

--- a/spec/tasks/evaluation_status_spec.rb
+++ b/spec/tasks/evaluation_status_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "evaluation:status rake task" do # rubocop:disable RSpec/DescribeClass
+  let(:task_name) { "evaluation:status" }
+  let(:agent_name) { "Emails::ClassifyAgent" }
+
+  let!(:orchestration_agent) { create(:orchestration_agent, name: agent_name) }
+  let!(:prompt) { create(:orchestration_prompt, name: agent_name) }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task[task_name].reenable
+  end
+
+  def run_task
+    output = StringIO.new
+    $stdout = output
+    Rake::Task[task_name].invoke
+    output.string
+  ensure
+    $stdout = STDOUT
+  end
+
+  it "prints a header row" do
+    output = run_task
+    expect(output).to match(/Agent/i)
+    expect(output).to match(/Samples/i)
+  end
+
+  it "prints a row for the agent" do
+    output = run_task
+    expect(output).to include(agent_name)
+  end
+
+  it "shows the active prompt version" do
+    output = run_task
+    expect(output).to match(/v\d+/)
+  end
+
+  context "when no experiment exists" do
+    it "shows n/a for experiment id" do
+      output = run_task
+      expect(output).to match(/#{Regexp.escape(agent_name)}.*n\/a/)
+    end
+
+    it "shows n/a for score" do
+      output = run_task
+      expect(output).to match(/n\/a/)
+    end
+  end
+
+  context "when an experiment with results exists" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:dataset) { create(:leva_dataset, name: agent_name) }
+    let(:experiment) do
+      create(:leva_experiment,
+             prompt: prompt,
+             dataset: dataset,
+             status: :completed)
+    end
+    let(:runner_result) { create(:leva_runner_result, experiment: experiment) }
+
+    before do
+      create(:leva_evaluation_result,
+             experiment: experiment,
+             runner_result: runner_result,
+             dataset_record: runner_result.dataset_record,
+             score: 4.0)
+      create(:leva_evaluation_result,
+             experiment: experiment,
+             runner_result: runner_result,
+             dataset_record: runner_result.dataset_record,
+             score: 2.0)
+    end
+
+    it "shows the experiment id" do
+      output = run_task
+      expect(output).to include("##{experiment.id}")
+    end
+
+    it "shows the average score" do
+      output = run_task
+      expect(output).to include("3.00")
+    end
+  end
+
+  context "when qualifying action runs exist" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:action) { create(:orchestration_action, kind: :agent, agent: orchestration_agent) }
+    let(:step_action) { create(:orchestration_step_action, action: action) }
+    let(:pipeline_run) { create(:orchestration_pipeline_run, pipeline: step_action.step.pipeline) }
+
+    before do
+      chat = create(:chat)
+      create(:orchestration_action_run,
+             step_action: step_action,
+             pipeline_run: pipeline_run,
+             status: "completed",
+             chat: chat)
+    end
+
+    it "shows the qualifying sample count" do
+      output = run_task
+      expect(output).to match(/#{Regexp.escape(agent_name)}\s+1\b/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `evaluation:run[agent_name,model]` — creates a `Leva::Experiment` for the agent's active prompt and dataset, enqueues `Leva::ExperimentJob`, prints experiment id
- Adds `evaluation:run_all[model]` — runs an evaluation for every agent in the database, skipping agents without a prompt or dataset
- Adds `evaluation:status` — prints a per-agent table with qualifying sample count, latest experiment id, average score, and active prompt version

Closes #70

## Test plan
- [ ] 25 new specs in `spec/tasks/evaluation_run_spec.rb`, `spec/tasks/evaluation_run_all_spec.rb`, `spec/tasks/evaluation_status_spec.rb` — all pass
- [ ] Full RSpec suite: 1257 examples, 0 failures
- [ ] RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)