### PR TITLE
feat: orchestration data flow foundation — schema migration + model validations

### DIFF
--- a/app/components/orchestration/step_component.html.erb
+++ b/app/components/orchestration/step_component.html.erb
@@ -24,12 +24,6 @@
           </div>
         <% end %>
 
-        <% if @step.input_mapping.present? %>
-          <div class="mt-2">
-            <span class="text-xs text-gray-400">Input mapping: </span>
-            <code class="text-xs text-gray-600 font-mono"><%= @step.input_mapping.to_json %></code>
-          </div>
-        <% end %>
       </div>
     </div>
 

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -6,12 +6,28 @@ module Orchestration
     before_action :set_step
 
     def create
+      action = Orchestration::Action.find_by(id: params.dig(:orchestration_step_action, :action_id))
+      unless action
+        redirect_to orchestration_pipeline_path(@pipeline), alert: "Invalid action." and return
+      end
+
+      parsed = step_action_params
+      unless parsed
+        redirect_to orchestration_pipeline_path(@pipeline), alert: "Params must be valid JSON." and return
+      end
+
       next_position = (@step.step_actions.maximum(:position) || 0) + 1
-      action = Orchestration::Action.find_by(id: step_action_params[:action_id])
-      key = action ? derive_output_key(action.name) : "action_#{next_position}"
-      attrs = step_action_params.merge(position: next_position, output_key: key)
-      @step_action = @step.step_actions.build(attrs)
-      if @step_action.save
+      key = Orchestration::OutputKeyDeriver.call(action_name: action.name, step: @step)
+      @step_action = @step.step_actions.build(parsed.merge(position: next_position, output_key: key))
+
+      begin
+        saved = @step_action.save
+      rescue ActiveRecord::RecordNotUnique
+        @step_action.output_key = "#{key}_#{SecureRandom.hex(3)}"
+        saved = @step_action.save
+      end
+
+      if saved
         redirect_to orchestration_pipeline_path(@pipeline), notice: "Action attached."
       else
         redirect_to orchestration_pipeline_path(@pipeline), alert: "Could not attach action."
@@ -40,21 +56,7 @@ module Orchestration
       permitted[:params] = JSON.parse(raw) if raw.present?
       permitted
     rescue JSON::ParserError
-      permitted
-    end
-
-    def derive_output_key(action_name)
-      base = action_name.to_s.parameterize(separator: "_")
-      base = "action" if base.blank?
-      base = "x_#{base}" unless base.match?(/\A[a-z]/)
-
-      candidate = base
-      suffix    = 2
-      while @step.step_actions.exists?(output_key: candidate)
-        candidate = "#{base}_#{suffix}"
-        suffix += 1
-      end
-      candidate
+      nil
     end
   end
 end

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -7,7 +7,10 @@ module Orchestration
 
     def create
       next_position = (@step.step_actions.maximum(:position) || 0) + 1
-      @step_action = @step.step_actions.build(step_action_params.merge(position: next_position))
+      action = Orchestration::Action.find_by(id: step_action_params[:action_id])
+      key = action ? derive_output_key(action.name) : "action_#{next_position}"
+      attrs = step_action_params.merge(position: next_position, output_key: key)
+      @step_action = @step.step_actions.build(attrs)
       if @step_action.save
         redirect_to orchestration_pipeline_path(@pipeline), notice: "Action attached."
       else
@@ -38,6 +41,20 @@ module Orchestration
       permitted
     rescue JSON::ParserError
       permitted
+    end
+
+    def derive_output_key(action_name)
+      base = action_name.to_s.parameterize(separator: "_")
+      base = "action" if base.blank?
+      base = "x_#{base}" unless base.match?(/\A[a-z]/)
+
+      candidate = base
+      suffix    = 2
+      while @step.step_actions.exists?(output_key: candidate)
+        candidate = "#{base}_#{suffix}"
+        suffix += 1
+      end
+      candidate
     end
   end
 end

--- a/app/controllers/orchestration/steps_controller.rb
+++ b/app/controllers/orchestration/steps_controller.rb
@@ -63,17 +63,7 @@ module Orchestration
     end
 
     def step_params
-      permitted = params.require(:orchestration_step).permit(:name, :input_mapping)
-      raw = permitted[:input_mapping]
-      return permitted unless raw.present?
-
-      permitted.merge(input_mapping: parse_input_mapping(raw))
-    end
-
-    def parse_input_mapping(raw)
-      JSON.parse(raw)
-    rescue JSON::ParserError
-      raw
+      params.require(:orchestration_step).permit(:name)
     end
   end
 end

--- a/app/models/orchestration/step_action.rb
+++ b/app/models/orchestration/step_action.rb
@@ -18,8 +18,7 @@ module Orchestration
     private
 
     def output_key_immutable_after_first_run
-      return unless persisted? && output_key_changed?
-      return unless action_runs.exists?
+      return if !persisted? || !output_key_changed? || !action_runs.exists?
 
       errors.add(:output_key, "cannot be changed once a run exists for this step_action")
     end

--- a/app/models/orchestration/step_action.rb
+++ b/app/models/orchestration/step_action.rb
@@ -2,9 +2,26 @@ module Orchestration
   class StepAction < ApplicationRecord
     self.table_name = "step_actions"
 
+    OUTPUT_KEY_FORMAT = /\A[a-z][a-z0-9_]*\z/
+
     belongs_to :step, class_name: "Orchestration::Step"
     belongs_to :action, class_name: "Orchestration::Action"
+    has_many :action_runs, class_name: "Orchestration::ActionRun", dependent: :restrict_with_error
 
     validates :position, presence: true, uniqueness: { scope: :step_id }
