### PR TITLE
feat: input_mapping editor, per-step validity badge, and observability panel

### DIFF
--- a/app/components/orchestration/action_run_component.html.erb
+++ b/app/components/orchestration/action_run_component.html.erb
@@ -31,4 +31,5 @@
 
   <%= input_disclosure %>
   <%= output_disclosure %>
+  <%= available_outputs_disclosure %>
 </div>

--- a/app/components/orchestration/action_run_component.rb
+++ b/app/components/orchestration/action_run_component.rb
@@ -8,9 +8,11 @@ module Orchestration
     renders_one :diagnostics_disclosure, -> { UI::JsonDisclosureComponent.new(label: "Diagnostics", data: diagnostics_data) }
     renders_one :input_disclosure, -> { UI::JsonDisclosureComponent.new(label: "Input", data: @action_run.input) }
     renders_one :output_disclosure, -> { UI::JsonDisclosureComponent.new(label: "Output", data: @action_run.output) }
+    renders_one :available_outputs_disclosure, -> { UI::JsonDisclosureComponent.new(label: "Available Outputs", data: @available_outputs) }
 
-    def initialize(action_run:)
+    def initialize(action_run:, available_outputs: nil)
       @action_run = action_run
+      @available_outputs = available_outputs
     end
 
     def before_render
@@ -18,6 +20,7 @@ module Orchestration
       with_diagnostics_disclosure if diagnostics_data.present?
       with_input_disclosure
       with_output_disclosure
+      with_available_outputs_disclosure if @available_outputs.present?
     end
 
     def action_name

--- a/app/components/orchestration/input_mapping_component.html.erb
+++ b/app/components/orchestration/input_mapping_component.html.erb
@@ -1,29 +1,7 @@
 <%= form_with url: form_url, method: :patch, class: "space-y-2" do %>
   <p class="text-xs font-medium text-gray-600">Mapping for <span class="font-mono"><%= @step_action.output_key %></span></p>
 
-  <% mapping_rows.each do |row| %>
-    <div class="flex items-center gap-2">
-      <span class="text-xs font-mono text-gray-700 w-24 truncate" title="<%= h(row.mapping_key) %>"><%= row.mapping_key %></span>
-      <span class="text-xs text-gray-400">←</span>
-      <%= select_tag "orchestration_step_action[input_mapping][#{row.mapping_key}][from]",
-            options_for_select(from_options, row.current_from),
-            "data-testid": "from-select",
-            class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-      <% if row.path_opts %>
-        <%= select_tag "orchestration_step_action[input_mapping][#{row.mapping_key}][path]",
-              options_for_select(row.path_opts, row.current_path),
-              include_blank: "— whole output —",
-              "data-testid": "path-select",
-              class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-      <% else %>
-        <%= text_field_tag "orchestration_step_action[input_mapping][#{row.mapping_key}][path]",
-              row.current_path,
-              placeholder: "dot.path (optional)",
-              "data-testid": "path-text",
-              class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render Orchestration::MappingEntryComponent.with_collection(mapping_rows, from_options: from_options) %>
 
   <%= render Orchestration::NewMappingEntryComponent.new(from_options: from_options) %>
 <% end %>

--- a/app/components/orchestration/input_mapping_component.html.erb
+++ b/app/components/orchestration/input_mapping_component.html.erb
@@ -1,0 +1,29 @@
+<%= form_with url: form_url, method: :patch, class: "space-y-2" do %>
+  <p class="text-xs font-medium text-gray-600">Mapping for <span class="font-mono"><%= @step_action.output_key %></span></p>
+
+  <% mapping_rows.each do |row| %>
+    <div class="flex items-center gap-2">
+      <span class="text-xs font-mono text-gray-700 w-24 truncate" title="<%= h(row.mapping_key) %>"><%= row.mapping_key %></span>
+      <span class="text-xs text-gray-400">←</span>
+      <%= select_tag "orchestration_step_action[input_mapping][#{row.mapping_key}][from]",
+            options_for_select(from_options, row.current_from),
+            "data-testid": "from-select",
+            class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+      <% if row.path_opts %>
+        <%= select_tag "orchestration_step_action[input_mapping][#{row.mapping_key}][path]",
+              options_for_select(row.path_opts, row.current_path),
+              include_blank: "— whole output —",
+              "data-testid": "path-select",
+              class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+      <% else %>
+        <%= text_field_tag "orchestration_step_action[input_mapping][#{row.mapping_key}][path]",
+              row.current_path,
+              placeholder: "dot.path (optional)",
+              "data-testid": "path-text",
+              class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= render Orchestration::NewMappingEntryComponent.new(from_options: from_options) %>
+<% end %>

--- a/app/components/orchestration/input_mapping_component.rb
+++ b/app/components/orchestration/input_mapping_component.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class InputMappingComponent < ViewComponent::Base
+    MappingRow = Data.define(:mapping_key, :current_from, :current_path, :path_opts)
+
+    def initialize(step_action:, pipeline:, step:, upstream_schemas:)
+      @step_action      = step_action
+      @pipeline         = pipeline
+      @step             = step
+      @upstream_schemas = upstream_schemas
+    end
+
+    def form_url
+      helpers.orchestration_pipeline_step_step_action_path(@pipeline, @step, @step_action)
+    end
+
+    def from_options
+      @upstream_schemas.keys.map { |k| [ k, k ] }
+    end
+
+    def path_options_for(from_key)
+      schema = @upstream_schemas[from_key]
+      return nil if schema.nil?
+
+      properties = schema["properties"]
+      return nil if properties.blank?
+
+      properties.keys.map { |k| [ k, k ] }
+    end
+
+    def mapping
+      @step_action.input_mapping || {}
+    end
+
+    def mapping_rows
+      mapping.map do |mapping_key, spec|
+        spec         = spec || {}
+        current_from = spec["from"]
+        current_path = spec["path"]
+        MappingRow.new(
+          mapping_key:  mapping_key,
+          current_from: current_from,
+          current_path: current_path,
+          path_opts:    path_options_for(current_from)
+        )
+      end
+    end
+  end
+end

--- a/app/components/orchestration/mapping_entry_component.html.erb
+++ b/app/components/orchestration/mapping_entry_component.html.erb
@@ -1,0 +1,21 @@
+<div class="flex items-center gap-2">
+  <span class="text-xs font-mono text-gray-700 w-24 truncate" title="<%= h(@row.mapping_key) %>"><%= @row.mapping_key %></span>
+  <span class="text-xs text-gray-400">←</span>
+  <%= select_tag "orchestration_step_action[input_mapping][#{@row.mapping_key}][from]",
+        options_for_select(@from_options, @row.current_from),
+        "data-testid": "from-select",
+        class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+  <% if @row.path_opts %>
+    <%= select_tag "orchestration_step_action[input_mapping][#{@row.mapping_key}][path]",
+          options_for_select(@row.path_opts, @row.current_path),
+          include_blank: "— whole output —",
+          "data-testid": "path-select",
+          class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+  <% else %>
+    <%= text_field_tag "orchestration_step_action[input_mapping][#{@row.mapping_key}][path]",
+          @row.current_path,
+          placeholder: "dot.path (optional)",
+          "data-testid": "path-text",
+          class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+  <% end %>
+</div>

--- a/app/components/orchestration/mapping_entry_component.rb
+++ b/app/components/orchestration/mapping_entry_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class MappingEntryComponent < ViewComponent::Base
+    with_collection_parameter :row
+
+    def initialize(row:, from_options:)
+      @row          = row
+      @from_options = from_options
+    end
+  end
+end

--- a/app/components/orchestration/new_mapping_entry_component.html.erb
+++ b/app/components/orchestration/new_mapping_entry_component.html.erb
@@ -1,0 +1,18 @@
+<div class="flex items-center gap-2 border-t border-dashed border-gray-200 pt-2">
+  <span class="text-xs text-gray-400 w-24">new key:</span>
+  <%= text_field_tag "orchestration_step_action[new_key]",
+        nil,
+        placeholder: "input_key",
+        class: "w-24 border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+  <span class="text-xs text-gray-400">←</span>
+  <%= select_tag "orchestration_step_action[new_from]",
+        options_for_select(@from_options),
+        include_blank: "— from —",
+        class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+  <%= text_field_tag "orchestration_step_action[new_path]",
+        nil,
+        placeholder: "dot.path (optional)",
+        class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+  <%= submit_tag "Save mapping",
+        class: "px-2 py-1 bg-indigo-600 text-white text-xs font-medium rounded hover:bg-indigo-700 transition-colors cursor-pointer" %>
+</div>

--- a/app/components/orchestration/new_mapping_entry_component.rb
+++ b/app/components/orchestration/new_mapping_entry_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class NewMappingEntryComponent < ViewComponent::Base
+    def initialize(from_options:)
+      @from_options = from_options
+    end
+  end
+end

--- a/app/components/orchestration/step_action_editor_component.html.erb
+++ b/app/components/orchestration/step_action_editor_component.html.erb
@@ -1,0 +1,16 @@
+<div class="mt-3 pt-3 border-t border-gray-100" data-testid="input-mapping-editor">
+  <%= render Orchestration::InputMappingComponent.new(
+        step_action: @step_action,
+        pipeline: @pipeline,
+        step: @step,
+        upstream_schemas: @upstream_schemas
+      ) %>
+
+  <% if validation_errors.any? %>
+    <ul class="mt-1 ml-4 space-y-0.5">
+      <% validation_errors.each do |err| %>
+        <li class="text-xs text-red-600">⚠ <%= err.message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/components/orchestration/step_action_editor_component.rb
+++ b/app/components/orchestration/step_action_editor_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepActionEditorComponent < ViewComponent::Base
+    with_collection_parameter :step_action
+
+    def initialize(step_action:, step_action_counter:, step_action_iteration:,
+                   pipeline:, step:, upstream_schemas:, validator_results:)
+      @step_action       = step_action
+      @pipeline          = pipeline
+      @step              = step
+      @upstream_schemas  = upstream_schemas
+      @validator_results = validator_results
+    end
+
+    def validation_errors
+      result = @validator_results.find { |r| r.step_action_id == @step_action.id }
+      result&.errors || []
+    end
+  end
+end

