### PR TITLE
feat: add Pipeline::Validator save-time validator

### DIFF
--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -4,6 +4,8 @@ module Orchestration
       Issue = Data.define(:code, :message, :mapping_key, :from, :path)
       StepResult = Data.define(:step_action_id, :output_key, :errors, :warnings)
 
+      def self.call(pipeline) = new(pipeline).call
+
       def initialize(pipeline)
         @pipeline = pipeline
       end
@@ -35,16 +37,17 @@ module Orchestration
       private
 
       def ordered_step_actions
-        @pipeline.steps.includes(step_actions: :action).order(:position).flat_map do |step|
+        @pipeline.steps.includes(step_actions: :action).flat_map do |step|
           step.step_actions.sort_by(&:position)
         end
       end
 
       def validate_input_mapping(step_action, known_schemas, errors, warnings)
         mapping = step_action.input_mapping || {}
-        effective_params = merge_params(step_action)
 
         mapping.each do |mapping_key, spec|
+          next unless spec.is_a?(Hash)
+
           from = spec["from"]
           path = spec["path"]
 
@@ -60,7 +63,7 @@ module Orchestration
             )
           end
 
-          if effective_params.key?(mapping_key)
+          if merge_params(step_action).key?(mapping_key)
             warnings << Issue.new(
               code: :param_collision,
               message: "key #{mapping_key.inspect} appears in both input_mapping and params; input_mapping wins at runtime",
@@ -114,7 +117,8 @@ module Orchestration
         schema = step_action.action.input_schema
         return if schema.nil?
 
-        required_keys = schema["required"] || []
+        required_keys = schema["required"]
+        return unless required_keys.is_a?(Array)
         return if required_keys.empty?
 
         covered = Set.new((step_action.input_mapping || {}).keys + merge_params(step_action).keys)

--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -1,0 +1,140 @@
+module Orchestration
+  class Pipeline
+    class Validator
+      Issue = Data.define(:code, :message, :mapping_key, :from, :path)
+      StepResult = Data.define(:step_action_id, :output_key, :errors, :warnings)
+
+      def initialize(pipeline)
+        @pipeline = pipeline
+      end
+
+      def call
+        known_schemas = { "_initial" => @pipeline.initial_input_schema }
+        results = [] # : Array[StepResult]
+
+        ordered_step_actions.each do |sa|
+          errors   = [] # : Array[Issue]
+          warnings = [] # : Array[Issue]
+
+          validate_input_mapping(sa, known_schemas, errors, warnings)
+          validate_input_schema(sa, errors)
+
+          results << StepResult.new(
+            step_action_id: sa.id,
+            output_key: sa.output_key,
+            errors: errors,
+            warnings: warnings
+          )
+
+          known_schemas[sa.output_key] = sa.action.output_schema
+        end
+
+        results
+      end
+
+      private
+
+      def ordered_step_actions
+        @pipeline.steps.includes(step_actions: :action).order(:position).flat_map do |step|
+          step.step_actions.sort_by(&:position)
+        end
+      end
+
+      def validate_input_mapping(step_action, known_schemas, errors, warnings)
+        mapping = step_action.input_mapping || {}
+        effective_params = merge_params(step_action)
+
+        mapping.each do |mapping_key, spec|
+          from = spec["from"]
+          path = spec["path"]
+
+          if known_schemas.key?(from)
+            validate_path_vs_schema(from, path, mapping_key, known_schemas[from], errors)
+          else
+            errors << Issue.new(
+              code: :unknown_from,
+              message: "input_mapping key #{mapping_key.inspect} references unknown output key #{from.inspect}",
+              mapping_key: mapping_key,
+              from: from,
+              path: nil
+            )
+          end
+
+          if effective_params.key?(mapping_key)
+            warnings << Issue.new(
+              code: :param_collision,
+              message: "key #{mapping_key.inspect} appears in both input_mapping and params; input_mapping wins at runtime",
+              mapping_key: mapping_key,
+              from: from,
+              path: nil
+            )
+          end
+        end
+      end
+
+      def validate_path_vs_schema(from, path, mapping_key, upstream_schema, errors)
+        return if path.nil? || upstream_schema.nil?
+
+        return if path_valid_in_schema?(path, upstream_schema)
+
+        errors << Issue.new(
+          code: :invalid_path,
+          message: "path #{path.inspect} does not resolve in output_schema of #{from.inspect}",
+          mapping_key: mapping_key,
+          from: from,
+          path: path
+        )
+      end
+
+      def path_valid_in_schema?(path, schema)
+        current = schema
+
+        path.split(".").each do |seg|
+          return false if current.nil?
+
+          case current["type"]
+          when "object"
+            properties = current["properties"] || {}
+            return false unless properties.key?(seg)
+
+            current = properties[seg]
+          when "array"
+            return false unless seg.match?(/\A\d+\z/)
+
+            current = current["items"]
+          else
+            return false
+          end
+        end
+
+        true
+      end
+
+      def validate_input_schema(step_action, errors)
+        schema = step_action.action.input_schema
+        return if schema.nil?
+
+        required_keys = schema["required"] || []
+        return if required_keys.empty?
+
+        covered = Set.new((step_action.input_mapping || {}).keys + merge_params(step_action).keys)
+
+        required_keys.each do |key|
+          next if covered.include?(key)
+
+          errors << Issue.new(
+            code: :missing_required_key,
+            message: "required input_schema key #{key.inspect} is not provided by input_mapping or params",
+            mapping_key: nil,
+            from: nil,
+            path: nil
+          )
+        end
+      end
+
+      def merge_params(step_action)
+        (step_action.action.params || {}).merge(step_action.params || {})
+      end
+    end
+  end
+end

--- a/sig/app/models/orchestration/action.rbs
+++ b/sig/app/models/orchestration/action.rbs
@@ -26,6 +26,8 @@ module Orchestration
     def params=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def output_schema: () -> Hash[String, untyped]?
     def output_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
+    def input_schema: () -> Hash[String, untyped]?
+    def input_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
 
     def step_actions: () -> ActiveRecord::Associations::CollectionProxy
     def agent: () -> Orchestration::Agent?

--- a/sig/app/services/orchestration/pipeline/validator.rbs
+++ b/sig/app/services/orchestration/pipeline/validator.rbs
@@ -1,0 +1,34 @@
+module Orchestration
+  class Pipeline
+    class Validator
+      class Issue < Data
+        def self.new: (code: Symbol, message: String, mapping_key: String?, from: String?, path: String?) -> Issue
+        attr_reader code: Symbol
+        attr_reader message: String
+        attr_reader mapping_key: String?
+        attr_reader from: String?
+        attr_reader path: String?
+      end
+
+      class StepResult < Data
+        def self.new: (step_action_id: Integer, output_key: String, errors: Array[Issue], warnings: Array[Issue]) -> StepResult
+        attr_reader step_action_id: Integer
+        attr_reader output_key: String
+        attr_reader errors: Array[Issue]
+        attr_reader warnings: Array[Issue]
+      end
+
+      def initialize: (Orchestration::Pipeline pipeline) -> void
+      def call: () -> Array[StepResult]
+
+      private
+
+      def ordered_step_actions: () -> Array[Orchestration::StepAction]
+      def validate_input_mapping: (Orchestration::StepAction step_action, Hash[String, untyped] known_schemas, Array[Issue] errors, Array[Issue] warnings) -> void
+      def validate_path_vs_schema: (String from, String? path, String mapping_key, Hash[String, untyped]? upstream_schema, Array[Issue] errors) -> void
+      def path_valid_in_schema?: (String path, Hash[String, untyped] schema) -> bool
+      def validate_input_schema: (Orchestration::StepAction step_action, Array[Issue] errors) -> void
+      def merge_params: (Orchestration::StepAction step_action) -> Hash[String, untyped]
+    end
+  end
+end

--- a/sig/app/services/orchestration/pipeline/validator.rbs
+++ b/sig/app/services/orchestration/pipeline/validator.rbs
@@ -18,6 +18,8 @@ module Orchestration
         attr_reader warnings: Array[Issue]
       end
 
+      def self.call: (Orchestration::Pipeline pipeline) -> Array[StepResult]
+
       def initialize: (Orchestration::Pipeline pipeline) -> void
       def call: () -> Array[StepResult]
 

--- a/spec/services/orchestration/pipeline/validator_spec.rb
+++ b/spec/services/orchestration/pipeline/validator_spec.rb
@@ -1,0 +1,226 @@
+require 'rails_helper'
+
+RSpec.describe Orchestration::Pipeline::Validator do
+  subject(:validator) { described_class.new(pipeline) }
+
+  let(:pipeline) { create(:orchestration_pipeline) }
+  let(:step)     { create(:orchestration_step, pipeline: pipeline, position: 1) }
+
+  describe '#call' do
+    context 'with a fully-correct pipeline (no input_mapping, no schema constraints)' do
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch", input_mapping: nil)
+      end
+
+      it 'returns one result with no errors or warnings' do
+        results = validator.call
+        expect(results.size).to eq(1)
+        expect(results.first.errors).to be_empty
+        expect(results.first.warnings).to be_empty
+      end
+
+      it 'populates step_action_id and output_key on the result' do
+        result = validator.call.first
+        expect(result.output_key).to eq("fetch")
+        expect(result.step_action_id).to be_a(Integer)
+      end
+    end
+
+    context 'with a typo in from' do
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               input_mapping: { "emails" => { "from" => "nonexistent_key" } })
+      end
+
+      it 'returns an unknown_from error with the correct code, message, and mapping_key' do
+        error = validator.call.first.errors.first
+        expect(error.code).to eq(:unknown_from)
+        expect(error.message).to include("nonexistent_key")
+        expect(error.mapping_key).to eq("emails")
+      end
+
+      it 'names the bad from reference on the error' do
+        error = validator.call.first.errors.first
+        expect(error.from).to eq("nonexistent_key")
+      end
+
+      it 'produces no warnings' do
+        expect(validator.call.first.warnings).to be_empty
+      end
+    end
+
+    context 'with a valid from but typo in path against upstream output_schema' do
+      let(:upstream_action) do
+        create(:orchestration_action,
+               output_schema: {
+                 "type" => "object",
+                 "properties" => { "result" => { "type" => "string" } }
+               })
+      end
+      let(:step2) { create(:orchestration_step, pipeline: pipeline, position: 2) }
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               action: upstream_action, input_mapping: nil)
+        create(:orchestration_step_action,
+               step: step2, position: 1, output_key: "classify",
+               input_mapping: { "data" => { "from" => "fetch", "path" => "nonexistent_path" } })
+      end
+
+      it 'returns an invalid_path error with correct code and mapping_key' do
+        error = validator.call.find { |r| r.output_key == "classify" }.errors.first
+        expect(error.code).to eq(:invalid_path)
+        expect(error.mapping_key).to eq("data")
+      end
+
+      it 'includes the bad path and upstream output_key in the error message' do
+        error = validator.call.find { |r| r.output_key == "classify" }.errors.first
+        expect(error.message).to include("nonexistent_path")
+        expect(error.message).to include("fetch")
+      end
+
+      it 'populates path and from on the error' do
+        error = validator.call.find { |r| r.output_key == "classify" }.errors.first
+        expect(error.path).to eq("nonexistent_path")
+        expect(error.from).to eq("fetch")
+      end
+
+      it 'returns no errors for the upstream step' do
+        fetch_result = validator.call.find { |r| r.output_key == "fetch" }
+        expect(fetch_result.errors).to be_empty
+      end
+    end
+
+    context 'when upstream has no output_schema' do
+      let(:step2) { create(:orchestration_step, pipeline: pipeline, position: 2) }
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               input_mapping: nil)
+        create(:orchestration_step_action,
+               step: step2, position: 1, output_key: "classify",
+               input_mapping: { "data" => { "from" => "fetch", "path" => "any.path" } })
+      end
+
+      it 'does not produce a path error when upstream has no output_schema' do
+        classify_result = validator.call.find { |r| r.output_key == "classify" }
+        expect(classify_result.errors).to be_empty
+      end
+    end
+
+    context 'with a missing required input_schema key' do
+      let(:action) do
+        create(:orchestration_action,
+               input_schema: {
+                 "type" => "object",
+                 "required" => [ "emails", "date" ]
+               })
+      end
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               action: action,
+               input_mapping: { "emails" => { "from" => "_initial" } })
+      end
+
+      it 'returns a missing_required_key error naming the missing key' do
+        results = validator.call
+        error = results.first.errors.first
+        expect(error.code).to eq(:missing_required_key)
+        expect(error.message).to include("date")
+      end
+
+      it 'does not error on covered keys' do
+        errors = validator.call.first.errors
+        expect(errors.none? { |e| e.message.include?("emails") }).to be true
+      end
+    end
+
+    context 'when a required input_schema key is covered by step_action params' do
+      let(:action) do
+        create(:orchestration_action,
+               input_schema: { "type" => "object", "required" => [ "date" ] })
+      end
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               action: action,
+               params: { "date" => "2026-05-10" },
+               input_mapping: nil)
+      end
+
+      it 'returns no error' do
+        expect(validator.call.first.errors).to be_empty
+      end
+    end
+
+    context 'when a required input_schema key is covered by action default params' do
+      let(:action) do
+        create(:orchestration_action,
+               params: { "date" => "default" },
+               input_schema: { "type" => "object", "required" => [ "date" ] })
+      end
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               action: action,
+               input_mapping: nil)
+      end
+
+      it 'returns no error' do
+        expect(validator.call.first.errors).to be_empty
+      end
+    end
+
+    context 'with a key collision between input_mapping and params' do
+      let(:action) do
+        create(:orchestration_action, params: { "key1" => "default_value" })
+      end
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               action: action,
+               input_mapping: { "key1" => { "from" => "_initial" } })
+      end
+
+      it 'produces no errors' do
+        expect(validator.call.first.errors).to be_empty
+      end
+
+      it 'produces a param_collision warning naming the colliding key' do
+        warning = validator.call.first.warnings.first
+        expect(warning.code).to eq(:param_collision)
+        expect(warning.message).to include("key1")
+        expect(warning.mapping_key).to eq("key1")
+      end
+    end
+
+    it 'does not raise on a misconfigured pipeline' do
+      create(:orchestration_step_action,
+             step: step, position: 1, output_key: "bad",
+             input_mapping: { "x" => { "from" => "bad_ref" } })
+      expect { validator.call }.not_to raise_error
+    end
+
+    context 'with _initial as a from reference' do
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               input_mapping: { "run_date" => { "from" => "_initial", "path" => "date" } })
+      end
+
+      it 'does not produce an unknown_from error for _initial' do
+        results = validator.call
+        expect(results.first.errors.none? { |e| e.code == :unknown_from }).to be true
+      end
+    end
+  end
+end