+    validates :output_key,
+              presence: true,
+              format: { with: OUTPUT_KEY_FORMAT },
+              uniqueness: { scope: :step_id }
+    validate :output_key_immutable_after_first_run
+
+    private
+
+    def output_key_immutable_after_first_run
+      return unless persisted? && output_key_changed?
+      return unless action_runs.exists?
+
+      errors.add(:output_key, "cannot be changed once a run exists for this step_action")
+    end
   end
 end

--- a/app/services/orchestration/output_key_deriver.rb
+++ b/app/services/orchestration/output_key_deriver.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class OutputKeyDeriver
+    def self.call(action_name:, step:)
+      new(action_name: action_name, step: step).call
+    end
+
+    def initialize(action_name:, step:)
+      @action_name = action_name
+      @step = step
+    end
+
+    def call
+      base = @action_name.to_s.parameterize(separator: "_")
+      base = "action" if base.blank?
+      base = "x_#{base}" unless base.match?(/\A[a-z]/)
+
+      candidate = base
+      suffix    = 2
+      while @step.step_actions.where(output_key: candidate).exists?
+        candidate = "#{base}_#{suffix}"
+        suffix += 1
+      end
+      candidate
+    end
+  end
+end

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -11,6 +11,7 @@ module Orchestration
       previous_outputs << { "step_name" => "initial", "output" => @pipeline_run.initial_input } if @pipeline_run.initial_input.present?
 
       @pipeline_run.pipeline.steps.where(enabled: true).order(:position).each do |step|