--- a/app/components/orchestration/step_component.html.erb
+++ b/app/components/orchestration/step_component.html.erb
@@ -8,6 +8,7 @@
           <% unless @step.enabled? %>
             <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-500">disabled</span>
           <% end %>
+          <span class="<%= validity_badge_classes %>" data-testid="validity-badge"><%= validity_badge_label %></span>
         </div>
 
         <% if @step.step_actions.any? %>
@@ -22,6 +23,78 @@
               </div>
             <% end %>
           </div>
+
+          <%# Input mapping editors %>
+          <% @step.step_actions.each do |sa| %>
+            <div class="mt-3 pt-3 border-t border-gray-100" data-testid="input-mapping-editor">
+              <%= form_with url: orchestration_pipeline_step_step_action_path(@pipeline, @step, sa),
+                            method: :patch, class: "space-y-2" do |f| %>
+                <p class="text-xs font-medium text-gray-600">Mapping for <span class="font-mono"><%= sa.output_key %></span></p>
+
+                <% (sa.input_mapping || {}).each do |mapping_key, spec| %>
+                  <% spec ||= {} %>
+                  <% current_from = spec["from"] %>
+                  <% current_path = spec["path"] %>
+                  <% path_opts = path_options_for(current_from) %>
+                  <div class="flex items-center gap-2">
+                    <span class="text-xs font-mono text-gray-700 w-24 truncate" title="<%= mapping_key %>"><%= mapping_key %></span>
+                    <span class="text-xs text-gray-400">←</span>
+                    <%= f.select "orchestration_step_action[input_mapping][#{mapping_key}][from]",
+                          options_for_select(from_options, current_from),
+                          {},
+                          name: "orchestration_step_action[input_mapping][#{mapping_key}][from]",
+                          "data-testid": "from-select",
+                          class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+                    <% if path_opts %>
+                      <%= f.select "orchestration_step_action[input_mapping][#{mapping_key}][path]",
+                            options_for_select(path_opts, current_path),
+                            { include_blank: "— whole output —" },
+                            name: "orchestration_step_action[input_mapping][#{mapping_key}][path]",
+                            "data-testid": "path-select",
+                            class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+                    <% else %>
+                      <%= f.text_field "orchestration_step_action[input_mapping][#{mapping_key}][path]",
+                            value: current_path,
+                            name: "orchestration_step_action[input_mapping][#{mapping_key}][path]",
+                            placeholder: "dot.path (optional)",
+                            "data-testid": "path-text",
+                            class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+                    <% end %>
+                  </div>
+                <% end %>
+
+                <%# Add new mapping entry row %>
+                <div class="flex items-center gap-2 border-t border-dashed border-gray-200 pt-2">
+                  <span class="text-xs text-gray-400 w-24">new key:</span>
+                  <%= f.text_field :new_key,
+                        name: "orchestration_step_action[new_key]",
+                        placeholder: "input_key",
+                        class: "w-24 border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+                  <span class="text-xs text-gray-400">←</span>
+                  <%= f.select :new_from,
+                        options_for_select(from_options),
+                        { include_blank: "— from —" },
+                        name: "orchestration_step_action[new_from]",
+                        class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+                  <%= f.text_field :new_path,
+                        name: "orchestration_step_action[new_path]",
+                        placeholder: "dot.path (optional)",
+                        class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+                  <%= f.submit "Save mapping", class: "px-2 py-1 bg-indigo-600 text-white text-xs font-medium rounded hover:bg-indigo-700 transition-colors cursor-pointer" %>
+                </div>
+              <% end %>
+            </div>
+
+            <%# Per-step-action validation errors %>
+            <% step_action_result = @validator_results.find { |r| r.step_action_id == sa.id } %>
+            <% if step_action_result&.errors&.any? %>
+              <ul class="mt-1 ml-4 space-y-0.5">
+                <% step_action_result.errors.each do |err| %>
+                  <li class="text-xs text-red-600">⚠ <%= err.message %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          <% end %>
         <% end %>
 
       </div>
@@ -62,4 +135,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/components/orchestration/step_component.html.erb
+++ b/app/components/orchestration/step_component.html.erb
@@ -25,76 +25,13 @@
           </div>
 
           <%# Input mapping editors %>
-          <% @step.step_actions.each do |sa| %>
-            <div class="mt-3 pt-3 border-t border-gray-100" data-testid="input-mapping-editor">
-              <%= form_with url: orchestration_pipeline_step_step_action_path(@pipeline, @step, sa),
-                            method: :patch, class: "space-y-2" do |f| %>
-                <p class="text-xs font-medium text-gray-600">Mapping for <span class="font-mono"><%= sa.output_key %></span></p>
-
-                <% (sa.input_mapping || {}).each do |mapping_key, spec| %>
-                  <% spec ||= {} %>
-                  <% current_from = spec["from"] %>
-                  <% current_path = spec["path"] %>
-                  <% path_opts = path_options_for(current_from) %>
-                  <div class="flex items-center gap-2">
-                    <span class="text-xs font-mono text-gray-700 w-24 truncate" title="<%= mapping_key %>"><%= mapping_key %></span>
-                    <span class="text-xs text-gray-400">←</span>
-                    <%= f.select "orchestration_step_action[input_mapping][#{mapping_key}][from]",
-                          options_for_select(from_options, current_from),
-                          {},
-                          name: "orchestration_step_action[input_mapping][#{mapping_key}][from]",
-                          "data-testid": "from-select",
-                          class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-                    <% if path_opts %>
-                      <%= f.select "orchestration_step_action[input_mapping][#{mapping_key}][path]",
-                            options_for_select(path_opts, current_path),
-                            { include_blank: "— whole output —" },
-                            name: "orchestration_step_action[input_mapping][#{mapping_key}][path]",
-                            "data-testid": "path-select",
-                            class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-                    <% else %>
-                      <%= f.text_field "orchestration_step_action[input_mapping][#{mapping_key}][path]",
-                            value: current_path,
-                            name: "orchestration_step_action[input_mapping][#{mapping_key}][path]",
-                            placeholder: "dot.path (optional)",
-                            "data-testid": "path-text",
-                            class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-                    <% end %>
-                  </div>
-                <% end %>
-
-                <%# Add new mapping entry row %>
-                <div class="flex items-center gap-2 border-t border-dashed border-gray-200 pt-2">
-                  <span class="text-xs text-gray-400 w-24">new key:</span>
-                  <%= f.text_field :new_key,
-                        name: "orchestration_step_action[new_key]",
-                        placeholder: "input_key",
-                        class: "w-24 border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-                  <span class="text-xs text-gray-400">←</span>
-                  <%= f.select :new_from,
-                        options_for_select(from_options),
-                        { include_blank: "— from —" },
-                        name: "orchestration_step_action[new_from]",
-                        class: "border border-gray-300 rounded px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-                  <%= f.text_field :new_path,
-                        name: "orchestration_step_action[new_path]",
-                        placeholder: "dot.path (optional)",
-                        class: "border border-gray-300 rounded px-1.5 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-                  <%= f.submit "Save mapping", class: "px-2 py-1 bg-indigo-600 text-white text-xs font-medium rounded hover:bg-indigo-700 transition-colors cursor-pointer" %>
-                </div>
-              <% end %>
-            </div>
-
-            <%# Per-step-action validation errors %>
-            <% step_action_result = @validator_results.find { |r| r.step_action_id == sa.id } %>
-            <% if step_action_result&.errors&.any? %>
-              <ul class="mt-1 ml-4 space-y-0.5">
-                <% step_action_result.errors.each do |err| %>
-                  <li class="text-xs text-red-600">⚠ <%= err.message %></li>
-                <% end %>
-              </ul>
-            <% end %>
-          <% end %>
+          <%= render Orchestration::StepActionEditorComponent.with_collection(
+                @step.step_actions,
+                pipeline: @pipeline,
+                step: @step,
+                upstream_schemas: @upstream_schemas,
+                validator_results: @validator_results
+              ) %>
         <% end %>
 
       </div>

--- a/app/components/orchestration/step_component.rb
+++ b/app/components/orchestration/step_component.rb
@@ -78,20 +78,6 @@ module Orchestration
       @actions.map { |a| [ a.name, a.id ] }
     end
 
-    def from_options
-      @upstream_schemas.keys.map { |k| [ k, k ] }
-    end
-
-    def path_options_for(from_key)
-      schema = @upstream_schemas[from_key]
-      return nil if schema.nil?
-
-      properties = schema["properties"]
-      return nil if properties.blank?
-
-      properties.keys.map { |k| [ k, k ] }
-    end
-
     def all_validator_errors
       @validator_results.flat_map(&:errors)
     end
@@ -106,7 +92,7 @@ module Orchestration
 
     def validity_badge_label
       if all_validator_errors.any?
-        "#{all_validator_errors.size} error#{"s" if all_validator_errors.size > 1}"
+        helpers.pluralize(all_validator_errors.size, "error")
       else
         "Valid"
       end

--- a/app/components/orchestration/step_component.rb
+++ b/app/components/orchestration/step_component.rb
@@ -7,12 +7,15 @@ module Orchestration
     renders_many :detach_buttons, UI::DialogComponent
     renders_one :remove_button, UI::DialogComponent
 
-    def initialize(step:, step_counter:, step_iteration:, pipeline:, actions:)
+    def initialize(step:, step_counter:, step_iteration:, pipeline:, actions:,
+                   upstream_schemas_per_step: {}, validator_results_per_step: {})
       @step = step
       @step_counter = step_counter
       @step_iteration = step_iteration
       @pipeline = pipeline
       @actions = actions
+      @upstream_schemas = upstream_schemas_per_step.fetch(step.id, { "_initial" => nil })
+      @validator_results = validator_results_per_step.fetch(step.id, [])
     end
 
     def before_render
