### PR TITLE
feat: evaluation dashboard with score-over-time chart per agent

### DIFF
--- a/app/components/evaluation/dashboard_component.html.erb
+++ b/app/components/evaluation/dashboard_component.html.erb
@@ -1,0 +1,29 @@
+<div class="rounded-lg border border-gray-200 bg-white shadow-sm p-6 space-y-4">
+  <div class="flex items-center justify-between">
+    <h2 class="text-lg font-semibold text-gray-800"><%= agent_name %></h2>
+    <% if latest_experiment %>
+      <%= link_to "View Experiment", evaluation_experiment_path(latest_experiment), class: "text-sm text-indigo-600 hover:underline" %>
+    <% end %>
+  </div>
+
+  <dl class="grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-4">
+    <div>
+      <dt class="font-medium text-gray-500">Latest Experiment</dt>
+      <dd class="text-gray-700"><%= latest_experiment&.id || "—" %></dd>
+    </div>
+    <div>
+      <dt class="font-medium text-gray-500">Avg Score</dt>
+      <dd class="text-gray-700"><%= format_score(latest_score) %></dd>
+    </div>
+    <div>
+      <dt class="font-medium text-gray-500">Active Prompt</dt>
+      <dd class="text-gray-700"><%= active_prompt_version ? "v#{active_prompt_version}" : "—" %></dd>
+    </div>
+    <div>
+      <dt class="font-medium text-gray-500">Samples</dt>
+      <dd class="text-gray-700"><%= sample_count %></dd>
+    </div>
+  </dl>
+
+  <%= render Evaluation::ScoreOverTimeComponent.new(agent_name: agent_name, data: score_over_time_data) %>
+</div>

--- a/app/components/evaluation/dashboard_component.rb
+++ b/app/components/evaluation/dashboard_component.rb
@@ -11,23 +11,7 @@ module Evaluation
     def latest_score = @summary.latest_score
     def active_prompt_version = @summary.active_prompt_version
     def sample_count = @summary.sample_count
-
-    def score_over_time_data
-      experiments = Leva::Experiment
-        .joins(:prompt)
-        .where(leva_prompts: { name: agent_name })
-        .order(:created_at)
-
-      experiments.map do |exp|
-        avg = Leva::EvaluationResult.where(experiment_id: exp.id).average(:score)
-        {
-          id: exp.id,
-          name: exp.name,
-          created_at: exp.created_at.strftime("%Y-%m-%d"),
-          avg_score: avg&.to_f&.round(2)
-        }
-      end
-    end
+    def score_over_time_data = @summary.score_history
 
     def format_score(score)
       score.nil? ? "—" : score.to_s

--- a/app/components/evaluation/dashboard_component.rb
+++ b/app/components/evaluation/dashboard_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class DashboardComponent < ViewComponent::Base
+    def initialize(summary:)
+      @summary = summary
+    end
+
+    def agent_name = @summary.agent_name
+    def latest_experiment = @summary.latest_experiment
+    def latest_score = @summary.latest_score
+    def active_prompt_version = @summary.active_prompt_version
+    def sample_count = @summary.sample_count
+
+    def score_over_time_data
+      experiments = Leva::Experiment
+        .joins(:prompt)
+        .where(leva_prompts: { name: agent_name })
+        .order(:created_at)
+
+      experiments.map do |exp|
+        avg = Leva::EvaluationResult.where(experiment_id: exp.id).average(:score)
+        {
+          id: exp.id,
+          name: exp.name,
+          created_at: exp.created_at.strftime("%Y-%m-%d"),
+          avg_score: avg&.to_f&.round(2)
+        }
+      end
+    end
+
+    def format_score(score)
+      score.nil? ? "—" : score.to_s
+    end
+  end
+end

--- a/app/components/evaluation/score_over_time_component.html.erb
+++ b/app/components/evaluation/score_over_time_component.html.erb
@@ -1,0 +1,11 @@
+<% if has_data? %>
+  <div
+    data-controller="evaluation--score-chart"
+    data-evaluation--score-chart-points-value="<%= chart_data_json %>"
+    class="mt-4 h-40"
+  >
+    <canvas></canvas>
+  </div>
+<% else %>
+  <p class="mt-4 text-xs text-gray-400">No experiment data to chart.</p>
+<% end %>