+        # input_mapping: nil — auto-merge until step_action.input_mapping is wired in later slices
         resolved_input = InputMappingResolver.new(
           input_mapping: nil,
           previous_outputs: previous_outputs

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -12,7 +12,7 @@ module Orchestration
 
       @pipeline_run.pipeline.steps.where(enabled: true).order(:position).each do |step|
         resolved_input = InputMappingResolver.new(
-          input_mapping: step.input_mapping,
+          input_mapping: nil,
           previous_outputs: previous_outputs
         ).resolve
 

--- a/db/migrate/20260510120000_orchestration_data_flow_foundation.rb
+++ b/db/migrate/20260510120000_orchestration_data_flow_foundation.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+# Foundation slice for the orchestration data-flow refactor (PRD #77, issue #78).
+#
+# Moves `input_mapping` from `steps` to `step_actions`, introduces a stable
+# `output_key` handle on every `step_action`, and adds an optional
+# `input_schema` column to `actions`. Backfills existing rows so the new shape
+# carries the same semantics as the old `steps.input_mapping`.
+#
+# The new columns are intentionally unused at runtime in this slice; later
+# slices wire them into the resolver, validator, and runner.
+class OrchestrationDataFlowFoundation < ActiveRecord::Migration[8.1]
+  OUTPUT_KEY_FORMAT = /\A[a-z][a-z0-9_]*\z/
+
+  def up
+    add_column :step_actions, :input_mapping, :json
+    add_column :step_actions, :output_key, :string
+    add_column :actions, :input_schema, :json
+
+    backfill_output_keys
+    backfill_step_action_mappings
+
+    change_column_null :step_actions, :output_key, false
+    add_index :step_actions, [ :step_id, :output_key ], unique: true,
+              name: "index_step_actions_on_step_id_and_output_key"
+
+    remove_column :steps, :input_mapping
+  end
+
+  def down
+    add_column :steps, :input_mapping, :json
+
+    remove_index :step_actions, name: "index_step_actions_on_step_id_and_output_key"
+    remove_column :step_actions, :output_key
+    remove_column :step_actions, :input_mapping
+    remove_column :actions, :input_schema
+  end
+
+  private
+
+  def backfill_output_keys
+    say_with_time "backfilling step_actions.output_key from action.name" do
+      execute(<<~SQL.squish).then(&:to_a).each do |row|
+        SELECT step_actions.id        AS id,
+               step_actions.step_id   AS step_id,
+               actions.name           AS action_name
+        FROM step_actions
+        JOIN actions ON actions.id = step_actions.action_id
+      SQL
+        key = derive_output_key(row["action_name"], row["step_id"], row["id"])
+        execute "UPDATE step_actions SET output_key = #{quote(key)} WHERE id = #{row['id'].to_i}"
+      end
+    end
+  end
+
+  # Within a single `step`, two parallel `step_actions` referencing the same
+  # `Action` would parameterize to the same key. Append a suffix when needed
+  # so the unique index can be added.
+  def derive_output_key(action_name, step_id, step_action_id)
+    base = action_name.to_s.parameterize(separator: "_")
+    base = "action" if base.blank?
+    base = "x_#{base}" if base.start_with?("_") || base !~ /\A[a-z]/
+
+    candidate = base
+    suffix    = 2
+    until output_key_unique?(step_id, candidate, step_action_id)
+      candidate = "#{base}_#{suffix}"
+      suffix += 1
+    end
+    candidate
+  end
+
+  def output_key_unique?(step_id, candidate, step_action_id)
+    sql = <<~SQL.squish
+      SELECT id FROM step_actions
+      WHERE step_id = #{step_id.to_i}
+        AND output_key = #{quote(candidate)}
+        AND id <> #{step_action_id.to_i}
+      LIMIT 1
+    SQL
+    select_all(sql).empty?
+  end
+
+  def backfill_step_action_mappings
+    say_with_time "splitting steps.input_mapping into step_actions.input_mapping/params" do
+      step_rows = select_all(<<~SQL.squish).to_a
+        SELECT id, input_mapping
+        FROM steps
+        WHERE input_mapping IS NOT NULL AND input_mapping <> ''
+      SQL
+
+      step_rows.each { |row| backfill_one_step(row) }
+    end
+  end
+
+  def backfill_one_step(step_row)
+    step_id  = step_row["id"]
+    raw      = step_row["input_mapping"]
+    mapping  = parse_json_mapping(raw)
+    return if mapping.empty?
+
+    step_action_rows = select_all(<<~SQL.squish).to_a
+      SELECT step_actions.id, step_actions.params, step_actions.input_mapping
+      FROM step_actions
+      WHERE step_actions.step_id = #{step_id.to_i}
+    SQL
+
+    step_action_rows.each do |sa_row|
+      apply_mapping_to_step_action(sa_row, mapping)
+    end
+  end
+
+  def apply_mapping_to_step_action(sa_row, mapping)
+    existing_params  = parse_json_mapping(sa_row["params"])
+    new_params       = existing_params.dup
+    new_input_map    = {}
+
+    mapping.each do |key, spec|
+      next unless spec.is_a?(Hash)
+
+      if spec.key?("value")
+        new_params[key] = spec["value"]
+      elsif spec.key?("from_step")
+        translated = translate_from_step_spec(spec)
+        new_input_map[key] = translated if translated
+      end
+    end
+
+    update_sql = +"UPDATE step_actions SET "
+    parts = []
+    parts << "params = #{quote(new_params.to_json)}" if new_params != existing_params
+    parts << "input_mapping = #{quote(new_input_map.to_json)}" unless new_input_map.empty?
+    return if parts.empty?
+
+    update_sql << parts.join(", ")
+    update_sql << " WHERE id = #{sa_row['id'].to_i}"
+    execute update_sql
+  end
+
+  # Translates the legacy `{ "from_step" => name, "path" => "...", "merge" => ... }`
+  # shape into the new `{ "from" => output_key, "path" => "..." }` shape.
+  # `from_step` -> the upstream step's first step_action's output_key.
+  # The legacy `merge` strategy is dropped (resolver rewrite owns merging next).
+  def translate_from_step_spec(spec)
+    upstream_name = spec["from_step"]
+    return nil if upstream_name.blank?
+
+    upstream_key = upstream_output_key_for(upstream_name)
+    return nil if upstream_key.blank?
+
+    translated = { "from" => upstream_key }
+    translated["path"] = spec["path"] if spec["path"].present?
+    translated
+  end
+
+  def upstream_output_key_for(step_name)
+    return "_initial" if step_name == "initial"
+
+    sql = <<~SQL.squish
+      SELECT step_actions.output_key
+      FROM step_actions
+      JOIN steps ON steps.id = step_actions.step_id
+      WHERE steps.name = #{quote(step_name)}
+      ORDER BY step_actions.position ASC
+      LIMIT 1
+    SQL
+    row = select_all(sql).first
+    row && row["output_key"]
+  end
+
+  def parse_json_mapping(raw)
+    return {} if raw.nil? || raw == ""
+    return raw if raw.is_a?(Hash)
+
+    parsed = JSON.parse(raw)
+    parsed.is_a?(Hash) ? parsed : {}
+  rescue JSON::ParserError
+    {}
+  end
+
+  def quote(value)
+    ActiveRecord::Base.connection.quote(value)
+  end
+
+  def select_all(sql)
+    ActiveRecord::Base.connection.select_all(sql)
+  end
+end

--- a/db/migrate/20260510120000_orchestration_data_flow_foundation.rb
+++ b/db/migrate/20260510120000_orchestration_data_flow_foundation.rb
@@ -40,14 +40,22 @@ class OrchestrationDataFlowFoundation < ActiveRecord::Migration[8.1]
 
   def backfill_output_keys
     say_with_time "backfilling step_actions.output_key from action.name" do
-      execute(<<~SQL.squish).then(&:to_a).each do |row|
+      rows = execute(<<~SQL.squish).then(&:to_a)
         SELECT step_actions.id        AS id,
                step_actions.step_id   AS step_id,
                actions.name           AS action_name
         FROM step_actions
         JOIN actions ON actions.id = step_actions.action_id
+        ORDER BY step_actions.step_id, step_actions.position
       SQL
-        key = derive_output_key(row["action_name"], row["step_id"], row["id"])
+
+      # Track assigned keys per step in memory to avoid O(n²) uniqueness SELECTs.
+      assigned_per_step = Hash.new { |h, k| h[k] = Set.new }
+
+      rows.each do |row|
+        step_id = row["step_id"]
+        key = derive_output_key(row["action_name"], assigned_per_step[step_id])
+        assigned_per_step[step_id] << key
         execute "UPDATE step_actions SET output_key = #{quote(key)} WHERE id = #{row['id'].to_i}"
       end
     end
@@ -56,29 +64,18 @@ class OrchestrationDataFlowFoundation < ActiveRecord::Migration[8.1]
   # Within a single `step`, two parallel `step_actions` referencing the same
   # `Action` would parameterize to the same key. Append a suffix when needed
   # so the unique index can be added.
-  def derive_output_key(action_name, step_id, step_action_id)
+  def derive_output_key(action_name, existing_keys)
     base = action_name.to_s.parameterize(separator: "_")
     base = "action" if base.blank?
-    base = "x_#{base}" if base.start_with?("_") || base !~ /\A[a-z]/
+    base = "x_#{base}" unless base.match?(/\A[a-z]/)
 
     candidate = base
     suffix    = 2
-    until output_key_unique?(step_id, candidate, step_action_id)
+    while existing_keys.include?(candidate)
       candidate = "#{base}_#{suffix}"
       suffix += 1
     end
     candidate
-  end
-
-  def output_key_unique?(step_id, candidate, step_action_id)
-    sql = <<~SQL.squish
-      SELECT id FROM step_actions
-      WHERE step_id = #{step_id.to_i}
-        AND output_key = #{quote(candidate)}
-        AND id <> #{step_action_id.to_i}
-      LIMIT 1
-    SQL
-    select_all(sql).empty?
   end
 
   def backfill_step_action_mappings

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,38 +50,47 @@ INGEST_EMAILS_PARAMS = {
   ]
 }.freeze
 