@@ -73,6 +76,40 @@ module Orchestration
 
     def actions_select_options
       @actions.map { |a| [ a.name, a.id ] }
+    end
+
+    def from_options
+      @upstream_schemas.keys.map { |k| [ k, k ] }
+    end
+
+    def path_options_for(from_key)
+      schema = @upstream_schemas[from_key]
+      return nil if schema.nil?
+
+      properties = schema["properties"]
+      return nil if properties.blank?
+
+      properties.keys.map { |k| [ k, k ] }
+    end
+
+    def all_validator_errors
+      @validator_results.flat_map(&:errors)
+    end
+
+    def validity_badge_classes
+      if all_validator_errors.any?
+        "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700"
+      else
+        "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700"
+      end
+    end
+
+    def validity_badge_label
+      if all_validator_errors.any?
+        "#{all_validator_errors.size} error#{"s" if all_validator_errors.size > 1}"
+      else
+        "Valid"
+      end
     end
   end
 end

--- a/app/components/orchestration/step_run_component.rb
+++ b/app/components/orchestration/step_run_component.rb
@@ -11,11 +11,12 @@ module Orchestration
       @step = entry[:step]
       @action_run_records = entry[:action_runs]
       @derived_status = entry[:derived_status]
+      @available_outputs = entry[:available_outputs]
     end
 
     def before_render
       with_status_badge
-      @action_run_records.each { |ar| with_action_run_item(action_run: ar) }
+      @action_run_records.each { |ar| with_action_run_item(action_run: ar, available_outputs: @available_outputs) }
     end
   end
 end

--- a/app/components/orchestration/steps_list_component.html.erb
+++ b/app/components/orchestration/steps_list_component.html.erb
@@ -1,0 +1,7 @@
+<%= render Orchestration::StepComponent.with_collection(
+      @steps,
+      pipeline: @pipeline,
+      actions: @actions,
+      upstream_schemas_per_step: @upstream_schemas_per_step,
+      validator_results_per_step: @validator_results_per_step
+    ) %>

--- a/app/components/orchestration/steps_list_component.rb
+++ b/app/components/orchestration/steps_list_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepsListComponent < ViewComponent::Base
+    def initialize(pipeline:, steps:, actions:)
+      @pipeline = pipeline
+      @steps    = steps
+      @actions  = actions
+      @upstream_schemas_per_step  = compute_upstream_schemas_per_step
+      @validator_results_per_step = compute_validator_results_per_step
+    end
+
+    private
+
+    def compute_upstream_schemas_per_step
+      seen = { "_initial" => @pipeline.initial_input_schema }
+      @steps.each_with_object({}) do |step, result|
+        result[step.id] = seen.dup
+        step.step_actions.sort_by(&:position).each do |sa|
+          seen[sa.output_key] = sa.action.output_schema
+        end
+      end
+    end
+
+    def compute_validator_results_per_step
+      all_results = Pipeline::Validator.call(@pipeline)
+      step_action_id_to_step_id = @steps.each_with_object({}) do |step, map|
+        step.step_actions.each { |sa| map[sa.id] = step.id }
+      end
+      all_results.each_with_object(Hash.new { |h, k| h[k] = [] }) do |result, map|
+        step_id = step_action_id_to_step_id[result.step_action_id]
+        map[step_id] << result if step_id
+      end
+    end
+  end
+end

--- a/app/components/orchestration/steps_list_component.rb
+++ b/app/components/orchestration/steps_list_component.rb
@@ -23,7 +23,7 @@ module Orchestration
     end
 
     def compute_validator_results_per_step
-      all_results = Pipeline::Validator.call(@pipeline)
+      all_results = @pipeline.validate_steps
       step_action_id_to_step_id = @steps.each_with_object({}) do |step, map|
         step.step_actions.each { |sa| map[sa.id] = step.id }
       end

--- a/app/components/orchestration/steps_run_list_component.html.erb
+++ b/app/components/orchestration/steps_run_list_component.html.erb
@@ -1,0 +1,3 @@
+<div class="grid grid-cols-1 gap-4">
+  <%= render(Orchestration::StepRunComponent.with_collection(@steps_with_action_runs)) %>
+</div>