--- a/app/components/evaluation/score_over_time_component.rb
+++ b/app/components/evaluation/score_over_time_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class ScoreOverTimeComponent < ViewComponent::Base
+    def initialize(agent_name:, data:)
+      @agent_name = agent_name
+      @data = data
+    end
+
+    def chart_data_json
+      @data.to_json
+    end
+
+    def has_data?
+      @data.any?
+    end
+  end
+end

--- a/app/controllers/evaluation/dashboard_controller.rb
+++ b/app/controllers/evaluation/dashboard_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class DashboardController < ApplicationController
+    def show
+      @agent_summaries = agent_summaries
+    end
+
+    private
+
+    AgentSummary = Data.define(:agent_name, :latest_experiment, :latest_score, :active_prompt_version, :sample_count)
+
+    def agent_summaries
+      prompt_names = Leva::Experiment.joins(:prompt).distinct.pluck("leva_prompts.name")
+      prompt_names.map { |name| build_summary(name) }
+    end
+
+    def build_summary(agent_name)
+      experiments = Leva::Experiment
+        .joins(:prompt)
+        .where(leva_prompts: { name: agent_name })
+        .order(created_at: :desc)
+
+      latest = experiments.first
+      score = latest ? average_score(latest) : nil
+      count = latest ? Leva::EvaluationResult.where(experiment_id: latest.id).count : 0
+      version = active_version(agent_name)
+
+      AgentSummary.new(
+        agent_name: agent_name,
+        latest_experiment: latest,
+        latest_score: score,
+        active_prompt_version: version,
+        sample_count: count
+      )
+    end
+
+    def average_score(experiment)
+      avg = Leva::EvaluationResult.where(experiment_id: experiment.id).average(:score)
+      avg&.to_f&.round(2)
+    end
+
+    def active_version(agent_name)
+      Orchestration::Prompt.where(name: agent_name).find_each do |p|
+        meta = JSON.parse(p.metadata || "{}")
+        return p.version if meta["active"]
+      rescue JSON::ParserError
+        next
+      end
+      nil
+    end
+  end
+end

--- a/app/controllers/evaluation/dashboard_controller.rb
+++ b/app/controllers/evaluation/dashboard_controller.rb
@@ -2,52 +2,85 @@
 
 module Evaluation
   class DashboardController < ApplicationController
+    AgentSummary = Data.define(:agent_name, :latest_experiment, :latest_score, :active_prompt_version, :sample_count, :score_history)
+
     def show
       @agent_summaries = agent_summaries
     end
 
     private
 
-    AgentSummary = Data.define(:agent_name, :latest_experiment, :latest_score, :active_prompt_version, :sample_count)
-
     def agent_summaries
       prompt_names = Leva::Experiment.joins(:prompt).distinct.pluck("leva_prompts.name")
-      prompt_names.map { |name| build_summary(name) }
-    end
+      return [] if prompt_names.empty?
 
-    def build_summary(agent_name)
-      experiments = Leva::Experiment
+      all_experiments = Leva::Experiment
         .joins(:prompt)
-        .where(leva_prompts: { name: agent_name })
-        .order(created_at: :desc)
+        .where(leva_prompts: { name: prompt_names })
+        .includes(:prompt)
+        .order(:created_at)
+        .to_a
 
-      latest = experiments.first
-      score = latest ? average_score(latest) : nil
-      count = latest ? Leva::EvaluationResult.where(experiment_id: latest.id).count : 0
-      version = active_version(agent_name)
+      experiments_by_agent = all_experiments.group_by { |e| e.prompt.name }
+      latest_by_agent = experiments_by_agent.transform_values(&:last)
 
-      AgentSummary.new(
-        agent_name: agent_name,
-        latest_experiment: latest,
-        latest_score: score,
-        active_prompt_version: version,
-        sample_count: count
-      )
-    end
+      latest_ids = latest_by_agent.values.compact.map(&:id)
+      latest_stats = batch_stats(latest_ids)
 
-    def average_score(experiment)
-      avg = Leva::EvaluationResult.where(experiment_id: experiment.id).average(:score)
-      avg&.to_f&.round(2)
-    end
+      history_avgs = Leva::EvaluationResult
+        .where(experiment_id: all_experiments.map(&:id))
+        .group(:experiment_id)
+        .average(:score)
 
