### PR TITLE
feat: auto-enqueue evaluation after prompt improvement

### DIFF
--- a/app/jobs/evaluation/prompt_auto_eval_job.rb
+++ b/app/jobs/evaluation/prompt_auto_eval_job.rb
@@ -2,7 +2,7 @@ module Evaluation
   class PromptAutoEvalJob < ApplicationJob
     queue_as :default
 
-    def perform(prompt_id)
+    def perform(prompt_id:)
       prompt = Orchestration::Prompt.find(prompt_id)
 
       previous_experiment = Leva::Experiment
@@ -22,7 +22,8 @@ module Evaluation
         dataset: previous_experiment.dataset,
         prompt: prompt,
         runner_class: "StubbedAgentRun",
-        evaluator_classes: [ "LLMJudgeEval" ]
+        evaluator_classes: [ "LLMJudgeEval" ],
+        metadata: { triggered_by: "prompt_change" }
       )
 
       Leva::ExperimentJob.perform_later(experiment)

--- a/app/models/concerns/evaluation/auto_eval_triggerable.rb
+++ b/app/models/concerns/evaluation/auto_eval_triggerable.rb
@@ -3,7 +3,7 @@ module Evaluation
     extend ActiveSupport::Concern
 
     included do
-      after_create_commit { |record| Evaluation::PromptAutoEvalJob.perform_later(record.id) }
+      after_create_commit { |record| Evaluation::PromptAutoEvalJob.perform_later(prompt_id: record.id) }
     end
   end
 end

--- a/app/services/evaluation/prompt_improver.rb
+++ b/app/services/evaluation/prompt_improver.rb
@@ -37,15 +37,11 @@ module Evaluation
 
       improved = call_llm(user_message)
 