--- a/app/components/orchestration/steps_run_list_component.rb
+++ b/app/components/orchestration/steps_run_list_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepsRunListComponent < ViewComponent::Base
+    def initialize(pipeline:, run:, action_runs_by_step:)
+      @pipeline            = pipeline
+      @run                 = run
+      @action_runs_by_step = action_runs_by_step
+      @steps_with_action_runs = compute_steps_with_action_runs
+    end
+
+    private
+
+    def compute_steps_with_action_runs
+      accumulated_outputs = { "_initial" => @run.initial_input }.compact
+
+      @pipeline.steps.map do |step|
+        available_outputs = accumulated_outputs.dup
+        action_runs       = @action_runs_by_step.fetch(step.id, [])
+        action_runs.each { |ar| accumulated_outputs[ar.step_action.output_key] = ar.output || {} }
+        {
+          step:           step,
+          action_runs:    action_runs,
+          derived_status: Orchestration::Step.derive_status(action_runs),
+          available_outputs: available_outputs
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/orchestration/pipeline_runs_controller.rb
+++ b/app/controllers/orchestration/pipeline_runs_controller.rb
@@ -12,6 +12,7 @@ module Orchestration
       @run = @pipeline.pipeline_runs.find(params[:id])
       action_runs_by_step = @run.action_runs
         .includes(step_action: :action)
+        .order(:id)
         .group_by { |ar| ar.step_action.step_id }
 
       accumulated_outputs = { "_initial" => @run.initial_input }.compact

--- a/app/controllers/orchestration/pipeline_runs_controller.rb
+++ b/app/controllers/orchestration/pipeline_runs_controller.rb
@@ -10,24 +10,10 @@ module Orchestration
 
     def show
       @run = @pipeline.pipeline_runs.find(params[:id])
-      action_runs_by_step = @run.action_runs
+      @action_runs_by_step = @run.action_runs
         .includes(step_action: :action)
         .order(:id)
         .group_by { |ar| ar.step_action.step_id }
-
-      accumulated_outputs = { "_initial" => @run.initial_input }.compact
-
-      @steps_with_action_runs = @pipeline.steps.map do |step|
-        available_outputs = accumulated_outputs.dup
-        action_runs = action_runs_by_step.fetch(step.id, [])
-        action_runs.each { |ar| accumulated_outputs[ar.step_action.output_key] = ar.output || {} }
-        {
-          step: step,
-          action_runs: action_runs,
-          derived_status: Orchestration::Step.derive_status(action_runs),
-          available_outputs: available_outputs
-        }
-      end
     end
 
     private

--- a/app/controllers/orchestration/pipeline_runs_controller.rb
+++ b/app/controllers/orchestration/pipeline_runs_controller.rb
@@ -13,9 +13,19 @@ module Orchestration
       action_runs_by_step = @run.action_runs
         .includes(step_action: :action)
         .group_by { |ar| ar.step_action.step_id }
+
+      accumulated_outputs = { "_initial" => @run.initial_input }.compact
+
       @steps_with_action_runs = @pipeline.steps.map do |step|
+        available_outputs = accumulated_outputs.dup
         action_runs = action_runs_by_step.fetch(step.id, [])
-        { step: step, action_runs: action_runs, derived_status: Orchestration::Step.derive_status(action_runs) }
+        action_runs.each { |ar| accumulated_outputs[ar.step_action.output_key] = ar.output || {} }
+        {
+          step: step,
+          action_runs: action_runs,
+          derived_status: Orchestration::Step.derive_status(action_runs),
+          available_outputs: available_outputs
+        }
       end
     end
 

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -29,6 +29,8 @@ module Orchestration
       @steps = @pipeline.steps.includes(step_actions: :action)
       @actions = Orchestration::Action.order(:name)
       @latest_run = @pipeline.pipeline_runs.order(created_at: :desc).first
+      @upstream_schemas_per_step = compute_upstream_schemas_per_step
+      @validator_results_per_step = compute_validator_results_per_step
     end
 
     def run
@@ -85,6 +87,27 @@ module Orchestration
 
     def set_pipeline
       @pipeline = Orchestration::Pipeline.find(params[:id])
+    end
+
+    def compute_upstream_schemas_per_step
+      seen = { "_initial" => @pipeline.initial_input_schema }
+      @steps.each_with_object({}) do |step, result|
+        result[step.id] = seen.dup
+        step.step_actions.sort_by(&:position).each do |sa|
+          seen[sa.output_key] = sa.action.output_schema
+        end
+      end
+    end
+
+    def compute_validator_results_per_step
+      all_results = Orchestration::Pipeline::Validator.call(@pipeline)
+      step_action_id_to_step_id = @steps.each_with_object({}) do |step, map|
+        step.step_actions.each { |sa| map[sa.id] = step.id }
+      end
+      all_results.each_with_object(Hash.new { |h, k| h[k] = [] }) do |result, map|
+        step_id = step_action_id_to_step_id[result.step_action_id]
+        map[step_id] << result if step_id
+      end
     end
 
     def pipeline_params

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -29,8 +29,6 @@ module Orchestration
       @steps = @pipeline.steps.includes(step_actions: :action)
       @actions = Orchestration::Action.order(:name)
       @latest_run = @pipeline.pipeline_runs.order(created_at: :desc).first
-      @upstream_schemas_per_step = compute_upstream_schemas_per_step
-      @validator_results_per_step = compute_validator_results_per_step
     end
 
     def run
@@ -87,27 +85,6 @@ module Orchestration
 
     def set_pipeline
       @pipeline = Orchestration::Pipeline.find(params[:id])
-    end
-
-    def compute_upstream_schemas_per_step
-      seen = { "_initial" => @pipeline.initial_input_schema }
-      @steps.each_with_object({}) do |step, result|
-        result[step.id] = seen.dup
-        step.step_actions.sort_by(&:position).each do |sa|
-          seen[sa.output_key] = sa.action.output_schema
-        end
-      end
-    end
-
-    def compute_validator_results_per_step
-      all_results = Orchestration::Pipeline::Validator.call(@pipeline)
-      step_action_id_to_step_id = @steps.each_with_object({}) do |step, map|
-        step.step_actions.each { |sa| map[sa.id] = step.id }
-      end
-      all_results.each_with_object(Hash.new { |h, k| h[k] = [] }) do |result, map|
-        step_id = step_action_id_to_step_id[result.step_action_id]
-        map[step_id] << result if step_id
-      end
     end
 
     def pipeline_params

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -34,6 +34,39 @@ module Orchestration
       end
     end
 
+    def update
+      @step_action = @step.step_actions.find(params[:id])
+      new_mapping = parse_input_mapping
+
+      result = nil
+      saved = false
+
+      ActiveRecord::Base.transaction do
+        @step_action.update!(input_mapping: new_mapping)
+        validator_results = Orchestration::Pipeline::Validator.call(@pipeline)
+        result = validator_results.find { |r| r.step_action_id == @step_action.id }
+
+        if result&.errors&.any?
+          raise ActiveRecord::Rollback
+        end
+
+        saved = true
+      end
+
+      if saved
+        if result&.warnings&.any?
+          warning_summary = result.warnings.map { |w| "#{w.code}: #{w.message}" }.join("; ")
+          redirect_to orchestration_pipeline_path(@pipeline),
+                      notice: "Mapping saved. Warning: #{warning_summary}"
+        else
+          redirect_to orchestration_pipeline_path(@pipeline), notice: "Mapping saved."
+        end
+      else
+        error_summary = result&.errors&.map(&:message)&.join("; ") || "Invalid mapping."
+        redirect_to orchestration_pipeline_path(@pipeline), alert: error_summary
+      end
+    end
+
     def destroy
       @step_action = @step.step_actions.find(params[:id])
       @step_action.destroy
@@ -57,6 +90,20 @@ module Orchestration
       permitted
     rescue JSON::ParserError
       nil
+    end
+
+    def parse_input_mapping
+      raw = params.dig(:orchestration_step_action, :input_mapping)
+      mapping = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h.deep_stringify_keys : {}
+
+      new_key  = params.dig(:orchestration_step_action, :new_key).presence
+      new_from = params.dig(:orchestration_step_action, :new_from).presence
+      if new_key && new_from
+        new_path = params.dig(:orchestration_step_action, :new_path).presence
+        mapping[new_key] = { "from" => new_from, "path" => new_path }.compact
+      end
+
+      mapping
     end
   end
 end

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -36,33 +36,22 @@ module Orchestration
 
     def update
       @step_action = @step.step_actions.find(params[:id])
-      new_mapping = parse_input_mapping
-
-      result = nil
-      saved = false
-
-      ActiveRecord::Base.transaction do
-        @step_action.update!(input_mapping: new_mapping)
-        validator_results = Orchestration::Pipeline::Validator.call(@pipeline)
-        result = validator_results.find { |r| r.step_action_id == @step_action.id }
-
-        if result&.errors&.any?
-          raise ActiveRecord::Rollback
-        end
-
-        saved = true
+      mapping, key_error = parse_input_mapping
+      if key_error
+        redirect_to orchestration_pipeline_path(@pipeline), alert: key_error and return
       end
 
-      if saved
-        if result&.warnings&.any?
-          warning_summary = result.warnings.map { |w| "#{w.code}: #{w.message}" }.join("; ")
-          redirect_to orchestration_pipeline_path(@pipeline),
-                      notice: "Mapping saved. Warning: #{warning_summary}"
+      result = Orchestration::InputMappingUpdater.call(step_action: @step_action, input_mapping: mapping)
+
+      if result.saved
+        notice = if result.warnings.any?
+          "Mapping saved. Warning: #{result.warnings.map { |w| "#{w.code}: #{w.message}" }.join("; ")}"
         else
-          redirect_to orchestration_pipeline_path(@pipeline), notice: "Mapping saved."
+          "Mapping saved."
         end
+        redirect_to orchestration_pipeline_path(@pipeline), notice: notice
       else
-        error_summary = result&.errors&.map(&:message)&.join("; ") || "Invalid mapping."
+        error_summary = result.errors.map(&:message).join("; ").presence || "Invalid mapping."
         redirect_to orchestration_pipeline_path(@pipeline), alert: error_summary
       end
     end
@@ -93,17 +82,23 @@ module Orchestration
     end
 
     def parse_input_mapping
-      raw = params.dig(:orchestration_step_action, :input_mapping)
-      mapping = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h.deep_stringify_keys : {}
+      permitted = params.require(:orchestration_step_action).permit(input_mapping: {})
+      mapping   = (permitted[:input_mapping]&.to_h || {}).deep_stringify_keys
 
       new_key  = params.dig(:orchestration_step_action, :new_key).presence
       new_from = params.dig(:orchestration_step_action, :new_from).presence
-      if new_key && new_from
-        new_path = params.dig(:orchestration_step_action, :new_path).presence
-        mapping[new_key] = { "from" => new_from, "path" => new_path }.compact
+
+      if new_key
+        unless new_key.match?(Orchestration::StepAction::OUTPUT_KEY_FORMAT)
+          return [ {}, "Key #{new_key.inspect} is invalid: must only contain lowercase letters, digits, and underscores, and start with a letter." ]
+        end
+        if new_from
+          new_path = params.dig(:orchestration_step_action, :new_path).presence
+          mapping[new_key] = { "from" => new_from, "path" => new_path }.compact
+        end
       end
 
-      mapping
+      [ mapping, nil ]
     end
   end
 end

--- a/app/controllers/orchestration/steps_controller.rb
+++ b/app/controllers/orchestration/steps_controller.rb
@@ -59,30 +59,7 @@ module Orchestration
     def render_pipeline_show
       @steps = @pipeline.steps.includes(step_actions: :action)
       @actions = Orchestration::Action.order(:name)
-      @upstream_schemas_per_step = compute_upstream_schemas_per_step
-      @validator_results_per_step = compute_validator_results_per_step
       render "orchestration/pipelines/show", status: :unprocessable_entity
-    end
-
-    def compute_upstream_schemas_per_step
-      seen = { "_initial" => @pipeline.initial_input_schema }
-      @steps.each_with_object({}) do |step, result|
-        result[step.id] = seen.dup
-        step.step_actions.sort_by(&:position).each do |sa|
-          seen[sa.output_key] = sa.action.output_schema
-        end
-      end
-    end
-
-    def compute_validator_results_per_step
-      all_results = Orchestration::Pipeline::Validator.call(@pipeline)
-      step_action_id_to_step_id = @steps.each_with_object({}) do |step, map|
-        step.step_actions.each { |sa| map[sa.id] = step.id }
-      end
-      all_results.each_with_object(Hash.new { |h, k| h[k] = [] }) do |result, map|
-        step_id = step_action_id_to_step_id[result.step_action_id]
-        map[step_id] << result if step_id
-      end
     end
 
     def step_params

--- a/app/controllers/orchestration/steps_controller.rb
+++ b/app/controllers/orchestration/steps_controller.rb
@@ -59,7 +59,30 @@ module Orchestration
     def render_pipeline_show
       @steps = @pipeline.steps.includes(step_actions: :action)
       @actions = Orchestration::Action.order(:name)
+      @upstream_schemas_per_step = compute_upstream_schemas_per_step
+      @validator_results_per_step = compute_validator_results_per_step
       render "orchestration/pipelines/show", status: :unprocessable_entity
+    end
+
+    def compute_upstream_schemas_per_step
+      seen = { "_initial" => @pipeline.initial_input_schema }
+      @steps.each_with_object({}) do |step, result|
+        result[step.id] = seen.dup
+        step.step_actions.sort_by(&:position).each do |sa|
+          seen[sa.output_key] = sa.action.output_schema
+        end
+      end
+    end
+
+    def compute_validator_results_per_step
+      all_results = Orchestration::Pipeline::Validator.call(@pipeline)
+      step_action_id_to_step_id = @steps.each_with_object({}) do |step, map|
+        step.step_actions.each { |sa| map[sa.id] = step.id }
+      end
+      all_results.each_with_object(Hash.new { |h, k| h[k] = [] }) do |result, map|
+        step_id = step_action_id_to_step_id[result.step_action_id]
+        map[step_id] << result if step_id
+      end
     end
 
     def step_params

--- a/app/models/orchestration/pipeline.rb
+++ b/app/models/orchestration/pipeline.rb
@@ -8,6 +8,10 @@ module Orchestration
     validates :name, presence: true
     validate :cron_expression_parseable, if: -> { cron_expression.present? }
 
+    def validate_steps
+      Pipeline::Validator.call(self)
+    end
+
     def next_run_at(from: Time.current)
       return nil if cron_expression.blank?
       cron = Fugit::Cron.parse(cron_expression)

--- a/app/services/orchestration/input_mapping_updater.rb
+++ b/app/services/orchestration/input_mapping_updater.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class InputMappingUpdater
+    Result = Data.define(:saved, :errors, :warnings)
+
+    def self.call(step_action:, input_mapping:) = new(step_action: step_action, input_mapping: input_mapping).call
+
+    def initialize(step_action:, input_mapping:)
+      @step_action   = step_action
+      @pipeline      = step_action.step.pipeline
+      @input_mapping = input_mapping
+    end
+
+    def call
+      errors   = [] # : Array[Pipeline::Validator::Issue]
+      warnings = [] # : Array[Pipeline::Validator::Issue]
+      saved    = false
+
+      ActiveRecord::Base.transaction do
+        @step_action.update!(input_mapping: @input_mapping)
+        all_results = Pipeline::Validator.call(@pipeline)
+        step_result = all_results.find { |r| r.step_action_id == @step_action.id }
+        errors      = step_result&.errors   || []
+        warnings    = step_result&.warnings || []
+
+        if errors.any?
+          raise ActiveRecord::Rollback
+        else
+          saved = true
+        end
+      end
+
+      Result.new(saved: saved, errors: errors, warnings: warnings)
+    end
+  end
+end

--- a/app/views/orchestration/pipeline_runs/show.html.erb
+++ b/app/views/orchestration/pipeline_runs/show.html.erb
@@ -13,6 +13,4 @@
 
 <%= render Orchestration::RunDetailCardComponent.new(run: @run) %>
 
-<div class="grid grid-cols-1 gap-4">
-  <%= render(Orchestration::StepRunComponent.with_collection(@steps_with_action_runs)) %>
-</div>
+<%= render Orchestration::StepsRunListComponent.new(pipeline: @pipeline, run: @run, action_runs_by_step: @action_runs_by_step) %>

--- a/app/views/orchestration/pipelines/show.html.erb
+++ b/app/views/orchestration/pipelines/show.html.erb
@@ -83,7 +83,13 @@
         <p class="px-6 py-8 text-center text-gray-400 text-sm">No steps yet. Add a step below.</p>
       <% else %>
         <div class="divide-y divide-gray-100">
-          <%= render Orchestration::StepComponent.with_collection(@steps, pipeline: @pipeline, actions: @actions) %>
+          <%= render Orchestration::StepComponent.with_collection(
+                @steps,
+                pipeline: @pipeline,
+                actions: @actions,
+                upstream_schemas_per_step: @upstream_schemas_per_step,
+                validator_results_per_step: @validator_results_per_step
+              ) %>
         </div>
       <% end %>
 

--- a/app/views/orchestration/pipelines/show.html.erb
+++ b/app/views/orchestration/pipelines/show.html.erb
@@ -83,12 +83,10 @@
         <p class="px-6 py-8 text-center text-gray-400 text-sm">No steps yet. Add a step below.</p>
       <% else %>
         <div class="divide-y divide-gray-100">
-          <%= render Orchestration::StepComponent.with_collection(
-                @steps,
+          <%= render Orchestration::StepsListComponent.new(
                 pipeline: @pipeline,
-                actions: @actions,
-                upstream_schemas_per_step: @upstream_schemas_per_step,
-                validator_results_per_step: @validator_results_per_step
+                steps: @steps,
+                actions: @actions
               ) %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
           patch :move_down
           patch :toggle
         end
-        resources :step_actions, only: [ :create, :destroy ]
+        resources :step_actions, only: [ :create, :update, :destroy ]
       end
     end
   end

--- a/sig/app/components/orchestration/action_run_component.rbs
+++ b/sig/app/components/orchestration/action_run_component.rbs
@@ -1,6 +1,6 @@
 module Orchestration
   class ActionRunComponent < ViewComponent::Base
-    def initialize: (action_run: ActionRun) -> void
+    def initialize: (action_run: ActionRun, ?available_outputs: Hash[String, untyped]?) -> void
     def before_render: () -> void
     def action_name: () -> String
     def formatted_started_at: () -> String?
@@ -11,5 +11,6 @@ module Orchestration
     def diagnostics_disclosure: () -> UI::JsonDisclosureComponent?
     def input_disclosure: () -> UI::JsonDisclosureComponent?
     def output_disclosure: () -> UI::JsonDisclosureComponent?
+    def available_outputs_disclosure: () -> UI::JsonDisclosureComponent?
   end
 end

--- a/sig/app/components/orchestration/input_mapping_component.rbs
+++ b/sig/app/components/orchestration/input_mapping_component.rbs
@@ -1,0 +1,19 @@
+module Orchestration
+  class InputMappingComponent < ViewComponent::Base
+    class MappingRow
+      attr_reader mapping_key: String
+      attr_reader current_from: String?
+      attr_reader current_path: String?
+      attr_reader path_opts: Array[[String, String]]?
+
+      def self.new: (mapping_key: String, current_from: String?, current_path: String?, path_opts: Array[[String, String]]?) -> instance
+    end
+
+    def initialize: (step_action: StepAction, pipeline: Pipeline, step: Step, upstream_schemas: Hash[String, untyped?]) -> void
+    def form_url: () -> String
+    def from_options: () -> Array[[String, String]]
+    def path_options_for: (String from_key) -> Array[[String, String]]?
+    def mapping: () -> Hash[String, untyped]
+    def mapping_rows: () -> Array[MappingRow]
+  end
+end

--- a/sig/app/components/orchestration/mapping_entry_component.rbs
+++ b/sig/app/components/orchestration/mapping_entry_component.rbs
@@ -1,0 +1,5 @@
+module Orchestration
+  class MappingEntryComponent < ViewComponent::Base
+    def initialize: (row: InputMappingComponent::MappingRow, from_options: Array[[String, String]]) -> void
+  end
+end

--- a/sig/app/components/orchestration/new_mapping_entry_component.rbs
+++ b/sig/app/components/orchestration/new_mapping_entry_component.rbs
@@ -1,0 +1,5 @@
+module Orchestration
+  class NewMappingEntryComponent < ViewComponent::Base
+    def initialize: (from_options: Array[[String, String]]) -> void
+  end
+end

--- a/sig/app/components/orchestration/step_action_editor_component.rbs
+++ b/sig/app/components/orchestration/step_action_editor_component.rbs
@@ -1,0 +1,6 @@
+module Orchestration
+  class StepActionEditorComponent < ViewComponent::Base
+    def initialize: (step_action: StepAction, step_action_counter: Integer, step_action_iteration: untyped, pipeline: Pipeline, step: Step, upstream_schemas: Hash[String, untyped?], validator_results: Array[Pipeline::Validator::StepResult]) -> void
+    def validation_errors: () -> Array[Pipeline::Validator::Issue]
+  end
+end

--- a/sig/app/components/orchestration/step_component.rbs
+++ b/sig/app/components/orchestration/step_component.rbs
@@ -1,6 +1,6 @@
 module Orchestration
   class StepComponent < ViewComponent::Base
-    def initialize: (step: Step, step_counter: Integer, step_iteration: untyped, pipeline: Pipeline, actions: untyped) -> void
+    def initialize: (step: Step, step_counter: Integer, step_iteration: untyped, pipeline: Pipeline, actions: untyped, ?upstream_schemas_per_step: Hash[Integer, Hash[String, untyped?]], ?validator_results_per_step: Hash[Integer, Array[Pipeline::Validator::StepResult]]) -> void
     def before_render: () -> void
     def move_up?: () -> bool
     def move_down?: () -> bool
@@ -8,8 +8,12 @@ module Orchestration
     def toggle_label: () -> String
     def toggle_button_classes: () -> String
     def actions_select_options: () -> Array[[String, Integer]]
+    def from_options: () -> Array[[String, String]]
+    def path_options_for: (String from_key) -> Array[[String, String]]?
+    def all_validator_errors: () -> Array[Pipeline::Validator::Issue]
+    def validity_badge_classes: () -> String
+    def validity_badge_label: () -> String
     def detach_buttons: () -> Array[UI::DialogComponent]
     def remove_button: () -> UI::DialogComponent?
   end
 end
-

--- a/sig/app/components/orchestration/steps_list_component.rbs
+++ b/sig/app/components/orchestration/steps_list_component.rbs
@@ -1,0 +1,5 @@
+module Orchestration
+  class StepsListComponent < ViewComponent::Base
+    def initialize: (pipeline: Pipeline, steps: untyped, actions: untyped) -> void
+  end
+end

--- a/sig/app/components/orchestration/steps_run_list_component.rbs
+++ b/sig/app/components/orchestration/steps_run_list_component.rbs
@@ -1,0 +1,5 @@
+module Orchestration
+  class StepsRunListComponent < ViewComponent::Base
+    def initialize: (pipeline: Pipeline, run: PipelineRun, action_runs_by_step: Hash[Integer, Array[ActionRun]]) -> void
+  end
+end

--- a/sig/app/controllers/orchestration/pipelines_controller.rbs
+++ b/sig/app/controllers/orchestration/pipelines_controller.rbs
@@ -15,7 +15,5 @@ module Orchestration
     def set_pipeline: () -> void
     def pipeline_params: () -> ActionController::Parameters
     def extract_initial_input: () -> Hash[String, untyped]?
-    def compute_upstream_schemas_per_step: () -> Hash[Integer, Hash[String, untyped?]]
-    def compute_validator_results_per_step: () -> Hash[Integer, Array[Pipeline::Validator::StepResult]]
   end
 end

--- a/sig/app/controllers/orchestration/pipelines_controller.rbs
+++ b/sig/app/controllers/orchestration/pipelines_controller.rbs
@@ -15,5 +15,7 @@ module Orchestration
     def set_pipeline: () -> void
     def pipeline_params: () -> ActionController::Parameters
     def extract_initial_input: () -> Hash[String, untyped]?
+    def compute_upstream_schemas_per_step: () -> Hash[Integer, Hash[String, untyped?]]
+    def compute_validator_results_per_step: () -> Hash[Integer, Array[Pipeline::Validator::StepResult]]
   end
 end

--- a/sig/app/controllers/orchestration/step_actions_controller.rbs
+++ b/sig/app/controllers/orchestration/step_actions_controller.rbs
@@ -1,6 +1,7 @@
 module Orchestration
   class StepActionsController < ApplicationController
     def create: () -> void
+    def update: () -> void
     def destroy: () -> void
 
     private
@@ -8,5 +9,6 @@ module Orchestration
     def set_pipeline: () -> void
     def set_step: () -> void
     def step_action_params: () -> ActionController::Parameters?
+    def parse_input_mapping: () -> Hash[String, untyped]
   end
 end

--- a/sig/app/controllers/orchestration/step_actions_controller.rbs
+++ b/sig/app/controllers/orchestration/step_actions_controller.rbs
@@ -9,6 +9,6 @@ module Orchestration
     def set_pipeline: () -> void
     def set_step: () -> void
     def step_action_params: () -> ActionController::Parameters?
-    def parse_input_mapping: () -> Hash[String, untyped]
+    def parse_input_mapping: () -> ([Hash[String, untyped], nil] | [Hash[untyped, untyped], String])
   end
 end

--- a/sig/app/controllers/orchestration/steps_controller.rbs
+++ b/sig/app/controllers/orchestration/steps_controller.rbs
@@ -11,7 +11,8 @@ module Orchestration
     def set_pipeline: () -> void
     def set_step: () -> void
     def render_pipeline_show: () -> void
+    def compute_upstream_schemas_per_step: () -> Hash[Integer, Hash[String, untyped?]]
+    def compute_validator_results_per_step: () -> Hash[Integer, Array[Pipeline::Validator::StepResult]]
     def step_params: () -> ActionController::Parameters
-    def parse_input_mapping: (String? raw) -> untyped
   end
 end

--- a/sig/app/controllers/orchestration/steps_controller.rbs
+++ b/sig/app/controllers/orchestration/steps_controller.rbs
@@ -5,14 +5,13 @@ module Orchestration
     def destroy: () -> void
     def move_up: () -> void
     def move_down: () -> void
+    def toggle: () -> void
 
     private
 
     def set_pipeline: () -> void
     def set_step: () -> void
     def render_pipeline_show: () -> void
-    def compute_upstream_schemas_per_step: () -> Hash[Integer, Hash[String, untyped?]]
-    def compute_validator_results_per_step: () -> Hash[Integer, Array[Pipeline::Validator::StepResult]]
     def step_params: () -> ActionController::Parameters
   end
 end

--- a/sig/app/models/orchestration/pipeline.rbs
+++ b/sig/app/models/orchestration/pipeline.rbs
@@ -15,6 +15,8 @@ module Orchestration
     def initial_input_schema: () -> Hash[String, untyped]?
     def initial_input_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
 
+    def validate_steps: () -> Array[Pipeline::Validator::StepResult]
+
     def next_run_at: (?from: Time) -> Time?
 
     def steps: () -> ActiveRecord::Associations::CollectionProxy

--- a/sig/app/services/orchestration/input_mapping_updater.rbs
+++ b/sig/app/services/orchestration/input_mapping_updater.rbs
@@ -1,0 +1,16 @@
+module Orchestration
+  class InputMappingUpdater
+    class Result
+      attr_reader saved: bool
+      attr_reader errors: Array[Pipeline::Validator::Issue]
+      attr_reader warnings: Array[Pipeline::Validator::Issue]
+
+      def self.new: (saved: bool, errors: Array[Pipeline::Validator::Issue], warnings: Array[Pipeline::Validator::Issue]) -> instance
+    end
+
+    def self.call: (step_action: StepAction, input_mapping: Hash[String, untyped]) -> Result
+
+    def initialize: (step_action: StepAction, input_mapping: Hash[String, untyped]) -> void
+    def call: () -> Result
+  end
+end

--- a/spec/components/orchestration/action_run_component_spec.rb
+++ b/spec/components/orchestration/action_run_component_spec.rb
@@ -206,4 +206,25 @@ RSpec.describe Orchestration::ActionRunComponent, type: :component do
       end
     end
   end
+
+  context "when available_outputs is provided" do
+    let(:available_outputs) { { "_initial" => { "email" => "test@example.com" }, "prior_action" => { "result" => 42 } } }
+    let(:component) { described_class.new(action_run: action_run, available_outputs: available_outputs) }
+
+    it "renders an Available Outputs disclosure" do
+      expect(rendered.css("details summary").map { |s| s.text.strip }).to include("Available Outputs")
+    end
+
+    it "renders the available outputs content" do
+      expect(rendered.css("pre").map(&:text).join).to include('"_initial"')
+    end
+  end
+
+  context "when available_outputs is nil" do
+    let(:component) { described_class.new(action_run: action_run, available_outputs: nil) }
+
+    it "does not render an Available Outputs disclosure" do
+      expect(rendered.css("details summary").map { |s| s.text.strip }).not_to include("Available Outputs")
+    end
+  end
 end

--- a/spec/components/orchestration/mapping_entry_component_spec.rb
+++ b/spec/components/orchestration/mapping_entry_component_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Orchestration::MappingEntryComponent, type: :component do
       mapping_key:  "email_body",
       current_from: "_initial",
       current_path: "body",
-      path_opts:    [["body", "body"], ["subject", "subject"]]
+      path_opts:    [ [ "body", "body" ], [ "subject", "subject" ] ]
     )
   end
-  let(:from_options) { [["_initial", "_initial"], ["classification", "classification"]] }
+  let(:from_options) { [ [ "_initial", "_initial" ], [ "classification", "classification" ] ] }
   let(:component) { described_class.new(row: row, from_options: from_options) }
 
   it "renders the mapping key label" do

--- a/spec/components/orchestration/mapping_entry_component_spec.rb
+++ b/spec/components/orchestration/mapping_entry_component_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::MappingEntryComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:row) do
+    Orchestration::InputMappingComponent::MappingRow.new(
+      mapping_key:  "email_body",
+      current_from: "_initial",
+      current_path: "body",
+      path_opts:    [["body", "body"], ["subject", "subject"]]
+    )
+  end
+  let(:from_options) { [["_initial", "_initial"], ["classification", "classification"]] }
+  let(:component) { described_class.new(row: row, from_options: from_options) }
+
+  it "renders the mapping key label" do
+    expect(rendered.css("span").first.text.strip).to eq("email_body")
+  end
+
+  it "renders the from select with data-testid" do
+    expect(rendered.css("[data-testid='from-select']")).to be_present
+  end
+
+  it "renders the path select when path_opts are present" do
+    expect(rendered.css("[data-testid='path-select']")).to be_present
+    expect(rendered.css("[data-testid='path-text']")).to be_empty
+  end
+
+  context "when path_opts is nil" do
+    let(:row) do
+      Orchestration::InputMappingComponent::MappingRow.new(
+        mapping_key:  "custom_key",
+        current_from: "_initial",
+        current_path: "some.path",
+        path_opts:    nil
+      )
+    end
+
+    it "renders the path text field" do
+      expect(rendered.css("[data-testid='path-text']")).to be_present
+      expect(rendered.css("[data-testid='path-select']")).to be_empty
+    end
+  end
+end

