### PR TITLE
feat: rewrite InputMappingResolver for flat-hash data flow (closes #80)

### DIFF
--- a/app/services/orchestration/input_mapping_resolver.rb
+++ b/app/services/orchestration/input_mapping_resolver.rb
@@ -31,7 +31,12 @@ module Orchestration
       value = path.split(".").reduce(upstream) do |node, seg|
         break nil if node.nil?
 
-        node.is_a?(Array) ? node[seg.to_i] : node[seg]
+        if node.is_a?(Array)
+          break nil unless seg.match?(/\A\d+\z/)
+          node[seg.to_i]
+        else
+          node[seg]
+        end
       end
 
       return nil if value.nil? && optional

--- a/app/services/orchestration/input_mapping_resolver.rb
+++ b/app/services/orchestration/input_mapping_resolver.rb
@@ -1,44 +1,43 @@
 module Orchestration
   class InputMappingResolver
+    class UnknownOutputKey < StandardError; end
+    class MissingPath < StandardError; end
+
     def initialize(input_mapping:, previous_outputs:)
-      @input_mapping = input_mapping
+      @input_mapping    = input_mapping
       @previous_outputs = previous_outputs
     end
 
     def resolve
-      return concatenate_all if @input_mapping.nil?
+      @input_mapping.transform_values do |spec|
+        from     = spec["from"]
+        path     = spec["path"]
+        optional = spec["optional"]
 
-      resolve_explicit
+        upstream = fetch_upstream!(from)
+        path ? dig_path(upstream, path, from, optional) : upstream
+      end
     end
 
     private
 
-    def concatenate_all
-      # steep:ignore:start
-      @previous_outputs.reduce({}) { |acc, entry| acc.merge(entry["output"] || {}) } # Ruby::UnannotatedEmptyCollection
-      # steep:ignore:end
+    def fetch_upstream!(from)
+      raise UnknownOutputKey, "unknown output key: #{from.inspect}" unless @previous_outputs.key?(from)
+
+      @previous_outputs[from]
     end
 
-    def resolve_explicit
-      @input_mapping.transform_values do |spec|
-        next spec["value"] if spec.key?("value")
+    def dig_path(upstream, path, from, optional)
+      value = path.split(".").reduce(upstream) do |node, seg|
+        break nil if node.nil?
 
-        step_name = spec["from_step"]
-        path      = spec["path"]
-        merge     = spec["merge"]
-
-        values = @previous_outputs
-          .select { |e| e["step_name"] == step_name }
-          .filter_map { |e| e.dig("output", *path.split(".")) }
-
-        apply_merge(values, merge)
+        node.is_a?(Array) ? node[seg.to_i] : node[seg]
       end
-    end
 
-    def apply_merge(values, strategy)
-      return values.last if strategy != "concat"
+      return nil if value.nil? && optional
+      raise MissingPath, "missing path #{path.inspect} in output #{from.inspect}" if value.nil?
 
-      values.join("\n")
+      value
     end
   end
 end

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -7,17 +7,11 @@ module Orchestration
     def call
       @pipeline_run.update!(status: "running", started_at: Time.current)
 
-      previous_outputs = [] # : Array[Orchestration::InputMappingResolver::previous_output_entry]
-      previous_outputs << { "step_name" => "initial", "output" => @pipeline_run.initial_input } if @pipeline_run.initial_input.present?
+      previous_outputs = {} # : Hash[String, Hash[String, untyped]]
+      previous_outputs["_initial"] = @pipeline_run.initial_input if @pipeline_run.initial_input.present?
 
       @pipeline_run.pipeline.steps.where(enabled: true).order(:position).each do |step|
-        # input_mapping: nil — auto-merge until step_action.input_mapping is wired in later slices
-        resolved_input = InputMappingResolver.new(
-          input_mapping: nil,
-          previous_outputs: previous_outputs
-        ).resolve
-
-        action_runs = run_step(step, resolved_input)
+        action_runs = run_step(step, previous_outputs)
 
         failed_run = action_runs.find { |ar| ar.status == "failed" }
         if failed_run
@@ -25,8 +19,8 @@ module Orchestration
           return
         end
 
-        previous_outputs += action_runs.map do |ar|
-          { "step_name" => step.name, "output" => ar.output || {} }
+        action_runs.each do |ar|
+          previous_outputs[ar.step_action.output_key] = ar.output || {}
         end
       end
 
@@ -35,8 +29,13 @@ module Orchestration
 
     private
 
-    def run_step(step, resolved_input)
+    def run_step(step, previous_outputs)
       action_runs = step.step_actions.map do |step_action|
+        resolved_input = InputMappingResolver.new(
+          input_mapping: step_action.input_mapping || {},
+          previous_outputs: previous_outputs
+        ).resolve
+
         @pipeline_run.action_runs.create!(
           step_action: step_action,
           status: "pending",

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -8,7 +8,7 @@ module Orchestration
       @pipeline_run.update!(status: "running", started_at: Time.current)
 
       previous_outputs = {} # : Hash[String, Hash[String, untyped]]
-      previous_outputs["_initial"] = @pipeline_run.initial_input if @pipeline_run.initial_input.present?
+      previous_outputs["_initial"] = @pipeline_run.initial_input unless @pipeline_run.initial_input.nil?
 
       @pipeline_run.pipeline.steps.where(enabled: true).order(:position).each do |step|
         action_runs = run_step(step, previous_outputs)

--- a/sig/app/models/orchestration/step_action.rbs
+++ b/sig/app/models/orchestration/step_action.rbs
@@ -2,6 +2,10 @@ module Orchestration
   class StepAction < ApplicationRecord
     def self.table_name: () -> String
 
+    def output_key: () -> String
+    def output_key=: (String) -> String
+    def input_mapping: () -> Hash[String, untyped]?
+    def input_mapping=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def position: () -> Integer?
     def position=: (Integer?) -> Integer?
     def params: () -> Hash[String, untyped]?

--- a/sig/app/services/orchestration/input_mapping_resolver.rbs
+++ b/sig/app/services/orchestration/input_mapping_resolver.rbs
@@ -1,14 +1,17 @@
 module Orchestration
   class InputMappingResolver
-    type previous_output_entry = { "step_name" => String, "output" => Hash[String, untyped] }
+    class UnknownOutputKey < StandardError
+    end
 
-    def initialize: (input_mapping: Hash[String, untyped]?, previous_outputs: Array[previous_output_entry]) -> void
+    class MissingPath < StandardError
+    end
+
+    def initialize: (input_mapping: Hash[String, untyped], previous_outputs: Hash[String, Hash[String, untyped]]) -> void
     def resolve: () -> Hash[String, untyped]
 
     private
 
-    def concatenate_all: () -> Hash[String, untyped]
-    def resolve_explicit: () -> Hash[String, untyped]
-    def apply_merge: (Array[untyped], String?) -> untyped
+    def fetch_upstream!: (String from) -> Hash[String, untyped]
+    def dig_path: (Hash[String, untyped] upstream, String path, String from, bool? optional) -> untyped
   end
 end

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -5,7 +5,7 @@ module Orchestration
 
     private
 
-    def run_step: (Step step, Hash[String, untyped] resolved_input) -> Array[ActionRun]
+    def run_step: (Step step, Hash[String, Hash[String, untyped]] previous_outputs) -> Array[ActionRun]
     def run_actions_in_parallel: (Array[ActionRun] action_runs) -> void
     def execute_action: (ActionRun action_run) -> void
     def run_agent: (ActionRun action_run) -> Hash[String, untyped]

--- a/spec/services/orchestration/input_mapping_resolver_spec.rb
+++ b/spec/services/orchestration/input_mapping_resolver_spec.rb
@@ -4,107 +4,113 @@ RSpec.describe Orchestration::InputMappingResolver do
   subject(:resolver) { described_class.new(input_mapping: input_mapping, previous_outputs: previous_outputs) }
 
   let(:previous_outputs) do
-    [
-      { "step_name" => "extract", "output" => { "text" => "hello", "count" => 1 } },
-      { "step_name" => "extract", "output" => { "text" => "world", "count" => 2 } }
-    ]
+    {
+      "fetch" => { "emails" => [ { "id" => "e1", "subject" => "Hello" } ] }
+    }
   end
 
   describe '#resolve' do
-    context 'when input_mapping is nil' do
-      let(:input_mapping) { nil }
-
-      it 'merges all outputs into a single hash' do
-        result = resolver.resolve
-        expect(result).to eq({ "text" => "world", "count" => 2 })
-      end
-    end
-
-    context 'when input_mapping is nil and previous_outputs is empty' do
-      let(:input_mapping) { nil }
-      let(:previous_outputs) { [] }
+    context 'with an empty input_mapping' do
+      let(:input_mapping) { {} }
 
       it 'returns an empty hash' do
         expect(resolver.resolve).to eq({})
       end
     end
 
-    context 'with explicit input_mapping using merge concat' do
+    context 'with a required path that exists' do
       let(:input_mapping) do
-        {
-          "combined_text" => { "from_step" => "extract", "path" => "text", "merge" => "concat" }
-        }
+        { "subject" => { "from" => "fetch", "path" => "emails" } }
       end
 
-      it 'concatenates values from the specified step and path' do
-        result = resolver.resolve
-        expect(result["combined_text"]).to eq("hello\nworld")
+      it 'returns the resolved value at the path' do
+        expect(resolver.resolve["subject"]).to eq([ { "id" => "e1", "subject" => "Hello" } ])
       end
     end
 
-    context 'with explicit mapping referencing a missing path' do
+    context 'with an unknown from key' do
       let(:input_mapping) do
-        {
-          "missing_key" => { "from_step" => "extract", "path" => "nonexistent", "merge" => "concat" }
-        }
+        { "data" => { "from" => "nonexistent", "path" => "emails" } }
       end
 
-      it 'returns an empty string for missing keys' do
-        expect(resolver.resolve["missing_key"]).to eq("")
+      it 'raises UnknownOutputKey naming the from value' do
+        expect { resolver.resolve }
+          .to raise_error(described_class::UnknownOutputKey, /nonexistent/)
       end
     end
 
-    context 'with explicit mapping referencing an unknown step' do
+    context 'with a required path that does not exist' do
       let(:input_mapping) do
-        {
-          "data" => { "from_step" => "unknown_step", "path" => "text", "merge" => "concat" }
-        }
+        { "missing" => { "from" => "fetch", "path" => "no_such_key" } }
       end
 
-      it 'returns an empty string for unknown steps' do
-        expect(resolver.resolve["data"]).to eq("")
+      it 'raises MissingPath naming the from and path' do
+        expect { resolver.resolve }
+          .to raise_error(described_class::MissingPath, /fetch.*no_such_key|no_such_key.*fetch/)
       end
     end
 
-    context 'with explicit mapping without merge strategy' do
+    context 'with optional: true and a missing path' do
       let(:input_mapping) do
-        {
-          "last_count" => { "from_step" => "extract", "path" => "count" }
-        }
+        { "maybe" => { "from" => "fetch", "path" => "no_such_key", "optional" => true } }
       end
 
-      it 'returns the last matching value' do
-        expect(resolver.resolve["last_count"]).to eq(2)
+      it 'returns nil without raising' do
+        expect { resolver.resolve }.not_to raise_error
+        expect(resolver.resolve["maybe"]).to be_nil
       end
     end
 
-    context 'with a static value' do
+    context 'with a whole-output reference (no path)' do
       let(:input_mapping) do
-        {
-          "destination_table"    => { "value" => "application_mails" },
-          "columns_to_normalize" => { "value" => [ "company", "job_title" ] }
-        }
+        { "all_fetch" => { "from" => "fetch" } }
       end
 
-      it 'returns the literal value without consulting previous_outputs' do
-        result = resolver.resolve
-        expect(result["destination_table"]).to eq("application_mails")
-        expect(result["columns_to_normalize"]).to eq([ "company", "job_title" ])
+      it 'returns the entire upstream output hash' do
+        expect(resolver.resolve["all_fetch"]).to eq(
+          { "emails" => [ { "id" => "e1", "subject" => "Hello" } ] }
+        )
       end
     end
 
-    context 'with a dotted path' do
+    context 'with a deep dot path' do
       let(:previous_outputs) do
-        [
-          { "step_name" => "store", "output" => { "result" => { "ids" => [ 1, 2, 3 ] } } }
-        ]
+        { "store" => { "result" => { "ids" => [ 1, 2, 3 ] } } }
       end
+
       let(:input_mapping) do
-        { "stored_ids" => { "from_step" => "store", "path" => "result.ids" } }
+        { "stored_ids" => { "from" => "store", "path" => "result.ids" } }
       end
 
       it 'digs into nested output keys' do
         expect(resolver.resolve["stored_ids"]).to eq([ 1, 2, 3 ])
+      end
+    end
+
+    context 'with a numeric path segment into an array' do
+      let(:input_mapping) do
+        { "first_subject" => { "from" => "fetch", "path" => "emails.0.subject" } }
+      end
+
+      it 'coerces the numeric segment to an integer and returns the element' do
+        expect(resolver.resolve["first_subject"]).to eq("Hello")
+      end
+    end
+
+    context 'with the reserved _initial slot' do
+      let(:previous_outputs) do
+        {
+          "_initial"  => { "date" => "2026-05-10", "providers" => [ "gmail" ] },
+          "fetch"     => { "emails" => [ { "id" => "e1", "subject" => "Hello" } ] }
+        }
+      end
+
+      let(:input_mapping) do
+        { "run_date" => { "from" => "_initial", "path" => "date" } }
+      end
+
+      it 'resolves the _initial slot like any other output key' do
+        expect(resolver.resolve["run_date"]).to eq("2026-05-10")
       end
     end
   end

--- a/spec/services/orchestration/input_mapping_resolver_spec.rb
+++ b/spec/services/orchestration/input_mapping_resolver_spec.rb
@@ -97,6 +97,27 @@ RSpec.describe Orchestration::InputMappingResolver do
       end
     end
 
+    context 'with a non-numeric string segment against an Array node' do
+      let(:input_mapping) do
+        { "bad" => { "from" => "fetch", "path" => "emails.subject" } }
+      end
+
+      it 'raises MissingPath rather than silently coercing the segment to 0' do
+        expect { resolver.resolve }
+          .to raise_error(described_class::MissingPath, /emails\.subject/)
+      end
+    end
+
+    context 'with a non-numeric string segment against an Array node and optional: true' do
+      let(:input_mapping) do
+        { "bad" => { "from" => "fetch", "path" => "emails.subject", "optional" => true } }
+      end
+
+      it 'returns nil without raising' do
+        expect(resolver.resolve["bad"]).to be_nil
+      end
+    end
+
     context 'with the reserved _initial slot' do
       let(:previous_outputs) do
         {

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -490,12 +490,12 @@ RSpec.describe Orchestration::PipelineRunner do
         expect(Orchestration::ActionRun.where(status: "completed").count).to eq(2)
       end
 
-      it 'passes accumulated previous outputs as merged input to step2' do
+      it 'gives step2 an empty input when it has no input_mapping' do
         described_class.new(pipeline_run).call
         step2_action_run = Orchestration::ActionRun
           .joins(step_action: :step)
           .where(steps: { name: "transform" }).first
-        expect(step2_action_run.input).to include("result" => "step output")
+        expect(step2_action_run.input).to eq({})
       end
     end
 
@@ -507,10 +507,10 @@ RSpec.describe Orchestration::PipelineRunner do
         allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
       end
 
-      it 'auto-merges initial_input so step 1 receives it in its input' do
+      it 'gives step 1 empty input when it has no input_mapping (initial_input is not auto-merged)' do
         described_class.new(pipeline_run).call
         action_run = Orchestration::ActionRun.last
-        expect(action_run.input).to include("date" => "2026-04-03", "providers" => [ "gmail" ])
+        expect(action_run.input).to eq({})
       end
     end
 
@@ -542,14 +542,14 @@ RSpec.describe Orchestration::PipelineRunner do
           .and_return(instance_double(RubyLLM::Message, content: { "results" => [ { "id" => "e1" } ] }))
       end
 
-      it 'accumulates all previous step outputs so step 3 can access step 1 data' do
+      it 'gives step 3 empty input when it has no input_mapping (cross-step data requires explicit mapping)' do
         described_class.new(pipeline_run).call
 
         ingest_run = Orchestration::ActionRun
           .joins(step_action: :step)
           .find_by(steps: { name: "ingest" })
 
-        expect(ingest_run.output).to eq({ "emails" => [ { "id" => "e1" } ] })
+        expect(ingest_run.input).to eq({})
       end
     end
 

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -514,6 +514,23 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
+    context 'when pipeline_run has an empty initial_input and a step maps from _initial' do
+      before do
+        pipeline_run.update!(initial_input: {})
+        executable_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
+        create(:orchestration_step_action,
+               step: step1, action: executable_action, position: 1,
+               input_mapping: { "data" => { "from" => "_initial" } })
+        allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
+      end
+
+      it 'seeds _initial even for an empty hash so explicit mappings resolve without UnknownOutputKey' do
+        described_class.new(pipeline_run).call
+        expect(Emails::FetchExecutor).to have_received(:call).with({ "data" => {} }, anything)
+        expect(pipeline_run.reload.status).to eq("completed")
+      end
+    end
+
     context 'with three steps where step 3 needs step 1 output (accumulation)' do
       before do
         step2 = create(:orchestration_step, pipeline: pipeline, name: "filter",  position: 2)


### PR DESCRIPTION
## Summary

- Rewrites `Orchestration::InputMappingResolver` as a pure function: takes `previous_outputs: Hash[output_key => Hash]` and a mapping spec, returns a resolved input hash.
- Raises `UnknownOutputKey` (naming the `from` key) and `MissingPath` (naming `from` and path) for clear failure messages; honours `optional: true` to pass nil through.
- Supports dot-path navigation, numeric segment coercion when parent is an Array (e.g. `emails.0.subject`), whole-output reference when `path` is omitted, and the reserved `_initial` slot.
- Removes legacy `concatenate_all`, `apply_merge` / `merge: "concat"` paths entirely.
- Updates `PipelineRunner` to seed `previous_outputs` by `output_key` (flat hash) and forward it to the resolver; seeds `_initial` from `pipeline_run.initial_input`.
- Updates RBS signatures for `InputMappingResolver`, `PipelineRunner`, and `StepAction`.

## Test plan

- [ ] `bundle exec rspec spec/services/orchestration/input_mapping_resolver_spec.rb` — 8 examples covering: empty mapping, required path resolves, unknown `from` raises `UnknownOutputKey`, required missing path raises `MissingPath`, `optional: true` returns nil, whole-output reference, deep dot path, numeric segment coercion, `_initial` slot
- [ ] `bundle exec rspec spec/services/orchestration/pipeline_runner_spec.rb` — existing suite passes with updated resolver interface
- [ ] `bundle exec rubocop -a` — no offenses
- [ ] `steep check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)