--- a/spec/services/orchestration/pipeline/validator_spec.rb
+++ b/spec/services/orchestration/pipeline/validator_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe Orchestration::Pipeline::Validator do
   let(:pipeline) { create(:orchestration_pipeline) }
   let(:step)     { create(:orchestration_step, pipeline: pipeline, position: 1) }
 
+  describe '.call' do
+    it 'delegates to an instance and returns results' do
+      create(:orchestration_step_action, step: step, position: 1, output_key: "fetch", input_mapping: nil)
+      expect(described_class.call(pipeline)).to be_an(Array)
+    end
+  end
+
   describe '#call' do
     context 'with a fully-correct pipeline (no input_mapping, no schema constraints)' do
       before do
@@ -208,6 +215,39 @@ RSpec.describe Orchestration::Pipeline::Validator do
              step: step, position: 1, output_key: "bad",
              input_mapping: { "x" => { "from" => "bad_ref" } })
       expect { validator.call }.not_to raise_error
+    end
+
+    context 'with a non-Hash spec value in input_mapping' do
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               input_mapping: { "key" => "plain_string_value" })
+      end
+
+      it 'does not raise' do
+        expect { validator.call }.not_to raise_error
+      end
+
+      it 'returns no errors for the malformed entry' do
+        expect(validator.call.first.errors).to be_empty
+      end
+    end
+
+    context 'with a non-Array required field in input_schema' do
+      let(:action) do
+        create(:orchestration_action,
+               input_schema: { "type" => "object", "required" => "emails" })
+      end
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               action: action, input_mapping: nil)
+      end
+
+      it 'does not raise' do
+        expect { validator.call }.not_to raise_error
+      end
     end
 
     context 'with _initial as a from reference' do


### PR DESCRIPTION
## Summary
- Adds `Orchestration::Pipeline::Validator` — a pure save-time validator that walks every step_action in execution order and returns per-step-action structured errors and warnings
- Validates: unknown `from` references, invalid paths against upstream `output_schema`, missing required `input_schema` keys, and `input_mapping`/`params` key collisions
- Never raises on misconfigured pipelines — always returns results so callers can surface issues in the UI

Closes #81

## Test plan
- [x] 18 new spec examples covering all four validation rules (unknown from, invalid path, missing required key, param collision) plus edge cases
- [x] Full rspec suite passes (1478 examples, 0 failures, 95.63% coverage)
- [x] `bundle exec rubocop` clean
- [x] `steep check` clean — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)