### PR TITLE
Add orchestration LLM error observability

### DIFF
--- a/app/components/orchestration/action_run_component.html.erb
+++ b/app/components/orchestration/action_run_component.html.erb
@@ -20,7 +20,15 @@
     </div>
   <% end %>
 
+  <%= diagnostics_disclosure %>
+
+  <% if raw_response_excerpt.present? %>
+    <details class="mb-2">
+      <summary class="text-xs font-medium text-gray-500 cursor-pointer hover:text-gray-700">Raw response excerpt</summary>
+      <pre class="mt-2 p-3 bg-gray-50 border border-gray-200 rounded text-xs font-mono overflow-x-auto"><%= raw_response_excerpt %></pre>
+    </details>
+  <% end %>
+
   <%= input_disclosure %>
   <%= output_disclosure %>
 </div>
-

--- a/app/components/orchestration/action_run_component.rb
+++ b/app/components/orchestration/action_run_component.rb
@@ -5,6 +5,7 @@ module Orchestration
     with_collection_parameter :action_run
 
     renders_one :status_badge, -> { Orchestration::RunStatusBadgeComponent.new(status: @action_run.status) }
+    renders_one :diagnostics_disclosure, -> { UI::JsonDisclosureComponent.new(label: "Diagnostics", data: diagnostics_data) }
     renders_one :input_disclosure, -> { UI::JsonDisclosureComponent.new(label: "Input", data: @action_run.input) }
     renders_one :output_disclosure, -> { UI::JsonDisclosureComponent.new(label: "Output", data: @action_run.output) }
 
@@ -14,6 +15,7 @@ module Orchestration
 
     def before_render
       with_status_badge
+      with_diagnostics_disclosure if diagnostics_data.present?
       with_input_disclosure
       with_output_disclosure
     end
@@ -28,6 +30,16 @@ module Orchestration
 
     def formatted_finished_at
       @action_run.finished_at&.strftime("%H:%M:%S")
+    end
+
+    def diagnostics_data
+      return if @action_run.error_details.blank?
+
+      @action_run.error_details.except("raw_response_excerpt").compact_blank
+    end
+
+    def raw_response_excerpt
+      @action_run.error_details&.dig("raw_response_excerpt")
     end
   end
 end

--- a/app/models/orchestration/action_run.rb
+++ b/app/models/orchestration/action_run.rb
@@ -32,6 +32,7 @@ module Orchestration
         input: input,
         output: output,
         error: error,
+        error_details: error_details,
         agent_snapshot: agent_snapshot,
         started_at: started_at,
         finished_at: finished_at

--- a/app/services/orchestration/invalid_model_output_error.rb
+++ b/app/services/orchestration/invalid_model_output_error.rb
@@ -1,0 +1,10 @@
+module Orchestration
+  class InvalidModelOutputError < StandardError
+    attr_reader :raw_content
+
+    def initialize(message, raw_content:)
+      @raw_content = raw_content
+      super(message)
+    end
+  end
+end

