### PR TITLE
feat: add explicit input_mapping to all pipeline steps

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,6 +43,28 @@ STORE_EMAILS_OUTPUT_SCHEMA = {
   }
 }.freeze
 
+FETCH_EMAILS_INPUT_MAPPING = {
+  "date"      => { "from" => "_initial", "path" => "date" },
+  "providers" => { "from" => "_initial", "path" => "providers" }
+}.freeze
+
+CLASSIFY_EMAILS_INPUT_MAPPING = {
+  "emails" => { "from" => "fetch_emails", "path" => "emails" }
+}.freeze
+
+FILTER_EMAILS_STEP_PARAMS = {
+  "topic" => "job applications"
+}.freeze
+
+FILTER_EMAILS_INPUT_MAPPING = {
+  "emails" => { "from" => "classify_emails", "path" => "results" }
+}.freeze
+
+INGEST_EMAILS_INPUT_MAPPING = {
+  "emails"  => { "from" => "fetch_emails",  "path" => "emails" },
+  "results" => { "from" => "filter_emails", "path" => "results" }
+}.freeze
+
 INGEST_EMAILS_PARAMS = {
   "operations" => [
     { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "results", "output" => "emails" },
@@ -274,16 +296,16 @@ AGENT_DEFINITIONS = {
 }.freeze
 
 steps = [
-  { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor"                                                                                             },
-  { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent"                                                                                              },
-  { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent"                                                                                                },
-  { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor",  params: INGEST_EMAILS_PARAMS                                                   },
-  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",  schema_class: "ApplicationMailsSchema", sa_input_mapping: MAP_EMAILS_INPUT_MAPPING           },
-  { name: "Store Emails",                   kind: :agent,   agent_name: "Records::StoreAgent",   sa_params: STORE_EMAILS_STEP_PARAMS,  sa_input_mapping: STORE_EMAILS_INPUT_MAPPING           },
-  { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",  params: QUERY_EMAIL_RECORDS_PARAMS, sa_input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING },
-  { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",  sa_params: NORMALIZE_EMAILS_STEP_PARAMS, sa_input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING },
-  { name: "Reconcile Emails to Interviews", kind: :agent,   agent_name: "Records::ReconcileAgent",  sa_params: RECONCILE_EMAILS_STEP_PARAMS, sa_input_mapping: RECONCILE_EMAILS_INPUT_MAPPING },
-  { name: "Export to Gist",                 kind: :service, agent_class: "Interviews::GistExportExecutor"                                                                                    }
+  { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor",                                                                     sa_input_mapping: FETCH_EMAILS_INPUT_MAPPING    },
+  { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent",                                                                      sa_input_mapping: CLASSIFY_EMAILS_INPUT_MAPPING },
+  { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent",                sa_params: FILTER_EMAILS_STEP_PARAMS,                  sa_input_mapping: FILTER_EMAILS_INPUT_MAPPING   },
+  { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor",  params: INGEST_EMAILS_PARAMS,                           sa_input_mapping: INGEST_EMAILS_INPUT_MAPPING   },
+  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",               schema_class: "ApplicationMailsSchema",                sa_input_mapping: MAP_EMAILS_INPUT_MAPPING      },
+  { name: "Store Emails",                   kind: :agent,   agent_name: "Records::StoreAgent",                sa_params: STORE_EMAILS_STEP_PARAMS,                   sa_input_mapping: STORE_EMAILS_INPUT_MAPPING    },
+  { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",      params: QUERY_EMAIL_RECORDS_PARAMS,                    sa_input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING },
+  { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",            sa_params: NORMALIZE_EMAILS_STEP_PARAMS,               sa_input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING },
+  { name: "Reconcile Emails to Interviews", kind: :agent,   agent_name: "Records::ReconcileAgent",            sa_params: RECONCILE_EMAILS_STEP_PARAMS,               sa_input_mapping: RECONCILE_EMAILS_INPUT_MAPPING },
+  { name: "Export to Gist",                 kind: :service, agent_class: "Interviews::GistExportExecutor",                                                            sa_input_mapping: {}                            }
 ]
 
 Orchestration::Action.where(name: "Merge Email Records").destroy_all

--- a/spec/db/seeds_pipeline_input_mapping_spec.rb
+++ b/spec/db/seeds_pipeline_input_mapping_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Seeds: pipeline 2 step input_mapping" do # rubocop:disable RSpec/DescribeClass
+  before { load Rails.root.join("db/seeds.rb") }
+
+  let(:pipeline) { Orchestration::Pipeline.find_by!(name: "Applications Workflow") }
+
+  def step_action_for(step_name)
+    pipeline.steps.find_by!(name: step_name).step_actions.first!
+  end
+
+  describe "Fetch Emails (step 1)" do
+    subject(:sa) { step_action_for("Fetch Emails") }
+
+    it "maps date from initial input" do
+      expect(sa.input_mapping).to include("date" => { "from" => "_initial", "path" => "date" })
+    end
+
+    it "maps providers from initial input" do
+      expect(sa.input_mapping).to include("providers" => { "from" => "_initial", "path" => "providers" })
+    end
+  end
+
+  describe "Classify Emails (step 2)" do
+    subject(:sa) { step_action_for("Classify Emails") }
+
+    it "maps emails from fetch_emails output" do
+      expect(sa.input_mapping).to include("emails" => { "from" => "fetch_emails", "path" => "emails" })
+    end
+  end
+
+  describe "Filter Emails (step 3)" do
+    subject(:sa) { step_action_for("Filter Emails") }
+
+    it "has topic param set to job applications" do
+      expect(sa.params).to include("topic" => "job applications")
+    end
+
+    it "maps emails from classify_emails results" do
+      expect(sa.input_mapping).to include("emails" => { "from" => "classify_emails", "path" => "results" })
+    end
+  end
+
+  describe "Ingest Emails (step 4)" do
+    subject(:sa) { step_action_for("Ingest Emails") }
+
+    it "maps emails from fetch_emails output" do
+      expect(sa.input_mapping).to include("emails" => { "from" => "fetch_emails", "path" => "emails" })
+    end
+
+    it "maps results from filter_emails output" do
+      expect(sa.input_mapping).to include("results" => { "from" => "filter_emails", "path" => "results" })
+    end
+  end
+
+  describe "Export to Gist (step 10)" do
+    subject(:sa) { step_action_for("Export to Gist") }
+
+    it "has explicit non-nil input_mapping" do
+      expect(sa.input_mapping).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Added `FETCH_EMAILS_INPUT_MAPPING`, `CLASSIFY_EMAILS_INPUT_MAPPING`, `FILTER_EMAILS_INPUT_MAPPING`, `INGEST_EMAILS_INPUT_MAPPING` constants to wire the 5 previously-nil steps
- Added `FILTER_EMAILS_STEP_PARAMS` with `topic: "job applications"` so FilterAgent gets its required static param via `step_action.params`
- Steps 1–4 and 10 now explicitly map from `_initial` or upstream `output_key`s; no step relies on `nil` input_mapping

Closes #83

## Test plan

- [x] `spec/db/seeds_pipeline_input_mapping_spec.rb` — 8 new examples verifying each step's `input_mapping` and `params`
- [x] Existing `spec/db/seeds_agent_backfill_spec.rb` still passes (64 examples, 0 failures)
- [x] Full suite passes (1501 examples, 0 failures)
- [x] `bundle exec rubocop` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)