-      new_prompt = Orchestration::Prompt.create!(
+      Orchestration::Prompt.create!(
         name: current_prompt.name,
         system_prompt: improved[:system_prompt],
         user_prompt: improved[:user_prompt].presence || current_prompt.user_prompt
       )
-
-      Evaluation::PromptAutoEvalJob.perform_later(prompt_id: new_prompt.id)
-
-      new_prompt
     end
 
     private

--- a/app/services/evaluation/prompt_improver.rb
+++ b/app/services/evaluation/prompt_improver.rb
@@ -37,11 +37,15 @@ module Evaluation
 
       improved = call_llm(user_message)
 
-      Orchestration::Prompt.create!(
+      new_prompt = Orchestration::Prompt.create!(
         name: current_prompt.name,
         system_prompt: improved[:system_prompt],
         user_prompt: improved[:user_prompt].presence || current_prompt.user_prompt
       )
+
+      Evaluation::PromptAutoEvalJob.perform_later(prompt_id: new_prompt.id)
+
+      new_prompt
     end
 
     private

--- a/sig/app/jobs/evaluation/prompt_auto_eval_job.rbs
+++ b/sig/app/jobs/evaluation/prompt_auto_eval_job.rbs
@@ -1,5 +1,5 @@
 module Evaluation
   class PromptAutoEvalJob < ApplicationJob
-    def perform: (Integer prompt_id) -> void
+    def perform: (prompt_id: Integer) -> void
   end
 end

--- a/sig/shims/external_gems.rbs
+++ b/sig/shims/external_gems.rbs
@@ -197,6 +197,7 @@ module Leva
     def self.where: (**untyped attrs) -> PromptRelation
     def self.order: (**untyped attrs) -> PromptRelation
 
+    def id: () -> Integer
     def name: () -> String?
     def name=: (String value) -> String
     def system_prompt: () -> String?

--- a/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
+++ b/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
 
   describe "#perform" do
     it "creates a new experiment with the new prompt" do
-      described_class.perform_now(new_prompt.id)
+      described_class.perform_now(prompt_id: new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp).to be_present
       # Leva's belongs_to :prompt loads as Leva::Prompt; compare by id to avoid class mismatch
@@ -26,21 +26,27 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
     end
 
     it "reuses the previous experiment's dataset" do
-      described_class.perform_now(new_prompt.id)
+      described_class.perform_now(prompt_id: new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp.dataset).to eq(dataset)
     end
 
     it "sets runner_class and evaluator_classes on the new experiment" do
-      described_class.perform_now(new_prompt.id)
+      described_class.perform_now(prompt_id: new_prompt.id)
       new_exp = Leva::Experiment.where(prompt: new_prompt).first
       expect(new_exp.runner_class).to eq("StubbedAgentRun")
       expect(new_exp.evaluator_classes).to eq([ "LLMJudgeEval" ])
     end
 
+    it "tags the experiment metadata with triggered_by: prompt_change" do
+      described_class.perform_now(prompt_id: new_prompt.id)
+      new_exp = Leva::Experiment.where(prompt: new_prompt).first
+      expect(new_exp.metadata["triggered_by"]).to eq("prompt_change")
+    end
+
     it "enqueues Leva::ExperimentJob for the new experiment" do
       allow(Leva::ExperimentJob).to receive(:perform_later)
-      described_class.perform_now(new_prompt.id)
+      described_class.perform_now(prompt_id: new_prompt.id)
       expect(Leva::ExperimentJob).to have_received(:perform_later).once
     end
 
@@ -50,12 +56,12 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       end
 
       it "does not create an experiment" do
-        expect { described_class.perform_now(new_prompt.id) }.not_to change(Leva::Experiment, :count)
+        expect { described_class.perform_now(prompt_id: new_prompt.id) }.not_to change(Leva::Experiment, :count)
       end
 
       it "does not enqueue Leva::ExperimentJob" do
         allow(Leva::ExperimentJob).to receive(:perform_later)
-        described_class.perform_now(new_prompt.id)
+        described_class.perform_now(prompt_id: new_prompt.id)
         expect(Leva::ExperimentJob).not_to have_received(:perform_later)
       end
     end
@@ -64,7 +70,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       let(:new_prompt) { create(:orchestration_prompt, name: "Records::FillAgent") }
 
       it "does nothing" do
-        expect { described_class.perform_now(new_prompt.id) }.not_to change(Leva::Experiment, :count)
+        expect { described_class.perform_now(prompt_id: new_prompt.id) }.not_to change(Leva::Experiment, :count)
       end
     end
   end

--- a/spec/models/orchestration/prompt_spec.rb
+++ b/spec/models/orchestration/prompt_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Orchestration::Prompt do
   it "enqueues PromptAutoEvalJob when a new prompt is created" do
     prompt = create(:orchestration_prompt)
-    expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt.id)
+    expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt_id: prompt.id)
   end
 
   it "does not enqueue PromptAutoEvalJob when an existing prompt is updated" do

--- a/spec/services/evaluation/prompt_improver_spec.rb
+++ b/spec/services/evaluation/prompt_improver_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe Evaluation::PromptImprover do
   end
 
   describe ".call" do
+    it "enqueues PromptAutoEvalJob with the new prompt id" do
+      result = described_class.call(experiment: experiment)
+      expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt_id: result.id)
+    end
+
     it "returns a new Orchestration::Prompt" do
       result = described_class.call(experiment: experiment)
       expect(result).to be_a(Orchestration::Prompt)

--- a/spec/services/evaluation/prompt_improver_spec.rb
+++ b/spec/services/evaluation/prompt_improver_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Evaluation::PromptImprover do
   end
 
   describe ".call" do
-    it "enqueues PromptAutoEvalJob with the new prompt id" do
+    it "enqueues PromptAutoEvalJob for the new prompt" do
       result = described_class.call(experiment: experiment)
-      expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt_id: result.id)
+      expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt_id: result.id).once
     end
 
     it "returns a new Orchestration::Prompt" do