-MAP_EMAILS_INPUT_MAPPING = {
-  "emails" => { "from_step" => "Ingest Emails", "path" => "emails" }
-}.freeze
-
-STORE_EMAILS_INPUT_MAPPING = {
-  "emails" => { "from_step" => "Map Emails", "path" => "result.emails" },
-  "label"  => { "value" => "applications" },
-  "table"  => { "value" => "application_mails" }
-}.freeze
-
 QUERY_EMAIL_RECORDS_PARAMS = {
   "table"              => "application_mails",
   "column_name"        => "id",
   "column_values_from" => "stored_ids"
 }.freeze
 
+MAP_EMAILS_INPUT_MAPPING = {
+  "emails" => { "from" => "ingest_emails", "path" => "emails" }
+}.freeze
+
+STORE_EMAILS_INPUT_MAPPING = {
+  "emails" => { "from" => "map_emails", "path" => "result.emails" }
+}.freeze
+
+STORE_EMAILS_STEP_PARAMS = {
+  "label" => "applications",
+  "table" => "application_mails"
+}.freeze
+
 QUERY_EMAIL_RECORDS_INPUT_MAPPING = {
-  "stored_ids" => { "from_step" => "Store Emails", "path" => "result.ids" }
+  "stored_ids" => { "from" => "store_emails", "path" => "result.ids" }
+}.freeze
+
+NORMALIZE_EMAILS_STEP_PARAMS = {
+  "destination_table"    => "application_mails",
+  "columns_to_normalize" => [ "company", "job_title" ]
 }.freeze
 
 NORMALIZE_EMAILS_INPUT_MAPPING = {
-  "records_to_normalize" => { "from_step" => "Query Email Records", "path" => "application_mails" },
-  "destination_table"    => { "value" => "application_mails" },
-  "columns_to_normalize" => { "value" => [ "company", "job_title" ] }
+  "records_to_normalize" => { "from" => "query_email_records", "path" => "application_mails" }
+}.freeze
+
+RECONCILE_EMAILS_STEP_PARAMS = {
+  "destination_table"  => "interviews",
+  "matching_columns"   => [ "company", "job_title" ],
+  "statuses"           => [ "pending_reply", "having_interviews", "rejected", "offer_received" ],
+  "initial_status"     => "pending_reply"
 }.freeze
 
 RECONCILE_EMAILS_INPUT_MAPPING = {
-  "emails_to_reconcile" => { "from_step" => "Query Email Records", "path" => "application_mails" },
-  "destination_table"   => { "value" => "interviews" },
-  "matching_columns"    => { "value" => [ "company", "job_title" ] },
-  "statuses"            => { "value" => [ "pending_reply", "having_interviews", "rejected", "offer_received" ] },
-  "initial_status"      => { "value" => "pending_reply" }
+  "emails_to_reconcile" => { "from" => "query_email_records", "path" => "application_mails" }
 }.freeze
 
 # Agent runtime configs — model, tools, and prompt.