--- a/app/services/orchestration/normalize_action_run_failure.rb
+++ b/app/services/orchestration/normalize_action_run_failure.rb
@@ -1,0 +1,251 @@
+require "json"
+
+module Orchestration
+  class NormalizeActionRunFailure
+    MAX_EXCERPT_LENGTH = 500
+    REDACTED_VALUE = "[REDACTED]".freeze
+    REDACTED_EMAIL = "[REDACTED_EMAIL]".freeze
+
+    Result = Data.define(:summary, :details)
+    class Result
+      def initialize(summary:, details:) = super
+    end
+
+    def self.call(error:, action_run:, raw_content:)
+      new(error:, action_run:, raw_content:).call
+    end
+
+    def initialize(error:, action_run:, raw_content:)
+      @error = error
+      @action_run = action_run
+      @raw_content = raw_content
+    end
+
+    def call
+      return provider_http_error_result if provider_http_error?
+      return transport_error_result if transport_error?
+      return invalid_model_output_result if invalid_model_output?
+
+      Result.new(summary: sanitize_string(@error.message.to_s), details: nil)
+    end
+
+    private
+
+    def provider_http_error?
+      ruby_llm_error?(@error) && @error.respond_to?(:response) && @error.response.present?
+    end
+
+    def transport_error?
+      @error.is_a?(Faraday::TimeoutError) ||
+        @error.is_a?(Faraday::ConnectionFailed) ||
+        @error.is_a?(Faraday::SSLError) ||
+        @error.is_a?(Faraday::ParsingError)
+    end
+
+    def invalid_model_output?
+      @error.is_a?(InvalidModelOutputError)
+    end
+
+    def provider_http_error_result
+      parsed_error = extract_parsed_error(response_body)
+      message = provider_error_message(parsed_error)
+      summary = "#{provider_label} API error (#{response_status}): #{message}"
+
+      Result.new(
+        summary:,
+        details: build_details(
+          category: "provider_http_error",
+          message:,
+          status_code: response_status,
+          parsed_error:,
+          raw_response_excerpt: sanitized_excerpt(response_body)
+        )
+      )
+    end
+
+    def transport_error_result
+      summary = "#{provider_label} transport error: #{sanitize_string(@error.message.to_s)}"
+
+      Result.new(
+        summary:,
+        details: build_details(
+          category: "transport_error",
+          message: sanitize_string(@error.message.to_s),
+          status_code: nil,
+          parsed_error: nil,
+          raw_response_excerpt: nil
+        )
+      )
+    end
+
+    def invalid_model_output_result
+      summary = sanitize_string(@error.message.to_s)
+
+      Result.new(
+        summary:,
+        details: build_details(
+          category: "invalid_model_output",
+          message: summary,
+          status_code: nil,
+          parsed_error: nil,
+          raw_response_excerpt: sanitized_excerpt(invalid_model_raw_content)
+        )
+      )
+    end
+
+    def build_details(category:, message:, status_code:, parsed_error:, raw_response_excerpt:)
+      {
+        "category" => category,
+        "provider" => provider_name,
+        "model" => model_name,
+        "status_code" => status_code,
+        "message" => message,
+        "parsed_error" => parsed_error,
+        "raw_response_excerpt" => raw_response_excerpt,
+        "chat_id" => @action_run.chat_id,
+        "request_context" => request_context
+      }
+    end
+
+    def request_context
+      return nil if @action_run.agent_snapshot.blank?
+
+      { "agent_snapshot" => sanitize_value(@action_run.agent_snapshot) }
+    end
+
+    def response
+      @error.response
+    end
+
+    def response_status
+      response.status
+    end
+
+    def response_body
+      response.body
+    end
+
+    def provider_error_message(parsed_error)
+      candidate =
+        case parsed_error
+        when Hash
+          parsed_error["message"] || parsed_error.dig("error", "message")
+        when String
+          parsed_error
+        end
+
+      candidate = @error.message if candidate.blank? || candidate == "An unknown error occurred"
+      candidate = response_body if candidate.blank? || candidate == "An unknown error occurred"
+      sanitize_string(candidate.to_s)
+    end
+
+    def extract_parsed_error(body)
+      parsed = parse_json(body)
+
+      value =
+        case parsed
+        when Hash
+          parsed["error"] || parsed
+        when Array
+          parsed
+        end
+
+      sanitize_value(value)
+    end
+
+    def parse_json(value)
+      JSON.parse(value)
+    rescue JSON::ParserError, TypeError
+      nil
+    end
+
+    def invalid_model_raw_content
+      @error.raw_content
+    end
+
+    def model_name
+      @model_name ||= @action_run.agent_snapshot&.dig("model")
+    end
+
+    def provider_name
+      @provider_name ||= begin
+        return nil if model_name.blank?
+
+        provider_class = Object.const_get(:RubyLLM).const_get(:Provider)
+        provider_class.for(model_name)&.slug
+      rescue StandardError
+        nil
+      end
+    end
+
+    def provider_label
+      labels = {
+        "openai" => "OpenAI",
+        "mistral" => "Mistral",
+        "gemini" => "Gemini",
+        "anthropic" => "Anthropic"
+      }
+      provider = provider_name
+
+      return "Provider" if provider.nil?
+
+      labels.fetch(provider, "Provider")
+    end
+
+    def sanitized_excerpt(value)
+      return nil if value.blank?
+
+      sanitize_string(stringify(value))
+    end
+
+    def stringify(value)
+      value.is_a?(String) ? value : JSON.generate(value)
+    rescue JSON::GeneratorError, TypeError
+      value.to_s
+    end
+
+    def sanitize_value(value)
+      case value
+      when Hash
+        result = {} # : Hash[String, untyped]
+        value.each do |key, nested_value|
+          result[key.to_s] =
+            if sensitive_key?(key)
+              REDACTED_VALUE
+            else
+              sanitize_value(nested_value)
+            end
+        end
+        result
+      when Array
+        value.map { |item| sanitize_value(item) }
+      when String
+        sanitize_string(value)
+      else
+        value
+      end
+    end
+
+    def ruby_llm_error?(error)
+      error.class.ancestors.any? { |ancestor| ancestor.name == "RubyLLM::Error" }
+    end
+
+    def sensitive_key?(key)
+      key.to_s.match?(/\A(api[_-]?key|authorization|token|secret|password)\z/i)
+    end
+
+    def sanitize_string(value)
+      sanitized = value.dup
+      sanitized.gsub!(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i, REDACTED_EMAIL)
+      sanitized.gsub!(/("?(?:api[_-]?key|authorization|token|secret|password)"?\s*:\s*")([^"]+)(")/i, "\\1#{REDACTED_VALUE}\\3")
+      sanitized.gsub!(/(Bearer\s+)[A-Za-z0-9\-._~+\/]+=*/i, "\\1#{REDACTED_VALUE}")
+      truncate(sanitized)
+    end
+
+    def truncate(value)
+      return value if value.length <= MAX_EXCERPT_LENGTH
+
+      "#{value[0, MAX_EXCERPT_LENGTH]}..."
+    end
+  end
+end

--- a/app/services/orchestration/normalize_action_run_failure.rb
+++ b/app/services/orchestration/normalize_action_run_failure.rb
@@ -49,7 +49,7 @@ module Orchestration
     def provider_http_error_result
       parsed_error = extract_parsed_error(response_body)
       message = provider_error_message(parsed_error)
-      summary = "#{provider_label} API error (#{response_status}): #{message}"
+      summary = "#{provider_display_name} API error (#{response_status}): #{message}"
 
       Result.new(
         summary:,
@@ -64,7 +64,7 @@ module Orchestration
     end
 
     def transport_error_result
-      summary = "#{provider_label} transport error: #{sanitize_string(@error.message.to_s)}"
+      summary = "#{provider_display_name} transport error: #{sanitize_string(@error.message.to_s)}"
 
       Result.new(
         summary:,
@@ -178,18 +178,8 @@ module Orchestration
       end
     end
 
-    def provider_label
-      labels = {
-        "openai" => "OpenAI",
-        "mistral" => "Mistral",
-        "gemini" => "Gemini",
-        "anthropic" => "Anthropic"
-      }
-      provider = provider_name
-
-      return "Provider" if provider.nil?
-
-      labels.fetch(provider, "Provider")
+    def provider_display_name
+      provider_name || "provider"
     end
 
     def sanitized_excerpt(value)

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -62,11 +62,11 @@ module Orchestration
 
     def execute_action(action_run)
       action_run.update!(status: "running", started_at: Time.current)
-      output = run_agent(action_run)
-      validate_output!(action_run.step_action.action, output)
-      action_run.update!(status: "completed", output: output, finished_at: Time.current)
+      execution = run_agent(action_run)
+      validate_output!(action_run.step_action.action, execution[:output], raw_content: execution[:raw_content])
+      action_run.update!(status: "completed", output: execution[:output], error: nil, error_details: nil, finished_at: Time.current)
     rescue StandardError => error
-      action_run.update!(status: "failed", error: error.message, finished_at: Time.current)
+      handle_action_failure(action_run, error, raw_content: execution&.dig(:raw_content))
     end
 
     def run_agent(action_run)
@@ -84,26 +84,29 @@ module Orchestration
         chat_id = agent.respond_to?(:chat) ? agent.chat&.id : agent.id
         action_run.update_columns(chat_id: chat_id, agent_snapshot: builder.snapshot)
         result = agent.ask(input.to_json)
-        output = parse_content(result.content)
-        action.agent&.output_schema.present? ? output : { "result" => output }
+        output = parse_content(result.content, structured_output_expected?(action))
+        normalized_output = action.agent&.output_schema.present? ? output : { "result" => output }
+        { output: normalized_output, raw_content: result.content }
       else
         klass = action.agent_class&.constantize
         raise ArgumentError, "Service class not found: #{action.agent_class}" unless klass
 
         params = (action.params || {}).merge(action_run.step_action.params || {})
-        klass.call(input, params)
+        { output: klass.call(input, params), raw_content: nil }
       end
     end
 
-    def parse_content(content)
+    def parse_content(content, structured_output_expected)
       return content unless content.is_a?(String)
 
       JSON.parse(content)
-    rescue JSON::ParserError
+    rescue JSON::ParserError => error
+      raise InvalidModelOutputError.new("Invalid model output: #{error.message}", raw_content: content) if structured_output_expected
+
       content
     end
 
-    def validate_output!(action, output)
+    def validate_output!(action, output, raw_content:)
       schema = if action.agent?
         action.agent&.output_schema.presence || action.output_schema
       else
@@ -111,6 +114,47 @@ module Orchestration
       end
 
       SchemaValidator.new(schema).validate!(output)
+    rescue SchemaValidator::Error => error
+      raise error unless action.agent? && structured_output_expected?(action)
+
+      raise InvalidModelOutputError.new("Invalid model output: #{error.message}", raw_content: raw_content)
+    end
+
+    def handle_action_failure(action_run, error, raw_content:)
+      failure = NormalizeActionRunFailure.call(error:, action_run:, raw_content:)
+      action_run.update!(
+        status: "failed",
+        error: failure.summary,
+        error_details: failure.details,
+        finished_at: Time.current
+      )
+      log_action_failure(action_run, failure) if failure.details.present?
+    end
+
+    def log_action_failure(action_run, failure)
+      details = failure.details || {}
+
+      Rails.logger.error(
+        {
+          event: "orchestration.action_run_failed",
+          category: details["category"],
+          provider: details["provider"],
+          model: details["model"],
+          status_code: details["status_code"],
+          action_run_id: action_run.id,
+          pipeline_run_id: @pipeline_run.id,
+          chat_id: details["chat_id"],
+          summary: failure.summary
+        }.to_json
+      )
+    end
+
+    def structured_output_expected?(action)
+      action.agent? && (
+        action.agent&.output_schema.present? ||
+        action.output_schema.present? ||
+        action.schema_class.present?
+      )
     end
 
     def leva_prompt_for(agent_class)

--- a/db/migrate/20260513143500_add_error_details_to_action_runs.rb
+++ b/db/migrate/20260513143500_add_error_details_to_action_runs.rb
@@ -1,0 +1,5 @@
+class AddErrorDetailsToActionRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :action_runs, :error_details, :json
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,10 +5,6 @@ CREATE UNIQUE INDEX "index_application_mails_on_email_id" ON "application_mails"
 CREATE INDEX "index_application_mails_on_date" ON "application_mails" ("date") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "interviews" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "company" varchar NOT NULL, "job_title" varchar NOT NULL, "status" varchar DEFAULT 'pending_reply', "applied_at" date, "rejected_at" date, "first_interview_at" date, "second_interview_at" date, "third_interview_at" date, "fourth_interview_at" date, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_interviews_on_company_and_job_title" ON "interviews" ("company", "job_title") /*application='ApplicationPipeline'*/;
-CREATE VIRTUAL TABLE email_vectors USING vec0(
-  email_id TEXT PRIMARY KEY,
-  embedding FLOAT[1536]
-);
 CREATE TABLE IF NOT EXISTS "email_vectors_info" (key text primary key, value any);
 CREATE TABLE IF NOT EXISTS "email_vectors_chunks"(chunk_id INTEGER PRIMARY KEY AUTOINCREMENT,size INTEGER NOT NULL,validity BLOB NOT NULL,rowids BLOB NOT NULL);
 CREATE TABLE IF NOT EXISTS "email_vectors_rowids"(rowid INTEGER PRIMARY KEY AUTOINCREMENT,id TEXT UNIQUE NOT NULL,chunk_id INTEGER,chunk_offset INTEGER);
@@ -53,7 +49,7 @@ CREATE INDEX "index_pipeline_runs_on_pipeline_id_and_created_at" ON "pipeline_ru
 CREATE TABLE IF NOT EXISTS "pipelines" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "cron_expression" varchar, "model" varchar /*application='ApplicationPipeline'*/, "initial_input_schema" json /*application='ApplicationPipeline'*/);
 CREATE INDEX "index_pipelines_on_enabled_and_cron_expression" ON "pipelines" ("enabled", "cron_expression") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "ruby_llm_monitoring_events" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "allocations" integer, "cost" float, "cpu_time" float, "duration" float, "end" float, "gc_time" float, "idle_time" float, "name" varchar, "payload" json, "time" float, "transaction_id" varchar, "provider" varchar GENERATED ALWAYS AS (payload->>'provider') STORED, "model" varchar GENERATED ALWAYS AS (payload->>'model') STORED, "input_tokens" integer GENERATED ALWAYS AS (CAST(payload->>'input_tokens' AS INTEGER)) STORED, "output_tokens" integer GENERATED ALWAYS AS (CAST(payload->>'output_tokens' AS INTEGER)) STORED, "exception_class" varchar GENERATED ALWAYS AS (json_extract(payload, '$.exception[0]')) STORED, "exception_message" varchar GENERATED ALWAYS AS (json_extract(payload, '$.exception[1]')) STORED, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "thinking_tokens" integer GENERATED ALWAYS AS (CAST(payload->>'thinking_tokens' AS INTEGER)) STORED);
-CREATE TABLE IF NOT EXISTS "action_runs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_run_id" integer NOT NULL, "step_action_id" integer NOT NULL, "status" varchar DEFAULT 'pending' NOT NULL, "input" json, "output" json, "error" text, "started_at" datetime(6), "finished_at" datetime(6), "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "chat_id" integer, "agent_snapshot" json /*application='ApplicationPipeline'*/, CONSTRAINT "fk_rails_98c536e7ea"
+CREATE TABLE IF NOT EXISTS "action_runs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_run_id" integer NOT NULL, "step_action_id" integer NOT NULL, "status" varchar DEFAULT 'pending' NOT NULL, "input" json, "output" json, "error" text, "started_at" datetime(6), "finished_at" datetime(6), "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "chat_id" integer, "agent_snapshot" json /*application='ApplicationPipeline'*/, "error_details" json, CONSTRAINT "fk_rails_98c536e7ea"
 FOREIGN KEY ("step_action_id")
   REFERENCES "step_actions" ("id")
 , CONSTRAINT "fk_rails_e54391b086"
@@ -159,6 +155,7 @@ CREATE UNIQUE INDEX "index_evaluation_wizard_drafts_on_session_token" ON "evalua
 CREATE TABLE IF NOT EXISTS "evaluation_synthetic_records" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "agent_name" varchar NOT NULL, "input" json NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE INDEX "index_evaluation_synthetic_records_on_agent_name" ON "evaluation_synthetic_records" ("agent_name") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260513143500'),
 ('20260512110721'),
 ('20260512110713'),
 ('20260510120000'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,10 @@ CREATE UNIQUE INDEX "index_application_mails_on_email_id" ON "application_mails"
 CREATE INDEX "index_application_mails_on_date" ON "application_mails" ("date") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "interviews" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "company" varchar NOT NULL, "job_title" varchar NOT NULL, "status" varchar DEFAULT 'pending_reply', "applied_at" date, "rejected_at" date, "first_interview_at" date, "second_interview_at" date, "third_interview_at" date, "fourth_interview_at" date, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_interviews_on_company_and_job_title" ON "interviews" ("company", "job_title") /*application='ApplicationPipeline'*/;
+CREATE VIRTUAL TABLE IF NOT EXISTS email_vectors USING vec0(
+  email_id TEXT PRIMARY KEY,
+  embedding FLOAT[1536]
+);
 CREATE TABLE IF NOT EXISTS "email_vectors_info" (key text primary key, value any);
 CREATE TABLE IF NOT EXISTS "email_vectors_chunks"(chunk_id INTEGER PRIMARY KEY AUTOINCREMENT,size INTEGER NOT NULL,validity BLOB NOT NULL,rowids BLOB NOT NULL);
 CREATE TABLE IF NOT EXISTS "email_vectors_rowids"(rowid INTEGER PRIMARY KEY AUTOINCREMENT,id TEXT UNIQUE NOT NULL,chunk_id INTEGER,chunk_offset INTEGER);
@@ -216,4 +220,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260316000003'),
 ('20260316000002'),
 ('20260316000001');
-

--- a/docs/prd-llm-error-observability.md
+++ b/docs/prd-llm-error-observability.md
@@ -1,0 +1,186 @@
+# PRD: LLM Provider Error Observability for Agentic Pipelines
+
+## Summary
+
+Improve observability for orchestration agent runs that use `ruby_llm` so provider failures no longer surface as generic `"unknown error"` messages. The system should capture structured diagnostics for HTTP/API failures, transport failures, and invalid model output, then expose those details in pipeline records, logs, and operator UI.
+
+## Problem
+
+Today, failures from LLM providers can collapse into low-signal errors with little actionable detail. This makes it hard to understand why a pipeline failed, debug provider-specific issues, and distinguish between infrastructure failures and model output problems.
+
+Current pain points:
+
+- 4xx and 5xx provider responses may surface as generic errors.
+- Invalid or malformed provider responses are not described clearly.
+- Model output that should be valid JSON may fail parsing without useful diagnostics.
+- Operators lack a concise summary plus drill-down details in the run UI.
+
+## Goals
+
+- Capture structured failure details for orchestration agent runs.
+- Distinguish provider/API failures from invalid model output failures.
+- Preserve useful provider context including status code, provider name, parsed error fields, and a redacted/truncated raw response excerpt.
+- Show concise summaries at the pipeline-run level.
+- Show detailed diagnostics at the action-run level.
+- Emit structured logs for failed LLM calls.
+
+## Non-Goals
+
+- Changing retry behavior, backoff, or failure-state transitions.
+- Modifying successful execution behavior.
+- Building a generic observability framework for all app subsystems.
+- Patching `ruby_llm` unless application-level extraction proves insufficient.
+
+## Primary Users
+
+- Operators reviewing failed orchestration runs
+- Developers debugging provider and prompt issues
+
+## Scope
+
+Initial scope focuses on orchestration agents/pipelines using these providers:
+
+- OpenAI
+- Mistral
+- Gemini
+- Anthropic
+
+## User Stories
+
+- As an operator, when a pipeline fails, I can see a concise error summary on the pipeline run.
+- As an operator, when an action run fails, I can inspect structured details about the provider response.
+- As a developer, I can tell whether the failure came from provider HTTP/API behavior, transport/network issues, or invalid model output.
+- As a developer, I can correlate a failure with the generated chat and agent configuration used for that run.
+
+## Functional Requirements
+
+### 1. Failure categorization
+
+The system must classify failures into distinct categories:
+
+- `provider_http_error`
+- `transport_error`
+- `invalid_model_output`
+
+### 2. Structured diagnostics on action runs
+
+The system must persist structured diagnostics on failed `action_runs`.
+
+Proposed fields:
+
+- `category`
+- `provider`
+- `model`
+- `status_code`
+- `message`
+- `parsed_error`
+- `raw_response_excerpt`
+- `chat_id`
+- `request_context`
+
+`request_context` may reuse already-persisted metadata such as `agent_snapshot`.
+
+### 3. Pipeline-run summary
+
+The system must continue showing a concise summary on `pipeline_runs.error`.
+
+The pipeline run should not carry the full structured payload by default. Full diagnostics should live on the failed `action_run`.
+
+### 4. Provider/API error extraction
+
+When `ruby_llm` raises a provider-related exception, the application must extract details from the exception and underlying response when available, including:
+
+- HTTP status code
+- Provider name
+- Raw response body excerpt
+- Parsed provider error structure, when parseable
+
+The implementation should work cleanly for OpenAI, Mistral, Gemini, and Anthropic.
+
+### 5. Invalid model output handling
+
+If an orchestration agent is expected to return structured JSON and the model output cannot be parsed as required, the system must treat that as `invalid_model_output` instead of a generic failure.
+
+The diagnostics must include:
+
+- The parse failure message
+- A redacted/truncated excerpt of the raw model output
+
+### 6. Logging
+
+For failed LLM calls, the application must emit structured log entries containing enough context to debug failures without opening the database first.
+
+Preferred log fields:
+
+- failure category
+- provider
+- model
+- status code
+- action run ID
+- pipeline run ID
+- chat ID
+- summary message
+
+### 7. UI presentation
+
+The run UI must:
+
+- show a concise failure summary by default
+- hide raw payload details behind a disclosure
+- present structured diagnostics in a readable format for operators
+
+## Data Handling Requirements
+
+- Raw provider payloads must be redacted or truncated before persistence.
+- The system must avoid storing full unbounded payloads in the database or showing them by default in UI.
+- Sensitive request or prompt data should not be introduced unnecessarily into persisted diagnostics.
+
+## UX Requirements
+
+### Pipeline run
+
+- Show a short, human-readable error summary.
+- Keep the view high-signal and scannable.
+
+### Action run
+
+- Show summary first.
+- Provide an expandable section for structured diagnostics.
+- Provide an expandable section for raw response excerpt.
+
+## Technical Approach
+
+### Preferred approach
+
+Implement this at the application layer around orchestration agent execution.
+
+Expected shape:
+
+- add a JSON column such as `action_runs.error_details`
+- introduce an orchestration-level error extraction/normalization service
+- update `PipelineRunner` to persist structured diagnostics on failure
+- update action-run UI components to render summary + disclosure
+
+### Fallback approach
+
+If application-level handling cannot reliably access enough provider information, use a narrow monkey patch or extension around `ruby_llm` error handling.
+
+## Success Criteria
+
+- Failed orchestration runs no longer present opaque `"unknown error"` messages when provider details are available.
+- Operators can identify the failure category from the UI without reading logs.
+- Developers can inspect structured failure details for action runs and quickly determine provider, status, and response shape.
+- Invalid JSON/model-output failures are clearly distinguishable from provider HTTP/API failures.
+
+## Risks and Considerations
+
+- Provider error payloads vary by vendor and may require normalization logic.
+- Some failures may bypass HTTP error middleware and surface as transport exceptions instead.
+- Over-capturing raw payloads could leak sensitive data if redaction is incomplete.
+- UI should avoid overwhelming operators with low-level details by default.
+
+## Open Questions
+
+- Should provider-specific parsed error fields be normalized into a common shape beyond the first version?
+- Should monitoring events from `ruby_llm_monitoring_events` be linked directly from failed action runs in a later iteration?
+- Should the same observability pattern be extended to non-orchestration RubyLLM entry points after orchestration is complete?

--- a/sig/app/components/orchestration/action_run_component.rbs
+++ b/sig/app/components/orchestration/action_run_component.rbs
@@ -5,9 +5,11 @@ module Orchestration
     def action_name: () -> String
     def formatted_started_at: () -> String?
     def formatted_finished_at: () -> String?
+    def diagnostics_data: () -> Hash[String, untyped]?
+    def raw_response_excerpt: () -> String?
     def status_badge: () -> RunStatusBadgeComponent?
+    def diagnostics_disclosure: () -> UI::JsonDisclosureComponent?
     def input_disclosure: () -> UI::JsonDisclosureComponent?
     def output_disclosure: () -> UI::JsonDisclosureComponent?
   end
 end
-

--- a/sig/app/models/orchestration/action_run.rbs
+++ b/sig/app/models/orchestration/action_run.rbs
@@ -12,6 +12,8 @@ module Orchestration
     def output=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def agent_snapshot: () -> Hash[String, untyped]?
     def agent_snapshot=: (Hash[String, untyped]?) -> Hash[String, untyped]?
+    def error_details: () -> Hash[String, untyped]?
+    def error_details=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def error: () -> String?
     def error=: (String?) -> String?
     def started_at: () -> Time?

--- a/sig/app/services/orchestration/invalid_model_output_error.rbs
+++ b/sig/app/services/orchestration/invalid_model_output_error.rbs
@@ -1,0 +1,7 @@
+module Orchestration
+  class InvalidModelOutputError < StandardError
+    attr_reader raw_content: untyped
+
+    def initialize: (String message, raw_content: untyped) -> void
+  end
+end

--- a/sig/app/services/orchestration/normalize_action_run_failure.rbs
+++ b/sig/app/services/orchestration/normalize_action_run_failure.rbs
@@ -1,0 +1,52 @@
+module Orchestration
+  class NormalizeActionRunFailure
+    MAX_EXCERPT_LENGTH: Integer
+    REDACTED_VALUE: String
+    REDACTED_EMAIL: String
+
+    class Result
+      def initialize: (summary: String, details: Hash[String, untyped]?) -> void
+      def summary: () -> String
+      def details: () -> Hash[String, untyped]?
+    end
+
+    def self.call: (error: StandardError, action_run: ActionRun, raw_content: untyped) -> Result
+
+    def initialize: (error: StandardError, action_run: ActionRun, raw_content: untyped) -> void
+    def call: () -> Result
+
+    private
+
+    def provider_http_error?: () -> bool
+    def transport_error?: () -> bool
+    def invalid_model_output?: () -> bool
+    def provider_http_error_result: () -> Result
+    def transport_error_result: () -> Result
+    def invalid_model_output_result: () -> Result
+    def build_details: (
+      category: String,
+      message: String,
+      status_code: Integer?,
+      parsed_error: untyped,
+      raw_response_excerpt: String?
+    ) -> Hash[String, untyped]
+    def request_context: () -> Hash[String, untyped]?
+    def response: () -> untyped
+    def response_status: () -> Integer
+    def response_body: () -> untyped
+    def provider_error_message: (untyped parsed_error) -> String
+    def extract_parsed_error: (untyped body) -> untyped
+    def parse_json: (untyped value) -> untyped
+    def invalid_model_raw_content: () -> untyped
+    def model_name: () -> String?
+    def provider_name: () -> String?
+    def provider_label: () -> String
+    def sanitized_excerpt: (untyped value) -> String?
+    def stringify: (untyped value) -> String
+    def sanitize_value: (untyped value) -> untyped
+    def sensitive_key?: (untyped key) -> bool
+    def sanitize_string: (String value) -> String
+    def truncate: (String value) -> String
+    def ruby_llm_error?: (StandardError error) -> bool
+  end
+end

--- a/sig/app/services/orchestration/normalize_action_run_failure.rbs
+++ b/sig/app/services/orchestration/normalize_action_run_failure.rbs
@@ -40,7 +40,7 @@ module Orchestration
     def invalid_model_raw_content: () -> untyped
     def model_name: () -> String?
     def provider_name: () -> String?
-    def provider_label: () -> String
+    def provider_display_name: () -> String
     def sanitized_excerpt: (untyped value) -> String?
     def stringify: (untyped value) -> String
     def sanitize_value: (untyped value) -> untyped

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -8,9 +8,12 @@ module Orchestration
     def run_step: (Step step, Hash[String, Hash[String, untyped]] previous_outputs) -> Array[ActionRun]
     def run_actions_in_parallel: (Array[ActionRun] action_runs) -> void
     def execute_action: (ActionRun action_run) -> void
-    def run_agent: (ActionRun action_run) -> Hash[String, untyped]
-    def parse_content: (String | untyped content) -> untyped
-    def validate_output!: (Action action, Hash[String, untyped] output) -> void
+    def run_agent: (ActionRun action_run) -> Hash[Symbol, untyped]
+    def parse_content: (String | untyped content, bool structured_output_expected) -> untyped
+    def validate_output!: (Action action, untyped output, raw_content: untyped) -> void
+    def handle_action_failure: (ActionRun action_run, StandardError error, raw_content: untyped) -> void
+    def log_action_failure: (ActionRun action_run, NormalizeActionRunFailure::Result failure) -> void
+    def structured_output_expected?: (Action action) -> bool
     def leva_prompt_for: (String? agent_name) -> String?
   end
 end

--- a/spec/components/orchestration/action_run_component_spec.rb
+++ b/spec/components/orchestration/action_run_component_spec.rb
@@ -87,6 +87,38 @@ RSpec.describe Orchestration::ActionRunComponent, type: :component do
     end
   end
 
+  context "when structured error details are present" do
+    let(:action_run) do
+      build_stubbed(:orchestration_action_run,
+                    step_action: step_action,
+                    status: "failed",
+                    started_at: nil,
+                    finished_at: nil,
+                    error: "OpenAI API error (429): Rate limit exceeded",
+                    error_details: {
+                      "category" => "provider_http_error",
+                      "provider" => "openai",
+                      "model" => "gpt-4.1-mini",
+                      "status_code" => 429,
+                      "message" => "Rate limit exceeded",
+                      "parsed_error" => { "type" => "rate_limit" },
+                      "raw_response_excerpt" => '{"error":{"message":"Rate limit exceeded"}}'
+                    },
+                    input: nil,
+                    output: nil)
+    end
+
+    it "renders a diagnostics disclosure" do
+      expect(rendered.css("details summary").map { |node| node.text.strip }).to include("Diagnostics")
+      expect(rendered.css("pre").map(&:text).join("\n")).to include('"provider"')
+    end
+
+    it "renders a raw response excerpt disclosure" do
+      expect(rendered.css("details summary").map { |node| node.text.strip }).to include("Raw response excerpt")
+      expect(rendered.css("pre").map(&:text).join("\n")).to include("Rate limit exceeded")
+    end
+  end
+
   context "when input is present" do
     let(:action_run) do
       build_stubbed(:orchestration_action_run,

--- a/spec/models/orchestration/action_run_spec.rb
+++ b/spec/models/orchestration/action_run_spec.rb
@@ -67,12 +67,17 @@ RSpec.describe Orchestration::ActionRun do
     end
 
     describe '#show_attributes' do
-      it 'returns hash including input, output, and status' do
-        action_run = create(:orchestration_action_run, status: 'completed', input: { 'email' => 'test' }, output: { 'result' => 'ok' })
+      it 'returns hash including input, output, status, and error_details' do # rubocop:disable RSpec/MultipleExpectations
+        action_run = create(:orchestration_action_run,
+                            status: 'completed',
+                            input: { 'email' => 'test' },
+                            output: { 'result' => 'ok' },
+                            error_details: { 'category' => 'provider_http_error' })
         result = action_run.show_attributes
         expect(result).to include(status: 'completed')
         expect(result).to have_key(:input)
         expect(result).to have_key(:output)
+        expect(result).to have_key(:error_details)
       end
     end
 

--- a/spec/services/orchestration/normalize_action_run_failure_spec.rb
+++ b/spec/services/orchestration/normalize_action_run_failure_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe Orchestration::NormalizeActionRunFailure do
+  describe ".call" do
+    let(:action_run) do
+      create(
+        :orchestration_action_run,
+        chat: create(:chat),
+        agent_snapshot: {
+          "model" => model,
+          "prompt" => "Classify this email"
+        }
+      )
+    end
+
+    context "when the failure is a provider HTTP error" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:response) do
+        instance_double(
+          Faraday::Response,
+          status: 429,
+          body: {
+            "error" => {
+              "message" => "Rate limit exceeded",
+              "type" => "rate_limit"
+            }
+          }.to_json
+        )
+      end
+      let(:error) { RubyLLM::RateLimitError.new(response, "An unknown error occurred") }
+
+      it "extracts a concise summary and structured details" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+        result = described_class.call(error:, action_run:, raw_content: nil)
+
+        expect(result.summary).to eq("OpenAI API error (429): Rate limit exceeded")
+        expect(result.details).to include(
+          "category" => "provider_http_error",
+          "provider" => "openai",
+          "model" => "gpt-4.1-mini",
+          "status_code" => 429,
+          "message" => "Rate limit exceeded",
+          "chat_id" => action_run.chat_id,
+          "request_context" => {
+            "agent_snapshot" => action_run.agent_snapshot
+          }
+        )
+        expect(result.details["parsed_error"]).to eq(
+          "message" => "Rate limit exceeded",
+          "type" => "rate_limit"
+        )
+        expect(result.details["raw_response_excerpt"]).to include("rate_limit")
+      end
+    end
+
+    context "when the failure is a transport error" do
+      let(:model) { "mistral-small-latest" }
+      let(:error) { Faraday::TimeoutError.new("execution expired") }
+
+      it "classifies it as a transport error" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+
+        expect(result.summary).to eq("Mistral transport error: execution expired")
+        expect(result.details).to include(
+          "category" => "transport_error",
+          "provider" => "mistral",
+          "model" => "mistral-small-latest",
+          "message" => "execution expired",
+          "status_code" => nil
+        )
+        expect(result.details["raw_response_excerpt"]).to be_nil
+      end
+    end
+
+    context "when the failure is invalid model output" do
+      let(:model) { "claude-3-5-haiku-latest" }
+      let(:error) do
+        Orchestration::InvalidModelOutputError.new(
+          "Invalid model output: data.result must be an array",
+          raw_content: %({"email":"person@example.com","token":"super-secret-token-value"})
+        )
+      end
+
+      it "sanitizes and truncates the raw excerpt" do # rubocop:disable RSpec/MultipleExpectations
+        result = described_class.call(error:, action_run:, raw_content: nil)
+
+        expect(result.summary).to eq("Invalid model output: data.result must be an array")
+        expect(result.details).to include(
+          "category" => "invalid_model_output",
+          "provider" => "anthropic",
+          "model" => "claude-3-5-haiku-latest",
+          "message" => "Invalid model output: data.result must be an array"
+        )
+        expect(result.details["raw_response_excerpt"]).to include("[REDACTED_EMAIL]")
+        expect(result.details["raw_response_excerpt"]).to include("[REDACTED]")
+      end
+    end
+  end
+end

--- a/spec/services/orchestration/normalize_action_run_failure_spec.rb
+++ b/spec/services/orchestration/normalize_action_run_failure_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
       it "extracts a concise summary and structured details" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
         result = described_class.call(error:, action_run:, raw_content: nil)
 
-        expect(result.summary).to eq("OpenAI API error (429): Rate limit exceeded")
+        expect(result.summary).to eq("openai API error (429): Rate limit exceeded")
         expect(result.details).to include(
           "category" => "provider_http_error",
           "provider" => "openai",
@@ -59,7 +59,7 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
       it "classifies it as a transport error" do
         result = described_class.call(error:, action_run:, raw_content: nil)
 
-        expect(result.summary).to eq("Mistral transport error: execution expired")
+        expect(result.summary).to eq("mistral transport error: execution expired")
         expect(result.details).to include(
           "category" => "transport_error",
           "provider" => "mistral",

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -347,6 +347,70 @@ RSpec.describe Orchestration::PipelineRunner do
         action_run = Orchestration::ActionRun.last
         expect(action_run.status).to eq("failed")
         expect(action_run.error).to eq("agent exploded")
+        expect(action_run.error_details).to be_nil
+      end
+    end
+
+    context "when the provider returns a low-signal HTTP error" do
+      let(:response) do
+        instance_double(
+          Faraday::Response,
+          status: 429,
+          body: {
+            "error" => {
+              "message" => "Rate limit exceeded",
+              "type" => "rate_limit"
+            }
+          }.to_json
+        )
+      end
+
+      before do
+        action.agent.update!(model: "gpt-4.1-mini")
+        create(:orchestration_step_action, step: step1, action: action, position: 1)
+        allow(Rails.logger).to receive(:error)
+        allow(stub_agent).to receive(:with_model).and_return(stub_agent)
+        allow(stub_agent).to receive(:ask).and_raise(RubyLLM::Error.new(response, "An unknown error occurred"))
+      end
+
+      it "persists structured provider diagnostics and logs them" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+        described_class.new(pipeline_run).call
+
+        action_run = Orchestration::ActionRun.last
+        expect(action_run.status).to eq("failed")
+        expect(action_run.error).to eq("OpenAI API error (429): Rate limit exceeded")
+        expect(action_run.error_details).to include(
+          "category" => "provider_http_error",
+          "provider" => "openai",
+          "model" => "gpt-4.1-mini",
+          "status_code" => 429,
+          "message" => "Rate limit exceeded"
+        )
+        expect(pipeline_run.reload.error).to eq("OpenAI API error (429): Rate limit exceeded")
+        expect(Rails.logger).to have_received(:error).with(include('"category":"provider_http_error"'))
+      end
+    end
+
+    context "when the provider call hits a transport timeout" do
+      before do
+        action.agent.update!(model: "mistral-small-latest")
+        create(:orchestration_step_action, step: step1, action: action, position: 1)
+        allow(stub_agent).to receive(:with_model).and_return(stub_agent)
+        allow(stub_agent).to receive(:ask).and_raise(Faraday::TimeoutError.new("execution expired"))
+      end
+
+      it "persists transport diagnostics" do
+        described_class.new(pipeline_run).call
+
+        action_run = Orchestration::ActionRun.last
+        expect(action_run.status).to eq("failed")
+        expect(action_run.error).to eq("Mistral transport error: execution expired")
+        expect(action_run.error_details).to include(
+          "category" => "transport_error",
+          "provider" => "mistral",
+          "model" => "mistral-small-latest",
+          "message" => "execution expired"
+        )
       end
     end
 
@@ -411,11 +475,16 @@ RSpec.describe Orchestration::PipelineRunner do
         allow(stub_agent).to receive_messages(with_schema: stub_agent, ask: instance_double(RubyLLM::Message, content: "I need more information."))
       end
 
-      it 'marks the ActionRun as failed with a schema error' do
+      it 'marks the ActionRun as failed with invalid model output diagnostics' do # rubocop:disable RSpec/MultipleExpectations
         described_class.new(pipeline_run).call
         action_run = Orchestration::ActionRun.last
         expect(action_run.status).to eq("failed")
-        expect(action_run.error).to match(/must be an array/)
+        expect(action_run.error).to match(/Invalid model output/)
+        expect(action_run.error_details).to include(
+          "category" => "invalid_model_output",
+          "message" => a_string_matching(/Invalid model output/)
+        )
+        expect(action_run.error_details["raw_response_excerpt"]).to include("I need more information.")
       end
 
       it 'marks the PipelineRun as failed' do
@@ -441,6 +510,7 @@ RSpec.describe Orchestration::PipelineRunner do
 
         expect(action_run.status).to eq("failed")
         expect(action_run.error).to match(/must be an array/)
+        expect(action_run.error_details).to include("category" => "invalid_model_output")
       end
     end
 

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Orchestration::PipelineRunner do
 
         action_run = Orchestration::ActionRun.last
         expect(action_run.status).to eq("failed")
-        expect(action_run.error).to eq("OpenAI API error (429): Rate limit exceeded")
+        expect(action_run.error).to eq("openai API error (429): Rate limit exceeded")
         expect(action_run.error_details).to include(
           "category" => "provider_http_error",
           "provider" => "openai",
@@ -386,7 +386,7 @@ RSpec.describe Orchestration::PipelineRunner do
           "status_code" => 429,
           "message" => "Rate limit exceeded"
         )
-        expect(pipeline_run.reload.error).to eq("OpenAI API error (429): Rate limit exceeded")
+        expect(pipeline_run.reload.error).to eq("openai API error (429): Rate limit exceeded")
         expect(Rails.logger).to have_received(:error).with(include('"category":"provider_http_error"'))
       end
     end
@@ -404,7 +404,7 @@ RSpec.describe Orchestration::PipelineRunner do
 
         action_run = Orchestration::ActionRun.last
         expect(action_run.status).to eq("failed")
-        expect(action_run.error).to eq("Mistral transport error: execution expired")
+        expect(action_run.error).to eq("mistral transport error: execution expired")
         expect(action_run.error_details).to include(
           "category" => "transport_error",
           "provider" => "mistral",


### PR DESCRIPTION
## Summary
- add structured action-run diagnostics for provider HTTP, transport, and invalid model output failures
- persist concise pipeline summaries, render action-run disclosures, and add failure logging
- add migration, RBS updates, PRD, and coverage for the new observability flow