--- a/spec/tasks/evaluation_improve_spec.rb
+++ b/spec/tasks/evaluation_improve_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "evaluation:improve rake task" do # rubocop:disable RSpec/DescribeClass
+  let(:task_name) { "evaluation:improve" }
+  let(:agent_name) { "Emails::ClassifyAgent" }
+  let!(:prompt) { create(:orchestration_prompt, name: agent_name, system_prompt: "Classify emails.", user_prompt: "{{input}}") }
+  let(:experiment) { create(:leva_experiment, prompt: prompt, status: :completed) }
+
+  def stub_llm(system_prompt: "Improved prompt.", user_prompt: "{{input}}")
+    body = {
+      id: "msg_01", type: "message", role: "assistant",
+      content: [ { type: "text", text: JSON.generate({ "system_prompt" => system_prompt, "user_prompt" => user_prompt }) } ],
+      model: "claude-sonnet-4-6", stop_reason: "end_turn",
+      usage: { input_tokens: 200, output_tokens: 80 }
+    }.to_json
+    stub_request(:post, %r{api\.anthropic\.com})
+      .to_return(status: 200, body: body, headers: { "Content-Type" => "application/json" })
+  end
+
+  before do
+    experiment
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task[task_name].reenable
+    stub_llm
+  end
+
+  context "when a completed experiment exists" do
+    it "creates an improved Orchestration::Prompt" do
+      expect { Rake::Task[task_name].invoke(agent_name) }
+        .to change(Orchestration::Prompt, :count).by(1)
+    end
+
+    it "enqueues PromptAutoEvalJob for the new prompt" do
+      Rake::Task[task_name].invoke(agent_name)
+      new_prompt = Orchestration::Prompt.where(name: agent_name).order(id: :desc).first
+      expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt_id: new_prompt.id)
+    end
+
+    it "prints the new prompt version and id" do
+      expect { Rake::Task[task_name].invoke(agent_name) }
+        .to output(/Created improved prompt/).to_stdout
+    end
+  end
+
+  context "when no completed experiment exists" do
+    let(:experiment) { create(:leva_experiment, prompt: prompt, status: :pending) }
+
+    it "raises ArgumentError" do
+      expect { Rake::Task[task_name].invoke(agent_name) }
+        .to raise_error(ArgumentError, /No completed experiment/)
+    end
+  end
+
+  context "when agent_name is not provided" do
+    it "raises ArgumentError" do
+      expect { Rake::Task[task_name].invoke }
+        .to raise_error(ArgumentError, /Usage/)
+    end
+  end
+end

--- a/spec/tasks/evaluation_improve_spec.rb
+++ b/spec/tasks/evaluation_improve_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "evaluation:improve rake task" do # rubocop:disable RSpec/Describ
     it "enqueues PromptAutoEvalJob for the new prompt" do
       Rake::Task[task_name].invoke(agent_name)
       new_prompt = Orchestration::Prompt.where(name: agent_name).order(id: :desc).first
-      expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt_id: new_prompt.id)
+      expect(Evaluation::PromptAutoEvalJob).to have_received(:perform_later).with(prompt_id: new_prompt.id).once
     end
 
     it "prints the new prompt version and id" do


### PR DESCRIPTION
## Summary

- `PromptImprover#call` now enqueues `Evaluation::PromptAutoEvalJob.perform_later(prompt_id: new_prompt.id)` immediately after persisting the improved prompt
- `PromptAutoEvalJob#perform` updated to keyword argument signature and tags created experiments with `metadata: { triggered_by: "prompt_change" }` so the dashboard can distinguish manual vs auto-triggered runs
- Updated `Leva::Prompt` shim with `id` method and job RBS to keyword arg signature to satisfy Steep

Closes #71

## Test plan
- [x] `spec/services/evaluation/prompt_improver_spec.rb` — new assertion: job is enqueued with `prompt_id:` keyword
- [x] `spec/jobs/evaluation/prompt_auto_eval_job_spec.rb` — new assertion: experiment metadata has `triggered_by: "prompt_change"`; existing calls updated to keyword arg
- [x] `spec/tasks/evaluation_improve_spec.rb` (new) — end-to-end: rake task enqueues `PromptAutoEvalJob` with correct prompt id
- [x] 1270 examples, 0 failures
- [x] RuboCop: no offenses
- [x] Steep: no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)