@@ -265,16 +274,16 @@ AGENT_DEFINITIONS = {
 }.freeze
 
 steps = [
-  { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor"                                                                              },
-  { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent"                                                                               },
-  { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent"                                                                                 },
-  { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor", params: INGEST_EMAILS_PARAMS                                     },
-  { name: "Map Emails",   kind: :agent, agent_name: "Emails::MappingAgent",  schema_class: "ApplicationMailsSchema",  input_mapping: MAP_EMAILS_INPUT_MAPPING   },
-  { name: "Store Emails", kind: :agent, agent_name: "Records::StoreAgent",                                             input_mapping: STORE_EMAILS_INPUT_MAPPING },
-  { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",    params: QUERY_EMAIL_RECORDS_PARAMS,   input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING  },
-  { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",                                               input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING     },
-  { name: "Reconcile Emails to Interviews", kind: :agent,   agent_name: "Records::ReconcileAgent",          input_mapping: RECONCILE_EMAILS_INPUT_MAPPING                                             },
-  { name: "Export to Gist",                 kind: :service, agent_class: "Interviews::GistExportExecutor"                                                                     }
+  { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor"                                                                                             },
+  { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent"                                                                                              },
+  { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent"                                                                                                },
+  { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor",  params: INGEST_EMAILS_PARAMS                                                   },
+  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",  schema_class: "ApplicationMailsSchema", sa_input_mapping: MAP_EMAILS_INPUT_MAPPING           },
+  { name: "Store Emails",                   kind: :agent,   agent_name: "Records::StoreAgent",   sa_params: STORE_EMAILS_STEP_PARAMS,  sa_input_mapping: STORE_EMAILS_INPUT_MAPPING           },
+  { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",  params: QUERY_EMAIL_RECORDS_PARAMS, sa_input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING },
+  { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",  sa_params: NORMALIZE_EMAILS_STEP_PARAMS, sa_input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING },
+  { name: "Reconcile Emails to Interviews", kind: :agent,   agent_name: "Records::ReconcileAgent",  sa_params: RECONCILE_EMAILS_STEP_PARAMS, sa_input_mapping: RECONCILE_EMAILS_INPUT_MAPPING },
+  { name: "Export to Gist",                 kind: :service, agent_class: "Interviews::GistExportExecutor"                                                                                    }
 ]
 
 Orchestration::Action.where(name: "Merge Email Records").destroy_all
@@ -332,15 +341,17 @@ pipeline.steps.destroy_all
 steps.each_with_index do |step_attrs, index|
   action = action_records[index]
   step = pipeline.steps.create!(
-    name:          action.name,
-    position:      index + 1,
-    input_mapping: step_attrs[:input_mapping]
+    name:     action.name,
+    position: index + 1
   )
 
   Orchestration::StepAction.create!(
-    step:     step,
-    action:   action,
-    position: 1
+    step:          step,
+    action:        action,
+    position:      1,
+    output_key:    action.name.parameterize(separator: "_"),
+    params:        step_attrs[:sa_params],
+    input_mapping: step_attrs[:sa_input_mapping]
   )
 end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -43,22 +43,6 @@ CREATE INDEX "index_messages_on_role" ON "messages" ("role") /*application='Appl
 CREATE INDEX "index_messages_on_chat_id" ON "messages" ("chat_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_messages_on_model_id" ON "messages" ("model_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_messages_on_tool_call_id" ON "messages" ("tool_call_id") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "steps" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_id" integer NOT NULL, "name" varchar NOT NULL, "position" integer NOT NULL, "input_mapping" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "enabled" boolean DEFAULT TRUE NOT NULL /*application='ApplicationPipeline'*/, CONSTRAINT "fk_rails_bbcf3ea2ee"
-FOREIGN KEY ("pipeline_id")
-  REFERENCES "pipelines" ("id")
-);
-CREATE INDEX "index_steps_on_pipeline_id" ON "steps" ("pipeline_id") /*application='ApplicationPipeline'*/;
-CREATE UNIQUE INDEX "index_steps_on_pipeline_id_and_position" ON "steps" ("pipeline_id", "position") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_d9cf618a2f"
-FOREIGN KEY ("step_id")
-  REFERENCES "steps" ("id")
-, CONSTRAINT "fk_rails_0b2a35e398"
-FOREIGN KEY ("action_id")
-  REFERENCES "actions" ("id")
-);
-CREATE INDEX "index_step_actions_on_step_id" ON "step_actions" ("step_id") /*application='ApplicationPipeline'*/;
-CREATE INDEX "index_step_actions_on_action_id" ON "step_actions" ("action_id") /*application='ApplicationPipeline'*/;
-CREATE UNIQUE INDEX "index_step_actions_on_step_id_and_position" ON "step_actions" ("step_id", "position") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "pipeline_runs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_id" integer NOT NULL, "status" varchar DEFAULT 'pending' NOT NULL, "triggered_by" varchar, "started_at" datetime(6), "finished_at" datetime(6), "error" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "initial_input" json /*application='ApplicationPipeline'*/, CONSTRAINT "fk_rails_7774d88070"
 FOREIGN KEY ("pipeline_id")
   REFERENCES "pipelines" ("id")
@@ -146,14 +130,32 @@ FOREIGN KEY ("evaluation_result_id")
 CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "prompt" text /*application='ApplicationPipeline'*/, "params" json DEFAULT '{}' NOT NULL /*application='ApplicationPipeline'*/, "output_schema" json /*application='ApplicationPipeline'*/);
 CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "model" varchar, "tools" json, "prompt" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "output_schema" json, "schema_class" varchar, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, CONSTRAINT "fk_rails_951418a714"
+CREATE TABLE IF NOT EXISTS "actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "model" varchar, "tools" json, "prompt" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "output_schema" json, "schema_class" varchar, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, "input_schema" json /*application='ApplicationPipeline'*/, CONSTRAINT "fk_rails_951418a714"
 FOREIGN KEY ("agent_id")
   REFERENCES "orchestration_agents" ("id")
 );
 CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_actions_on_agent_id" ON "actions" ("agent_id") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "email_connectors" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "provider" varchar NOT NULL, "configuration" text, "enabled" boolean DEFAULT TRUE NOT NULL, "last_connected_at" datetime(6), "status" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "input_mapping" json, "output_key" varchar NOT NULL, CONSTRAINT "fk_rails_0b2a35e398"
+FOREIGN KEY ("action_id")
+  REFERENCES "actions" ("id")
+, CONSTRAINT "fk_rails_d9cf618a2f"
+FOREIGN KEY ("step_id")
+  REFERENCES "steps" ("id")
+);
+CREATE INDEX "index_step_actions_on_step_id" ON "step_actions" ("step_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_step_actions_on_action_id" ON "step_actions" ("action_id") /*application='ApplicationPipeline'*/;
+CREATE UNIQUE INDEX "index_step_actions_on_step_id_and_position" ON "step_actions" ("step_id", "position") /*application='ApplicationPipeline'*/;
+CREATE UNIQUE INDEX "index_step_actions_on_step_id_and_output_key" ON "step_actions" ("step_id", "output_key") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "steps" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_id" integer NOT NULL, "name" varchar NOT NULL, "position" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "enabled" boolean DEFAULT TRUE NOT NULL, CONSTRAINT "fk_rails_bbcf3ea2ee"
+FOREIGN KEY ("pipeline_id")
+  REFERENCES "pipelines" ("id")
+);
+CREATE INDEX "index_steps_on_pipeline_id" ON "steps" ("pipeline_id") /*application='ApplicationPipeline'*/;
+CREATE UNIQUE INDEX "index_steps_on_pipeline_id_and_position" ON "steps" ("pipeline_id", "position") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260510120000'),
 ('20260507091027'),
 ('20260507091026'),
 ('20260507091025'),

--- a/sig/app/controllers/orchestration/step_actions_controller.rbs
+++ b/sig/app/controllers/orchestration/step_actions_controller.rbs
@@ -7,6 +7,6 @@ module Orchestration
 
     def set_pipeline: () -> void
     def set_step: () -> void
-    def step_action_params: () -> ActionController::Parameters
+    def step_action_params: () -> ActionController::Parameters?
   end
 end

--- a/sig/app/services/orchestration/output_key_deriver.rbs
+++ b/sig/app/services/orchestration/output_key_deriver.rbs
@@ -1,0 +1,13 @@
+module Orchestration
+  class OutputKeyDeriver
+    def self.call: (action_name: String, step: Step) -> String
+
+    def initialize: (action_name: String, step: Step) -> void
+    def call: () -> String
+
+    private
+
+    attr_reader action_name: String
+    attr_reader step: Step
+  end
+end

--- a/spec/components/orchestration/step_component_spec.rb
+++ b/spec/components/orchestration/step_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
   let(:pipeline) { build_stubbed(:orchestration_pipeline, id: 1) }
   let(:step) do
     build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
-      allow(s).to receive_messages(step_actions: [], input_mapping: nil)
+      allow(s).to receive_messages(step_actions: [],)
     end
   end
   let(:actions) { build_stubbed_list(:orchestration_action, 2) }
@@ -74,7 +74,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
   context "when the step is disabled" do
     let(:step) do
       build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: false).tap do |s|
-        allow(s).to receive_messages(step_actions: [], input_mapping: nil)
+        allow(s).to receive_messages(step_actions: [],)
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
         allow(s).to receive(:params).and_return(nil)
       end
       build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
-        allow(s).to receive_messages(step_actions: [ sa ], input_mapping: nil)
+        allow(s).to receive_messages(step_actions: [ sa ],)
       end
     end
 
@@ -113,18 +113,6 @@ RSpec.describe Orchestration::StepComponent, type: :component do
     end
   end
 
-  context "when the step has input_mapping" do
-    let(:step) do
-      build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
-        allow(s).to receive_messages(step_actions: [], input_mapping: { "key" => "value" })
-      end
-    end
-
-    it "renders the input mapping section" do
-      expect(rendered.text).to include("Input mapping:")
-      expect(rendered.css("code").text).to include("key")
-    end
-  end
 
   describe "#move_up?" do
     it "returns false when first" do
@@ -158,7 +146,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
     context "when step is disabled" do
       let(:step) do
         build_stubbed(:orchestration_step, enabled: false, id: 10, pipeline: pipeline).tap do |s|
-          allow(s).to receive_messages(step_actions: [], input_mapping: nil)
+          allow(s).to receive_messages(step_actions: [],)
         end
       end
 

--- a/spec/factories/step_actions.rb
+++ b/spec/factories/step_actions.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     association :step, factory: :orchestration_step
     association :action, factory: :orchestration_action
     sequence(:position) { |n| n }
+    sequence(:output_key) { |n| "step_action_#{n}" }
   end
 end

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -68,4 +68,23 @@ RSpec.describe Orchestration::Action do
       expect(described_class.exists?(action.id)).to be true
     end
   end
+
+  describe "input_schema column" do
+    it "round-trips a JSON object" do
+      schema = {
+        "type" => "object",
+        "required" => [ "emails" ],
+        "properties" => { "emails" => { "type" => "array" } }
+      }
+      action = create(:orchestration_action, input_schema: schema)
+      expect(action.reload.input_schema).to eq(schema)
+    end
+
+    it "is nullable" do
+      action = build(:orchestration_action, input_schema: nil)
+      expect(action).to be_valid
+      action.save!
+      expect(action.reload.input_schema).to be_nil
+    end
+  end
 end

--- a/spec/models/orchestration/step_action_spec.rb
+++ b/spec/models/orchestration/step_action_spec.rb
@@ -10,6 +10,82 @@ RSpec.describe Orchestration::StepAction do
     it_behaves_like 'requires attribute', :position, :orchestration_step_action
     it_behaves_like 'enforces position uniqueness scoped to',
                     :orchestration_step_action, :step, :orchestration_step
+
+    describe 'output_key' do
+      it 'is required' do
+        step_action = build(:orchestration_step_action, output_key: nil)
+        expect(step_action).not_to be_valid
+        expect(step_action.errors[:output_key]).to include(/can't be blank/)
+      end
+
+      it 'accepts lowercase letters, digits, and underscores starting with a letter' do
+        step_action = build(:orchestration_step_action, output_key: 'classify_emails_v2')
+        expect(step_action).to be_valid
+      end
+
+      it 'rejects keys starting with a digit' do
+        step_action = build(:orchestration_step_action, output_key: '1emails')
+        expect(step_action).not_to be_valid
+        expect(step_action.errors[:output_key]).to be_present
+      end
+
+      it 'rejects keys with uppercase letters' do
+        step_action = build(:orchestration_step_action, output_key: 'ClassifyEmails')
+        expect(step_action).not_to be_valid
+        expect(step_action.errors[:output_key]).to be_present
+      end
+
+      it 'rejects keys with hyphens' do
+        step_action = build(:orchestration_step_action, output_key: 'classify-emails')
+        expect(step_action).not_to be_valid
+        expect(step_action.errors[:output_key]).to be_present
+      end
+
+      it 'rejects keys starting with an underscore (reserved namespace)' do
+        step_action = build(:orchestration_step_action, output_key: '_initial')
+        expect(step_action).not_to be_valid
+        expect(step_action.errors[:output_key]).to be_present
+      end
+
+      it 'is unique within a step' do
+        step = create(:orchestration_step)
+        create(:orchestration_step_action, step: step, output_key: 'classify_emails', position: 1)
+        duplicate = build(:orchestration_step_action, step: step, output_key: 'classify_emails', position: 2)
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:output_key]).to include(/has already been taken/)
+      end
+
+      it 'allows the same output_key in different steps' do
+        pipeline = create(:orchestration_pipeline)
+        step_a   = create(:orchestration_step, pipeline: pipeline, position: 1)
+        step_b   = create(:orchestration_step, pipeline: pipeline, position: 2)
+        create(:orchestration_step_action, step: step_a, output_key: 'classify_emails', position: 1)
+        twin = build(:orchestration_step_action, step: step_b, output_key: 'classify_emails', position: 1)
+        expect(twin).to be_valid
+      end
+    end
+
+    describe 'output_key immutability' do
+      it 'allows changing output_key when no ActionRun exists' do
+        step_action = create(:orchestration_step_action, output_key: 'before_run')
+        step_action.output_key = 'after_edit'
+        expect(step_action).to be_valid
+      end
+
+      it 'rejects changing output_key once an ActionRun exists' do
+        step_action = create(:orchestration_step_action, output_key: 'classify_emails')
+        create(:orchestration_action_run, step_action: step_action)
+        step_action.output_key = 'something_else'
+        expect(step_action).not_to be_valid
+        expect(step_action.errors[:output_key]).to include(/cannot be changed once a run exists/)
+      end
+
+      it 'allows persisting the same output_key after a run exists' do
+        step_action = create(:orchestration_step_action, output_key: 'classify_emails')
+        create(:orchestration_action_run, step_action: step_action)
+        expect { step_action.update!(position: step_action.position + 10) }.not_to raise_error
+      end
+    end
   end
 
   describe 'associations' do
@@ -20,6 +96,19 @@ RSpec.describe Orchestration::StepAction do
       sa2 = create(:orchestration_step_action, step: step, action: action_a, position: 2)
       sa1 = create(:orchestration_step_action, step: step, action: action_b, position: 1)
       expect(step.step_actions.to_a).to eq([ sa1, sa2 ])
+    end
+  end
+
+  describe 'input_mapping column' do
+    it 'round-trips a JSON object' do
+      mapping = { 'emails' => { 'from' => 'fetch_emails', 'path' => 'emails' } }
+      step_action = create(:orchestration_step_action, input_mapping: mapping)
+      expect(step_action.reload.input_mapping).to eq(mapping)
+    end
+
+    it 'is nullable' do
+      step_action = build(:orchestration_step_action, input_mapping: nil)
+      expect(step_action).to be_valid
     end
   end
 end

--- a/spec/requests/orchestration/pipeline_lifecycle_spec.rb
+++ b/spec/requests/orchestration/pipeline_lifecycle_spec.rb
@@ -214,23 +214,15 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
       expect(pipeline.description).to eq("Enhanced with data transformation")
     end
 
-    # rubocop:disable RSpec/ExampleLength
-    it "renames an existing step and updates its input_mapping" do
+    it "renames an existing step and redirects" do
       patch orchestration_pipeline_step_path(pipeline, classify_step), params: {
-        orchestration_step: {
-          name: "AI Classification",
-          input_mapping: '{"emails":{"from_step":"Fetch Interviews","path":"interviews"}}'
-        }
+        orchestration_step: { name: "AI Classification" }
       }
 
       expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
       classify_step.reload
       expect(classify_step.name).to eq("AI Classification")
-      expect(classify_step.input_mapping).to eq(
-        "emails" => { "from_step" => "Fetch Interviews", "path" => "interviews" }
-      )
     end
-    # rubocop:disable RSpec/ExampleLength
 
     # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
     it "adds a new step with a service-object action at the end" do

--- a/spec/requests/orchestration/pipelines_spec.rb
+++ b/spec/requests/orchestration/pipelines_spec.rb
@@ -83,15 +83,6 @@ RSpec.describe "Orchestration::Pipelines" do
       expect(response.body).to include("My Action")
     end
 
-    it "shows input mapping on steps" do
-      pipeline = create(:orchestration_pipeline)
-      create(:orchestration_step, pipeline: pipeline, position: 1,
-             input_mapping: { "email" => "$.output.email" })
-
-      get orchestration_pipeline_path(pipeline)
-
-      expect(response).to have_http_status(:ok)
-    end
 
     it "displays latest run status when a run exists" do
       pipeline = create(:orchestration_pipeline, name: "Show Pipeline")
@@ -196,12 +187,12 @@ RSpec.describe "Orchestration::Pipelines" do
   end
 
   describe "PATCH /orchestration/pipelines/:pipeline_id/steps/:id" do
-    it "updates step name and input_mapping and redirects to show" do
+    it "updates step name and redirects to show" do
       pipeline = create(:orchestration_pipeline)
       step = create(:orchestration_step, pipeline: pipeline, name: "Old", position: 1)
 
       patch orchestration_pipeline_step_path(pipeline, step), params: {
-        orchestration_step: { name: "Updated", input_mapping: '{"key":"val"}' }
+        orchestration_step: { name: "Updated" }
       }
 
       expect(response).to redirect_to(orchestration_pipeline_path(pipeline))

--- a/spec/requests/orchestration/step_actions_spec.rb
+++ b/spec/requests/orchestration/step_actions_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Orchestration::StepActions" do
+  let(:pipeline) { create(:orchestration_pipeline) }
+  let(:step)     { create(:orchestration_step, pipeline: pipeline) }
+  let(:action)   { create(:orchestration_action, name: "Classify Emails") }
+
+  describe "POST /orchestration/pipelines/:pipeline_id/steps/:step_id/step_actions" do
+    def create_path
+      orchestration_pipeline_step_step_actions_path(pipeline, step)
+    end
+
+    def post_create(action_id: action.id, params_json: nil)
+      post create_path, params: {
+        orchestration_step_action: { action_id: action_id, params: params_json }.compact
+      }
+    end
+
+    context "with a valid action" do
+      it "attaches the action and redirects with notice" do
+        post_create
+
+        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+        follow_redirect!
+        expect(response.body).to include("Action attached.")
+      end
+
+      it "derives output_key from the action name" do
+        post_create
+        expect(step.step_actions.last.output_key).to eq("classify_emails")
+      end
+
+      it "parses valid JSON params and stores them" do
+        post_create(params_json: '{"threshold": 0.8}')
+        expect(step.step_actions.last.params).to eq("threshold" => 0.8)
+      end
+    end
+
+    context "with an invalid action_id" do
+      it "redirects with an alert and does not create a step_action" do
+        expect {
+          post_create(action_id: 0)
+        }.not_to change(Orchestration::StepAction, :count)
+
+        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+        follow_redirect!
+        expect(response.body).to include("Invalid action")
+      end
+    end
+
+    context "with invalid JSON in params" do
+      it "redirects with an alert and does not create a step_action" do
+        expect {
+          post_create(params_json: "{not json}")
+        }.not_to change(Orchestration::StepAction, :count)
+
+        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+        follow_redirect!
+        expect(response.body).to include("valid JSON")
+      end
+    end
+
+    context "when a unique-key collision occurs (race condition)" do
+      before do
+        allow(Orchestration::OutputKeyDeriver).to receive(:call).and_return("classify_emails")
+
+        # AR uniqueness validation passes before the INSERT; the collision arrives from a
+        # concurrent commit that can only be simulated by stubbing save on the instance.
+        first_call = true
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Orchestration::StepAction).to receive(:save).and_wrap_original do |m, **opts|
+          if first_call
+            first_call = false
+            raise ActiveRecord::RecordNotUnique, "UNIQUE constraint failed"
+          end
+          m.call(**opts)
+        end
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it "saves with a hex-suffixed key instead of raising" do
+        expect { post_create }.to change(Orchestration::StepAction, :count).by(1)
+        expect(step.step_actions.last.output_key).to match(/\Aclassify_emails_[0-9a-f]+\z/)
+      end
+    end
+  end
+end

--- a/spec/services/orchestration/output_key_deriver_spec.rb
+++ b/spec/services/orchestration/output_key_deriver_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::OutputKeyDeriver do
+  let(:step) { create(:orchestration_step) }
+
+  def call(action_name)
+    described_class.call(action_name: action_name, step: step)
+  end
+
+  it "parameterizes a normal action name to snake_case" do
+    expect(call("Classify Emails")).to eq("classify_emails")
+  end
+
+  it "returns 'action' for a blank name" do
+    expect(call("")).to eq("action")
+  end
+
+  it "prepends x_ when the base starts with a digit" do
+    expect(call("2fast")).to eq("x_2fast")
+  end
+
+  it "strips leading underscores via parameterize and produces a valid key" do
+    expect(call("_internal")).to eq("internal")
+  end
+
+  it "appends a numeric suffix when the base key already exists in the step" do
+    create(:orchestration_step_action, step: step, output_key: "classify_emails", position: 1)
+    expect(call("Classify Emails")).to eq("classify_emails_2")
+  end
+
+  it "increments the suffix until a unique key is found" do
+    create(:orchestration_step_action, step: step, output_key: "classify_emails",   position: 1)
+    create(:orchestration_step_action, step: step, output_key: "classify_emails_2", position: 2)
+    expect(call("Classify Emails")).to eq("classify_emails_3")
+  end
+
+  it "allows the same base key in a different step" do
+    other_step = create(:orchestration_step)
+    create(:orchestration_step_action, step: other_step, output_key: "classify_emails", position: 1)
+    expect(call("Classify Emails")).to eq("classify_emails")
+  end
+end

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -475,24 +475,13 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'with two steps and input_mapping on the second step' do
+    context 'with two steps' do
       before do
         step2 = create(:orchestration_step, pipeline: pipeline, name: "transform", position: 2)
         action2 = create(:orchestration_action, agent: action.agent)
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         create(:orchestration_step_action, step: step2, action: action2, position: 1)
         allow(stub_agent).to receive(:ask).and_return(instance_double(RubyLLM::Message, content: "step output"))
-        step2.update!(input_mapping: {
-          "processed" => { "from_step" => "extract", "path" => "result", "merge" => "concat" }
-        })
-      end
-
-      it 'passes step1 output as resolved input to the step2 ActionRun' do
-        described_class.new(pipeline_run).call
-        step2_action_run = Orchestration::ActionRun
-          .joins(step_action: :step)
-          .where(steps: { name: "transform" }).first
-        expect(step2_action_run.input).to eq({ "processed" => "step output" })
       end
 
       it 'completes both steps and the PipelineRun' do
@@ -500,21 +489,28 @@ RSpec.describe Orchestration::PipelineRunner do
         expect(pipeline_run.reload.status).to eq("completed")
         expect(Orchestration::ActionRun.where(status: "completed").count).to eq(2)
       end
+
+      it 'passes accumulated previous outputs as merged input to step2' do
+        described_class.new(pipeline_run).call
+        step2_action_run = Orchestration::ActionRun
+          .joins(step_action: :step)
+          .where(steps: { name: "transform" }).first
+        expect(step2_action_run.input).to include("result" => "step output")
+      end
     end
 
     context 'when pipeline_run has initial_input' do
       before do
         pipeline_run.update!(initial_input: { "date" => "2026-04-03", "providers" => [ "gmail" ] })
-        step1.update!(input_mapping: { "fetch_date" => { "from_step" => "initial", "path" => "date" } })
         executable_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         create(:orchestration_step_action, step: step1, action: executable_action, position: 1)
         allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
       end
 
-      it 'injects initial_input as step 0 output so step 1 can reference it via input_mapping' do
+      it 'auto-merges initial_input so step 1 receives it in its input' do
         described_class.new(pipeline_run).call
         action_run = Orchestration::ActionRun.last
-        expect(action_run.input).to eq({ "fetch_date" => "2026-04-03" })
+        expect(action_run.input).to include("date" => "2026-04-03", "providers" => [ "gmail" ])
       end
     end
 


### PR DESCRIPTION
## Summary
- Drops `steps.input_mapping`; adds `step_actions.{input_mapping, output_key}` (NOT NULL, unique per step) and `actions.input_schema` (JSON, nullable)
- Backfills `output_key` from `action.name.parameterize`; splits old step `input_mapping` `value` entries → `step_action.params` and `from_step` refs → `step_action.input_mapping` with `output_key` addressing
- `StepAction` validates `output_key` format (`/\A[a-z][a-z0-9_]*\z/`), uniqueness within `step_id`, and immutability once an `ActionRun` exists; `StepActionsController` auto-derives `output_key` on attach

Closes #78

## Test plan
- [x] New `StepAction` output_key specs (format, reserved underscore, uniqueness, immutability) — all green
- [x] New `Action` input_schema column specs — all green
- [x] Full suite: 1300 examples, 0 failures
- [x] `bundle exec rubocop -a` — no offenses
- [x] `bundle exec steep check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)