-    def active_version(agent_name)
-      Orchestration::Prompt.where(name: agent_name).find_each do |p|
-        meta = JSON.parse(p.metadata || "{}")
-        return p.version if meta["active"]
-      rescue JSON::ParserError
-        next
+      active_vers = active_versions_for(prompt_names)
+
+      prompt_names.map do |name|
+        exps = experiments_by_agent[name] || []
+        latest = latest_by_agent[name]
+        stats = latest ? latest_stats[latest.id] : nil
+
+        AgentSummary.new(
+          agent_name: name,
+          latest_experiment: latest,
+          latest_score: stats&.dig(:avg),
+          active_prompt_version: active_vers[name],
+          sample_count: stats&.dig(:count) || 0,
+          score_history: build_score_history(exps, history_avgs)
+        )
       end
-      nil
+    end
+
+    def batch_stats(experiment_ids)
+      return {} if experiment_ids.empty?
+
+      Leva::EvaluationResult
+        .where(experiment_id: experiment_ids)
+        .group(:experiment_id)
+        .pluck(:experiment_id, Arel.sql("AVG(score)"), Arel.sql("COUNT(*)"))
+        .each_with_object({}) do |(exp_id, avg, count), h|
+          h[exp_id] = { avg: avg&.to_f&.round(2), count: count }
+        end
+    end
+
+    def build_score_history(experiments, avgs_by_id)
+      experiments.map do |exp|
+        avg = avgs_by_id[exp.id]
+        { created_at: exp.created_at.strftime("%Y-%m-%d"), avg_score: avg&.to_f&.round(2) }
+      end
+    end
+
+    def active_versions_for(agent_names)
+      Orchestration::Prompt
+        .where(name: agent_names)
+        .where("metadata LIKE ?", '%"active":true%')
+        .each_with_object({}) do |p, h|
+          next if h.key?(p.name)
+
+          meta = JSON.parse(p.metadata || "{}")
+          h[p.name] = p.version if meta["active"]
+        rescue JSON::ParserError
+          Rails.logger.warn("Prompt #{p.id} has invalid JSON metadata")
+        end
     end
   end
 end