--- a/spec/components/orchestration/step_component_spec.rb
+++ b/spec/components/orchestration/step_component_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe Orchestration::StepComponent, type: :component do
     end
   end
 
-
   describe "#move_up?" do
     it "returns false when first" do
       allow(iteration).to receive(:first?).and_return(true)
@@ -153,6 +152,160 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       it "returns 'Enable'" do
         expect(component.toggle_label).to eq("Enable")
       end
+    end
+  end
+
+  context "when the step has a step_action and upstream_schemas are provided" do
+    let(:component) do
+      sa = build_stubbed(:orchestration_step_action,
+                         id: 99, output_key: "my_action",
+                         input_mapping: { "email" => { "from" => "_initial", "path" => nil } },
+                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+        allow(s).to receive(:params).and_return(nil)
+      end
+      the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
+        allow(s).to receive_messages(step_actions: [ sa ])
+      end
+      described_class.new(
+        step: the_step, step_counter: 1, step_iteration: iteration,
+        pipeline: pipeline, actions: actions,
+        upstream_schemas_per_step: { 10 => { "_initial" => nil, "prior_action" => nil } },
+        validator_results_per_step: {}
+      )
+    end
+
+    it "renders from select with _initial option" do
+      expect(rendered.css("select[data-testid='from-select'] option[value='_initial']")).to be_present
+    end
+
+    it "renders from select with upstream output_key option" do
+      expect(rendered.css("select[data-testid='from-select'] option[value='prior_action']")).to be_present
+    end
+
+    it "excludes the step_action's own output_key from from select" do
+      option_values = rendered.css("select[data-testid='from-select'] option").map { |o| o["value"] }
+      expect(option_values).not_to include("my_action")
+    end
+  end
+
+  context "when the upstream action has an output_schema with properties" do
+    let(:component) do
+      sa = build_stubbed(:orchestration_step_action,
+                         id: 99, output_key: "my_action",
+                         input_mapping: { "email" => { "from" => "prior_action", "path" => nil } },
+                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+        allow(s).to receive(:params).and_return(nil)
+      end
+      the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
+        allow(s).to receive_messages(step_actions: [ sa ])
+      end
+      upstream_schema = { "type" => "object", "properties" => { "email" => { "type" => "string" }, "name" => { "type" => "string" } } }
+      described_class.new(
+        step: the_step, step_counter: 1, step_iteration: iteration,
+        pipeline: pipeline, actions: actions,
+        upstream_schemas_per_step: { 10 => { "_initial" => nil, "prior_action" => upstream_schema } },
+        validator_results_per_step: {}
+      )
+    end
+
+    it "renders path as a select with schema property names as options" do
+      select = rendered.css("select[data-testid='path-select']").first
+      expect(select).to be_present
+      option_values = select.css("option").map { |o| o["value"] }
+      expect(option_values).to include("email", "name")
+    end
+  end
+
+  context "when the upstream action has no output_schema" do
+    let(:component) do
+      sa = build_stubbed(:orchestration_step_action,
+                         id: 99, output_key: "my_action",
+                         input_mapping: { "email" => { "from" => "_initial", "path" => nil } },
+                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+        allow(s).to receive(:params).and_return(nil)
+      end
+      the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
+        allow(s).to receive_messages(step_actions: [ sa ])
+      end
+      described_class.new(
+        step: the_step, step_counter: 1, step_iteration: iteration,
+        pipeline: pipeline, actions: actions,
+        upstream_schemas_per_step: { 10 => { "_initial" => nil } },
+        validator_results_per_step: {}
+      )
+    end
+
+    it "renders path as a text input" do
+      expect(rendered.css("input[data-testid='path-text']")).to be_present
+    end
+
+    it "does not render a path select" do
+      expect(rendered.css("select[data-testid='path-select']")).to be_empty
+    end
+  end
+
+  context "when the validator reports no errors for this step" do
+    let(:component) do
+      sa = build_stubbed(:orchestration_step_action,
+                         id: 99, output_key: "my_action",
+                         input_mapping: {},
+                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+        allow(s).to receive(:params).and_return(nil)
+      end
+      the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
+        allow(s).to receive_messages(step_actions: [ sa ])
+      end
+      described_class.new(
+        step: the_step, step_counter: 1, step_iteration: iteration,
+        pipeline: pipeline, actions: actions,
+        upstream_schemas_per_step: { 10 => { "_initial" => nil } },
+        validator_results_per_step: { 10 => [] }
+      )
+    end
+
+    it "renders a green validity badge" do
+      badge = rendered.css("[data-testid='validity-badge']").first
+      expect(badge).to be_present
+      expect(badge["class"]).to include("green")
+    end
+  end
+
+  context "when the validator reports errors for this step" do
+    let(:error_message) { "input_mapping key \"email\" references unknown output key \"missing\"" }
+    let(:component) do
+      issue = Orchestration::Pipeline::Validator::Issue.new(
+        code: :unknown_from, message: error_message,
+        mapping_key: "email", from: "missing", path: nil
+      )
+      result = Orchestration::Pipeline::Validator::StepResult.new(
+        step_action_id: 99, output_key: "my_action",
+        errors: [ issue ], warnings: []
+      )
+      sa = build_stubbed(:orchestration_step_action,
+                         id: 99, output_key: "my_action",
+                         input_mapping: {},
+                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+        allow(s).to receive(:params).and_return(nil)
+      end
+      the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
+        allow(s).to receive_messages(step_actions: [ sa ])
+      end
+      described_class.new(
+        step: the_step, step_counter: 1, step_iteration: iteration,
+        pipeline: pipeline, actions: actions,
+        upstream_schemas_per_step: { 10 => { "_initial" => nil } },
+        validator_results_per_step: { 10 => [ result ] }
+      )
+    end
+
+    it "renders a red validity badge" do
+      badge = rendered.css("[data-testid='validity-badge']").first
+      expect(badge).to be_present
+      expect(badge["class"]).to include("red")
+    end
+
+    it "renders the error message" do
+      expect(rendered.text).to include(error_message)
     end
   end
 end

--- a/spec/components/orchestration/steps_run_list_component_spec.rb
+++ b/spec/components/orchestration/steps_run_list_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Orchestration::StepsRunListComponent, type: :component do
   end
 
   before do
-    allow(pipeline).to receive(:steps).and_return([step])
+    allow(pipeline).to receive(:steps).and_return([ step ])
   end
 
   it "renders a grid container" do
@@ -31,21 +31,14 @@ RSpec.describe Orchestration::StepsRunListComponent, type: :component do
   end
 
   context "when action_runs exist for a step" do
-    let(:action) { build_stubbed(:orchestration_action, name: "Classify Agent") }
-    let(:step_action) do
-      build_stubbed(:orchestration_step_action, id: 1, step: step, action: action, output_key: "classification")
-    end
     let(:action_run) do
-      build_stubbed(:orchestration_action_run,
-                    step_action: step_action,
-                    status: "completed",
-                    started_at: nil,
-                    finished_at: nil,
-                    error: nil,
-                    input: nil,
-                    output: nil)
+      sa = build_stubbed(:orchestration_step_action, id: 1, step: step,
+                         action: build_stubbed(:orchestration_action, name: "Classify Agent"),
+                         output_key: "classification")
+      build_stubbed(:orchestration_action_run, step_action: sa, status: "completed",
+                    started_at: nil, finished_at: nil, error: nil, input: nil, output: nil)
     end
-    let(:action_runs_by_step) { { step.id => [action_run] } }
+    let(:action_runs_by_step) { { step.id => [ action_run ] } }
 
     it "renders the action run" do
       expect(rendered.css("[data-testid='action-run']")).to be_present

--- a/spec/components/orchestration/steps_run_list_component_spec.rb
+++ b/spec/components/orchestration/steps_run_list_component_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::StepsRunListComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:pipeline) { build_stubbed(:orchestration_pipeline, id: 1) }
+  let(:step) { build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "Parse Emails", position: 1) }
+  let(:action_runs_by_step) { {} }
+  let(:run) { build_stubbed(:orchestration_pipeline_run, pipeline: pipeline, initial_input: nil) }
+
+  let(:component) do
+    described_class.new(pipeline: pipeline, run: run, action_runs_by_step: action_runs_by_step)
+  end
+
+  before do
+    allow(pipeline).to receive(:steps).and_return([step])
+  end
+
+  it "renders a grid container" do
+    expect(rendered.css("div.grid")).to be_present
+  end
+
+  it "renders a step run for each step" do
+    expect(rendered.css("[data-testid='step-run']")).to be_present
+  end
+
+  it "renders the step name" do
+    expect(rendered.text).to include("Parse Emails")
+  end
+
+  context "when action_runs exist for a step" do
+    let(:action) { build_stubbed(:orchestration_action, name: "Classify Agent") }
+    let(:step_action) do
+      build_stubbed(:orchestration_step_action, id: 1, step: step, action: action, output_key: "classification")
+    end
+    let(:action_run) do
+      build_stubbed(:orchestration_action_run,
+                    step_action: step_action,
+                    status: "completed",
+                    started_at: nil,
+                    finished_at: nil,
+                    error: nil,
+                    input: nil,
+                    output: nil)
+    end
+    let(:action_runs_by_step) { { step.id => [action_run] } }
+
+    it "renders the action run" do
+      expect(rendered.css("[data-testid='action-run']")).to be_present
+    end
+  end
+end

--- a/spec/components/previews/orchestration/input_mapping_component_preview.rb
+++ b/spec/components/previews/orchestration/input_mapping_component_preview.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class InputMappingComponentPreview < ViewComponent::Preview
+    def default
+      pipeline    = Orchestration::Pipeline.new(id: 1, name: "Demo Pipeline")
+      step        = Orchestration::Step.new(id: 1, pipeline: pipeline, name: "Classify", position: 1, enabled: true)
+      step_action = Orchestration::StepAction.new(id: 1, step: step, position: 1, output_key: "classification", input_mapping: {})
+
+      render(Orchestration::InputMappingComponent.new(
+        step_action:      step_action,
+        pipeline:         pipeline,
+        step:             step,
+        upstream_schemas: { "_initial" => nil }
+      ))
+    end
+
+    def with_existing_mapping
+      pipeline    = Orchestration::Pipeline.new(id: 1, name: "Demo Pipeline")
+      step        = Orchestration::Step.new(id: 1, pipeline: pipeline, name: "Classify", position: 1, enabled: true)
+      mapping     = { "email_body" => { "from" => "_initial", "path" => "body" } }
+      step_action = Orchestration::StepAction.new(id: 1, step: step, position: 1, output_key: "classification", input_mapping: mapping)
+      schema      = { "properties" => { "subject" => {}, "body" => {}, "from" => {} } }
+
+      render(Orchestration::InputMappingComponent.new(
+        step_action:      step_action,
+        pipeline:         pipeline,
+        step:             step,
+        upstream_schemas: { "_initial" => schema }
+      ))
+    end
+  end
+end

--- a/spec/components/previews/orchestration/mapping_entry_component_preview.rb
+++ b/spec/components/previews/orchestration/mapping_entry_component_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class MappingEntryComponentPreview < ViewComponent::Preview
+    def default
+      row = Orchestration::InputMappingComponent::MappingRow.new(
+        mapping_key:  "email_body",
+        current_from: "_initial",
+        current_path: "body",
+        path_opts:    [["body", "body"], ["subject", "subject"]]
+      )
+      from_options = [["_initial", "_initial"], ["classification", "classification"]]
+
+      render(Orchestration::MappingEntryComponent.new(row: row, from_options: from_options))
+    end
+
+    def with_text_path_field
+      row = Orchestration::InputMappingComponent::MappingRow.new(
+        mapping_key:  "custom_key",
+        current_from: "_initial",
+        current_path: "some.nested.path",
+        path_opts:    nil
+      )
+      from_options = [["_initial", "_initial"]]
+
+      render(Orchestration::MappingEntryComponent.new(row: row, from_options: from_options))
+    end
+  end
+end

--- a/spec/components/previews/orchestration/mapping_entry_component_preview.rb
+++ b/spec/components/previews/orchestration/mapping_entry_component_preview.rb
@@ -7,9 +7,9 @@ module Orchestration
         mapping_key:  "email_body",
         current_from: "_initial",
         current_path: "body",
-        path_opts:    [["body", "body"], ["subject", "subject"]]
+        path_opts:    [ [ "body", "body" ], [ "subject", "subject" ] ]
       )
-      from_options = [["_initial", "_initial"], ["classification", "classification"]]
+      from_options = [ [ "_initial", "_initial" ], [ "classification", "classification" ] ]
 
       render(Orchestration::MappingEntryComponent.new(row: row, from_options: from_options))
     end
@@ -21,7 +21,7 @@ module Orchestration
         current_path: "some.nested.path",
         path_opts:    nil
       )
-      from_options = [["_initial", "_initial"]]
+      from_options = [ [ "_initial", "_initial" ] ]
 
       render(Orchestration::MappingEntryComponent.new(row: row, from_options: from_options))
     end

--- a/spec/components/previews/orchestration/new_mapping_entry_component_preview.rb
+++ b/spec/components/previews/orchestration/new_mapping_entry_component_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class NewMappingEntryComponentPreview < ViewComponent::Preview
+    def default
+      render(Orchestration::NewMappingEntryComponent.new(from_options: []))
+    end
+
+    def with_sources
+      render(Orchestration::NewMappingEntryComponent.new(
+        from_options: [["_initial", "_initial"], ["classification", "classification"]]
+      ))
+    end
+  end
+end

--- a/spec/components/previews/orchestration/new_mapping_entry_component_preview.rb
+++ b/spec/components/previews/orchestration/new_mapping_entry_component_preview.rb
@@ -8,7 +8,7 @@ module Orchestration
 
     def with_sources
       render(Orchestration::NewMappingEntryComponent.new(
-        from_options: [["_initial", "_initial"], ["classification", "classification"]]
+        from_options: [ [ "_initial", "_initial" ], [ "classification", "classification" ] ]
       ))
     end
   end

--- a/spec/components/previews/orchestration/step_action_editor_component_preview.rb
+++ b/spec/components/previews/orchestration/step_action_editor_component_preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepActionEditorComponentPreview < ViewComponent::Preview
+    def default
+      pipeline    = Orchestration::Pipeline.new(id: 1, name: "Demo Pipeline")
+      step        = Orchestration::Step.new(id: 1, pipeline: pipeline, name: "Classify", position: 1, enabled: true)
+      step_action = Orchestration::StepAction.new(id: 1, step: step, position: 1, output_key: "classification", input_mapping: {})
+      iteration   = OpenStruct.new(first?: true, last?: true)
+
+      render(Orchestration::StepActionEditorComponent.new(
+        step_action:             step_action,
+        step_action_counter:     1,
+        step_action_iteration:   iteration,
+        pipeline:                pipeline,
+        step:                    step,
+        upstream_schemas:        { "_initial" => nil },
+        validator_results:       []
+      ))
+    end
+  end
+end

--- a/spec/components/previews/orchestration/steps_list_component_preview.rb
+++ b/spec/components/previews/orchestration/steps_list_component_preview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepsListComponentPreview < ViewComponent::Preview
+    def default
+      pipeline = Orchestration::Pipeline.new(id: 1, name: "Demo Pipeline", initial_input_schema: {})
+      steps    = []
+      actions  = Orchestration::Action.none
+
+      render(Orchestration::StepsListComponent.new(
+        pipeline: pipeline,
+        steps:    steps,
+        actions:  actions
+      ))
+    end
+  end
+end

--- a/spec/components/previews/orchestration/steps_run_list_component_preview.rb
+++ b/spec/components/previews/orchestration/steps_run_list_component_preview.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepsRunListComponentPreview < ViewComponent::Preview
+    def default
+      pipeline = Orchestration::Pipeline.new(id: 1, name: "Demo Pipeline")
+      run      = Orchestration::PipelineRun.new(id: 1, pipeline: pipeline, initial_input: nil)
+
+      render(Orchestration::StepsRunListComponent.new(
+        pipeline:            pipeline,
+        run:                 run,
+        action_runs_by_step: {}
+      ))
+    end
+  end
+end

--- a/spec/models/orchestration/pipeline_spec.rb
+++ b/spec/models/orchestration/pipeline_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe Orchestration::Pipeline do
     end
   end
 
+  describe '#validate_steps' do
+    it 'delegates to Pipeline::Validator.call' do
+      pipeline = build(:orchestration_pipeline)
+      fake_results = []
+      allow(Orchestration::Pipeline::Validator).to receive(:call).with(pipeline).and_return(fake_results)
+
+      expect(pipeline.validate_steps).to eq(fake_results)
+      expect(Orchestration::Pipeline::Validator).to have_received(:call).with(pipeline)
+    end
+
+    it 'returns an array of StepResult objects for a pipeline with steps' do
+      pipeline = create(:orchestration_pipeline)
+
+      result = pipeline.validate_steps
+
+      expect(result).to be_an(Array)
+    end
+  end
+
   describe '#next_run_at' do
     it 'returns nil when cron_expression is nil' do
       pipeline = build(:orchestration_pipeline, cron_expression: nil)

--- a/spec/requests/orchestration/step_actions_spec.rb
+++ b/spec/requests/orchestration/step_actions_spec.rb
@@ -86,4 +86,68 @@ RSpec.describe "Orchestration::StepActions" do
       end
     end
   end
+
+  describe "PATCH /orchestration/pipelines/:pipeline_id/steps/:step_id/step_actions/:id" do
+    let(:step_action) { create(:orchestration_step_action, step: step, action: action, output_key: "classify_emails") }
+
+    def update_path
+      orchestration_pipeline_step_step_action_path(pipeline, step, step_action)
+    end
+
+    def patch_update(input_mapping: {}, new_key: nil, new_from: nil, new_path: nil)
+      params = { orchestration_step_action: { input_mapping: input_mapping } }
+      params[:orchestration_step_action][:new_key]  = new_key  if new_key
+      params[:orchestration_step_action][:new_from] = new_from if new_from
+      params[:orchestration_step_action][:new_path] = new_path if new_path
+      patch update_path, params: params
+    end
+
+    context "with a valid input_mapping (no validator errors)" do
+      it "saves the input_mapping and redirects with notice" do
+        patch_update(input_mapping: { "email" => { "from" => "_initial", "path" => "" } })
+
+        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+        follow_redirect!
+        expect(response.body).to include("Mapping saved")
+        expect(step_action.reload.input_mapping).to eq("email" => { "from" => "_initial", "path" => "" })
+      end
+
+      it "appends a new mapping entry when new_key and new_from are provided" do
+        patch_update(new_key: "result", new_from: "_initial")
+
+        expect(step_action.reload.input_mapping).to have_key("result")
+      end
+    end
+
+    context "when Pipeline::Validator returns errors" do
+      let(:bad_from) { "nonexistent_key" }
+
+      it "does not save the input_mapping and redirects with alert" do
+        original_mapping = step_action.input_mapping
+
+        patch_update(input_mapping: { "email" => { "from" => bad_from, "path" => "" } })
+
+        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+        follow_redirect!
+        expect(response.body).to include("unknown output key")
+        expect(step_action.reload.input_mapping).to eq(original_mapping)
+      end
+    end
+
+    context "when Pipeline::Validator returns warnings (param collision)" do
+      before do
+        action.update!(params: { "email" => "default@example.com" })
+        step_action.update!(params: { "email" => "override@example.com" })
+      end
+
+      it "saves the mapping and shows advisory warning in notice" do
+        patch_update(input_mapping: { "email" => { "from" => "_initial", "path" => "" } })
+
+        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
+        follow_redirect!
+        expect(response.body).to include("param_collision").or include("Warning")
+        expect(step_action.reload.input_mapping).to have_key("email")
+      end
+    end
+  end
 end

--- a/spec/services/orchestration/input_mapping_updater_spec.rb
+++ b/spec/services/orchestration/input_mapping_updater_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::InputMappingUpdater do
+  let(:pipeline)    { create(:orchestration_pipeline) }
+  let(:step)        { create(:orchestration_step, pipeline: pipeline) }
+  let(:action)      { create(:orchestration_action, name: "Classify Emails") }
+  let(:step_action) { create(:orchestration_step_action, step: step, action: action, output_key: "classify_emails") }
+
+  describe ".call" do
+    context "with a valid mapping (no validator errors)" do
+      it "returns a saved result" do
+        result = described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "_initial" } }
+        )
+
+        expect(result.saved).to be true
+      end
+
+      it "persists the mapping to the database" do
+        described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "_initial" } }
+        )
+
+        expect(step_action.reload.input_mapping).to eq("email" => { "from" => "_initial" })
+      end
+
+      it "returns empty errors" do
+        result = described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "_initial" } }
+        )
+
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "when the mapping triggers validator errors (unknown from key)" do
+      it "returns a not-saved result" do
+        result = described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "nonexistent_key" } }
+        )
+
+        expect(result.saved).to be false
+      end
+
+      it "populates errors on the result" do
+        result = described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "nonexistent_key" } }
+        )
+
+        expect(result.errors).not_to be_empty
+        expect(result.errors.first.code).to eq(:unknown_from)
+      end
+
+      it "does not persist the mapping (rolls back)" do
+        original_mapping = step_action.input_mapping
+
+        described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "nonexistent_key" } }
+        )
+
+        expect(step_action.reload.input_mapping).to eq(original_mapping)
+      end
+    end
+
+    context "when the mapping triggers a validator warning (param collision)" do
+      before do
+        action.update!(params: { "email" => "default@example.com" })
+        step_action.update!(params: { "email" => "override@example.com" })
+      end
+
+      it "returns a saved result" do
+        result = described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "_initial" } }
+        )
+
+        expect(result.saved).to be true
+      end
+
+      it "populates warnings on the result" do
+        result = described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "_initial" } }
+        )
+
+        expect(result.warnings).not_to be_empty
+        expect(result.warnings.first.code).to eq(:param_collision)
+      end
+
+      it "persists the mapping to the database" do
+        described_class.call(
+          step_action: step_action,
+          input_mapping: { "email" => { "from" => "_initial" } }
+        )
+
+        expect(step_action.reload.input_mapping).to have_key("email")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds dropdown-driven `from`/`path` input_mapping editor per step_action on the pipeline edit page, replacing any raw JSON editing; `from` is a `<select>` limited to upstream output keys + `_initial`, `path` is a `<select>` when the upstream action declares an `output_schema`, otherwise a free-text input
- Adds a per-step validity badge (green = no errors, red = errors with expandable list) driven by `Pipeline::Validator`; `StepActionsController#update` runs the validator on every save and blocks on errors, surfacing warnings as advisory notices
- Adds an "Available Outputs" observability panel to every action_run on the pipeline-run detail page, showing the full `previous_outputs` hash as it stood when that action was resolved (derived from existing data — no new column)

Closes #84

## Test plan

- [x] Component spec: `from` select includes `_initial` and upstream output_key; excludes same-step key
- [x] Component spec: `path` renders as `<select>` with schema properties when schema present; `<input>` when absent
- [x] Component spec: validity badge renders green / red with error messages
- [x] Component spec: "Available Outputs" disclosure renders when `available_outputs` provided; absent when nil
- [x] Request spec: `PATCH step_actions#update` saves input_mapping with notice; blocks on validator errors; shows advisory on warnings
- [x] `bundle exec rspec` — 1509 examples, 0 failures
- [x] `bundle exec rubocop -a` — no offenses
- [x] `bundle exec steep check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)