--- a/app/javascript/controllers/evaluation/score_chart_controller.ts
+++ b/app/javascript/controllers/evaluation/score_chart_controller.ts
@@ -1,0 +1,50 @@
+import { Controller } from "@hotwired/stimulus"
+import { Chart, LineController, LineElement, PointElement, LinearScale, CategoryScale, Tooltip } from "chart.js"
+
+Chart.register(LineController, LineElement, PointElement, LinearScale, CategoryScale, Tooltip)
+
+interface DataPoint {
+  id: number
+  name: string
+  created_at: string
+  avg_score: number | null
+}
+
+export default class extends Controller {
+  static values = { points: Array }
+
+  declare pointsValue: DataPoint[]
+
+  connect() {
+    const canvas = this.element.querySelector("canvas")
+    if (!canvas) return
+
+    const labels = this.pointsValue.map(p => p.created_at)
+    const scores = this.pointsValue.map(p => p.avg_score)
+
+    new Chart(canvas as HTMLCanvasElement, {
+      type: "line",
+      data: {
+        labels,
+        datasets: [
+          {
+            label: "Avg Score",
+            data: scores,
+            borderColor: "#6366f1",
+            backgroundColor: "rgba(99, 102, 241, 0.1)",
+            tension: 0.3,
+            fill: true,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: { min: 0, max: 5, ticks: { stepSize: 1 } },
+        },
+        plugins: { tooltip: { enabled: true } },
+      },
+    })
+  }
+}

--- a/app/javascript/controllers/evaluation/score_chart_controller.ts
+++ b/app/javascript/controllers/evaluation/score_chart_controller.ts
@@ -4,8 +4,6 @@ import { Chart, LineController, LineElement, PointElement, LinearScale, Category
 Chart.register(LineController, LineElement, PointElement, LinearScale, CategoryScale, Tooltip)
 
 interface DataPoint {
-  id: number
-  name: string
   created_at: string
   avg_score: number | null
 }

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -2,8 +2,10 @@ import { application } from "./application"
 import AccordionController from "./accordion_controller"
 import BatchController from "./batch_controller"
 import DialogController from "./dialog_controller"
+import ScoreChartController from "./evaluation/score_chart_controller"
 
 application.register("accordion", AccordionController)
 application.register("batch", BatchController)
 application.register("dialog", DialogController)
+application.register("evaluation--score-chart", ScoreChartController)
 

--- a/app/views/evaluation/dashboard/show.html.erb
+++ b/app/views/evaluation/dashboard/show.html.erb
@@ -1,0 +1,11 @@
+<%= render UI::PageHeaderComponent.new(title: "Evaluation Dashboard") %>
+
+<div class="space-y-8">
+  <% @agent_summaries.each do |summary| %>
+    <%= render Evaluation::DashboardComponent.new(summary: summary) %>
+  <% end %>
+
+  <% if @agent_summaries.empty? %>
+    <p class="text-gray-500 text-sm">No experiments found.</p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   end
 
   namespace :evaluation do
+    root to: "dashboard#show"
     resources :metrics, only: [ :index, :edit, :update ]
     get "prompts/:id/diff", to: "prompt_diffs#show", as: :prompt_diff
     resources :experiments, only: [ :index, :show ] do

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.12",
-    "@stimulus-components/dialog": "^1.0.1"
+    "@stimulus-components/dialog": "^1.0.1",
+    "chart.js": "^4.5.1"
   },
   "devDependencies": {
     "esbuild": "^0.25.0",
     "typescript": "^5.8.0"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@stimulus-components/dialog':
         specifier: ^1.0.1
         version: 1.0.1(@hotwired/stimulus@3.2.2)
+      chart.js:
+        specifier: ^4.5.1
+        version: 4.5.1
     devDependencies:
       esbuild:
         specifier: ^0.25.0
@@ -193,6 +196,9 @@ packages:
     resolution: {integrity: sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==}
     engines: {node: '>= 18'}
 
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
   '@rails/actioncable@8.1.300':
     resolution: {integrity: sha512-zOENQsq3NM2jyBY6Z2qtZa3V/R/6OEqA+LGKixQbBMl7kk/J3FXDRcszPe74LsHNgB01jCl/DXu/xA8sHt4I/g==}
 
@@ -200,6 +206,10 @@ packages:
     resolution: {integrity: sha512-7cpazrXeFKVmmuGnJOrykEvjRNRTOhLuI7SzgDdAlKWxM8ivBKziBHwjJGR96vCvSkoKwlGMGRcDzXgVRnr/7w==}
     peerDependencies:
       '@hotwired/stimulus': ^3.0.0
+
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -300,11 +310,17 @@ snapshots:
 
   '@hotwired/turbo@8.0.23': {}
 
+  '@kurkle/color@0.3.4': {}
+
   '@rails/actioncable@8.1.300': {}
 
   '@stimulus-components/dialog@1.0.1(@hotwired/stimulus@3.2.2)':
     dependencies:
       '@hotwired/stimulus': 3.2.2
+
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   esbuild@0.25.12:
     optionalDependencies:

--- a/sig/app/components/evaluation/dashboard_component.rbs
+++ b/sig/app/components/evaluation/dashboard_component.rbs
@@ -1,0 +1,12 @@
+module Evaluation
+  class DashboardComponent < ViewComponent::Base
+    def initialize: (summary: untyped) -> void
+    def agent_name: () -> String
+    def latest_experiment: () -> untyped
+    def latest_score: () -> Float?
+    def active_prompt_version: () -> Integer?
+    def sample_count: () -> Integer
+    def score_over_time_data: () -> Array[Hash[Symbol, untyped]]
+    def format_score: (Float? score) -> String
+  end
+end

--- a/sig/app/components/evaluation/score_over_time_component.rbs
+++ b/sig/app/components/evaluation/score_over_time_component.rbs
@@ -1,0 +1,7 @@
+module Evaluation
+  class ScoreOverTimeComponent < ViewComponent::Base
+    def initialize: (agent_name: String, data: Array[Hash[Symbol, untyped]]) -> void
+    def chart_data_json: () -> String
+    def has_data?: () -> bool
+  end
+end

--- a/sig/app/controllers/evaluation/dashboard_controller.rbs
+++ b/sig/app/controllers/evaluation/dashboard_controller.rbs
@@ -1,0 +1,14 @@
+module Evaluation
+  class DashboardController < ApplicationController
+    AgentSummary: Data
+
+    def show: () -> void
+
+    private
+
+    def agent_summaries: () -> Array[untyped]
+    def build_summary: (String agent_name) -> untyped
+    def average_score: (untyped experiment) -> Float?
+    def active_version: (String agent_name) -> Integer?
+  end
+end

--- a/sig/app/controllers/evaluation/dashboard_controller.rbs
+++ b/sig/app/controllers/evaluation/dashboard_controller.rbs
@@ -7,8 +7,8 @@ module Evaluation
     private
 
     def agent_summaries: () -> Array[untyped]
-    def build_summary: (String agent_name) -> untyped
-    def average_score: (untyped experiment) -> Float?
-    def active_version: (String agent_name) -> Integer?
+    def batch_stats: (Array[Integer] experiment_ids) -> Hash[Integer, Hash[Symbol, untyped]]
+    def build_score_history: (Array[untyped] experiments, Hash[Integer, untyped] avgs_by_id) -> Array[Hash[Symbol, untyped]]
+    def active_versions_for: (Array[String] agent_names) -> Hash[String, Integer]
   end
 end

--- a/spec/components/evaluation/dashboard_component_spec.rb
+++ b/spec/components/evaluation/dashboard_component_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Evaluation::DashboardComponent, type: :component do
       latest_score: nil,
       active_prompt_version: nil,
       sample_count: 0,
+      score_history: [],
       **overrides
     )
   end
@@ -72,17 +73,19 @@ RSpec.describe Evaluation::DashboardComponent, type: :component do
 
   context "with many experiments — score-over-time chart present" do
     let(:experiment) { create(:leva_experiment) }
+    let(:score_history) do
+      [
+        { created_at: "2026-01-01", avg_score: 3.0 },
+        { created_at: "2026-02-01", avg_score: 4.0 }
+      ]
+    end
     let(:component) do
       described_class.new(summary: build_summary(
         agent_name: experiment.prompt.name,
         latest_experiment: experiment,
-        sample_count: 5
+        sample_count: 5,
+        score_history: score_history
       ))
-    end
-
-    before do
-      # second experiment for same agent (same prompt name means same agent)
-      create(:leva_experiment, prompt: experiment.prompt)
     end
 
     it "renders the ScoreOverTimeComponent chart wrapper" do

--- a/spec/components/evaluation/dashboard_component_spec.rb
+++ b/spec/components/evaluation/dashboard_component_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::DashboardComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  def build_summary(overrides = {})
+    Evaluation::DashboardController::AgentSummary.new(
+      agent_name: "TestAgent",
+      latest_experiment: nil,
+      latest_score: nil,
+      active_prompt_version: nil,
+      sample_count: 0,
+      **overrides
+    )
+  end
+
+  context "with no experiments (nil latest_experiment)" do
+    let(:component) { described_class.new(summary: build_summary) }
+
+    it "renders agent name" do
+      expect(rendered.text).to include("TestAgent")
+    end
+
+    it "renders em dash for missing score" do
+      expect(rendered.text).to include("—")
+    end
+
+    it "renders 0 sample count" do
+      expect(rendered.text).to include("0")
+    end
+
+    it "does not render a link to experiment" do
+      expect(rendered.css("a[href*='experiment']")).to be_empty
+    end
+  end
+
+  context "with one completed experiment" do
+    let(:experiment) { create(:leva_experiment, status: :completed) }
+    let(:summary) do
+      build_summary(
+        agent_name: experiment.prompt.name,
+        latest_experiment: experiment,
+        latest_score: 3.8,
+        active_prompt_version: 2,
+        sample_count: 10
+      )
+    end
+    let(:component) { described_class.new(summary: summary) }
+
+    it "renders the experiment id" do
+      expect(rendered.text).to include(experiment.id.to_s)
+    end
+
+    it "renders the average score" do
+      expect(rendered.text).to include("3.8")
+    end
+
+    it "renders the active prompt version" do
+      expect(rendered.text).to include("v2")
+    end
+
+    it "renders the sample count" do
+      expect(rendered.text).to include("10")
+    end
+
+    it "links to the experiment" do
+      expect(rendered.css("a[href*='experiments']")).to be_present
+    end
+  end
+
+  context "with many experiments — score-over-time chart present" do
+    let(:experiment) { create(:leva_experiment) }
+    let(:component) do
+      described_class.new(summary: build_summary(
+        agent_name: experiment.prompt.name,
+        latest_experiment: experiment,
+        sample_count: 5
+      ))
+    end
+
+    before do
+      # second experiment for same agent (same prompt name means same agent)
+      create(:leva_experiment, prompt: experiment.prompt)
+    end
+
+    it "renders the ScoreOverTimeComponent chart wrapper" do
+      expect(rendered.css("[data-controller='evaluation--score-chart']")).to be_present
+    end
+  end
+end

--- a/spec/components/evaluation/score_over_time_component_spec.rb
+++ b/spec/components/evaluation/score_over_time_component_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::ScoreOverTimeComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:agent_name) { "EmailClassifierAgent" }
+
+  context "with no experiments" do
+    let(:component) { described_class.new(agent_name: agent_name, data: []) }
+
+    it "renders no-data message" do
+      expect(rendered.text).to include("No experiment data")
+    end
+
+    it "does not render a chart container" do
+      expect(rendered.css("[data-controller='evaluation--score-chart']")).to be_empty
+    end
+  end
+
+  context "with one experiment" do
+    let(:data) { [ { id: 1, name: "exp_1", created_at: "2026-01-01", avg_score: 3.5 } ] }
+    let(:component) { described_class.new(agent_name: agent_name, data: data) }
+
+    it "renders chart container with stimulus controller" do
+      expect(rendered.css("[data-controller='evaluation--score-chart']")).to be_present
+    end
+
+    it "embeds experiment data as JSON" do
+      json = rendered.at_css("[data-controller='evaluation--score-chart']")
+               &.attr("data-evaluation--score-chart-points-value")
+      expect(JSON.parse(json).first["avg_score"]).to eq(3.5)
+    end
+  end
+
+  context "with many experiments" do
+    let(:data) do
+      [
+        { id: 1, name: "exp_1", created_at: "2026-01-01", avg_score: 3.0 },
+        { id: 2, name: "exp_2", created_at: "2026-02-01", avg_score: 4.0 },
+        { id: 3, name: "exp_3", created_at: "2026-03-01", avg_score: 4.5 }
+      ]
+    end
+    let(:component) { described_class.new(agent_name: agent_name, data: data) }
+
+    it "encodes all experiments in the JSON payload" do
+      json = rendered.at_css("[data-controller='evaluation--score-chart']")
+               &.attr("data-evaluation--score-chart-points-value")
+      points = JSON.parse(json)
+      expect(points.length).to eq(3)
+      expect(points.map { |p| p["avg_score"] }).to eq([ 3.0, 4.0, 4.5 ])
+    end
+  end
+end

--- a/spec/requests/evaluation/dashboard_spec.rb
+++ b/spec/requests/evaluation/dashboard_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Evaluation::Dashboard" do
+  describe "GET /evaluation" do
+    it "returns 200" do
+      get evaluation_root_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "shows agent names from experiments" do
+      prompt = create(:orchestration_prompt, name: "EmailClassifierAgent")
+      create(:leva_experiment, prompt: prompt, status: :completed)
+      get evaluation_root_path
+      expect(response.body).to include("EmailClassifierAgent")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `/evaluation` route and `Evaluation::DashboardController#show` as the evaluation landing page
- `Evaluation::DashboardComponent` renders one card per agent: name, latest experiment id, avg score, active prompt version, and sample count
- `Evaluation::ScoreOverTimeComponent` embeds per-experiment avg-score history as a JSON data attribute for the Stimulus chart controller
- `evaluation/score_chart_controller.ts` uses Chart.js (added as a dep) to render the line chart from the JSON payload; `pnpm run build` produces the updated bundle
- Component specs cover zero/one/many experiments; request spec covers the new route
- RBS sigs added for both components and the controller

Closes #72

## Test plan
- [x] `spec/requests/evaluation/dashboard_spec.rb` — 2 examples, all passing
- [x] `spec/components/evaluation/dashboard_component_spec.rb` — 10 examples, all passing
- [x] `spec/components/evaluation/score_over_time_component_spec.rb` — 5 examples, all passing
- [x] Full suite: 1287 examples, 0 failures, 95.85% coverage
- [x] RuboCop: no offenses
- [x] Steep type check: no errors
- [x] `pnpm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)