### PR TITLE
Replace agent tools text input with grouped multi-checkbox UI

### DIFF
--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -67,7 +67,7 @@ module Orchestration
         :name, :description, :model, :prompt, :params, :output_schema, tools: []
       )
 
-      permitted[:tools] = Array(permitted[:tools]).reject(&:blank?)
+      permitted[:tools] = Array(permitted[:tools]).reject(&:blank?) if permitted.key?(:tools)
 
       begin
         parse_json_field(permitted, :params)

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -64,14 +64,10 @@ module Orchestration
 
     def agent_params
       permitted = params.require(:orchestration_agent).permit(
-        :name, :description, :model, :tools, :prompt, :params, :output_schema
+        :name, :description, :model, :prompt, :params, :output_schema, tools: []
       )
 
-      begin
-        parse_json_field(permitted, :tools)
-      rescue JSON::ParserError
-        permitted[:tools] = []
-      end
+      permitted[:tools] = Array(permitted[:tools]).reject(&:blank?)
 
       begin
         parse_json_field(permitted, :params)

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -15,6 +15,15 @@ module Orchestration
 
     before_destroy :ensure_not_referenced
 
+    def self.available_tools
+      Dir.glob(Rails.root.join("app/tools/**/*.rb")).filter_map do |path|
+        relative = path.delete_prefix("#{Rails.root}/app/tools/")
+        class_name = relative.delete_suffix(".rb").split("/").map(&:camelize).join("::")
+        namespace = class_name.split("::").first
+        class_name if ALLOWED_TOOL_NAMESPACES.include?(namespace)
+      end.sort
+    end
+
     def self.available_models
       RubyLLM.models.all
         .select { |m| m.type.to_s == "chat" }

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -20,7 +20,10 @@ module Orchestration
         relative = path.delete_prefix("#{Rails.root}/app/tools/")
         class_name = relative.delete_suffix(".rb").split("/").map(&:camelize).join("::")
         namespace = class_name.split("::").first
-        class_name if ALLOWED_TOOL_NAMESPACES.include?(namespace)
+        next unless ALLOWED_TOOL_NAMESPACES.include?(namespace)
+        class_name if class_name.constantize < RubyLLM::Tool
+      rescue NameError
+        nil
       end.sort
     end
 

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -86,7 +86,7 @@
             <% tools.each do |tool| %>
               <label class="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
                 <input type="checkbox" name="orchestration_agent[tools][]" value="<%= tool %>"
-                  <%= "checked" if agent.tools.include?(tool) %>
+                  <%= "checked" if Array(agent.tools).include?(tool) %>
                   class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
                 <%= tool %>
               </label>

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -77,8 +77,23 @@
     </div>
 
     <div>
-      <%= f.label :tools, "Tools (JSON array)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :tools, value: agent.tools.present? ? agent.tools.to_json : "", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if agent.errors[:tools].any?}", placeholder: '["ToolOne", "ToolTwo"]' %>
+      <%= f.label :tools, "Tools", class: "block text-sm font-medium text-gray-700 mb-2" %>
+      <input type="hidden" name="orchestration_agent[tools][]" value="">
+      <% Orchestration::Agent.available_tools.group_by { |t| t.split("::").first }.each do |namespace, tools| %>
+        <div class="mb-3">
+          <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2"><%= namespace %></p>
+          <div class="flex flex-wrap gap-x-4 gap-y-2">
+            <% tools.each do |tool| %>
+              <label class="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
+                <input type="checkbox" name="orchestration_agent[tools][]" value="<%= tool %>"
+                  <%= "checked" if agent.tools.include?(tool) %>
+                  class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                <%= tool %>
+              </label>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
       <% if agent.errors[:tools].any? %>
         <p class="mt-1 text-xs text-red-600"><%= agent.errors[:tools].first %></p>
       <% end %>

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -2,6 +2,7 @@ module Orchestration
   class Agent < ApplicationRecord
     ALLOWED_TOOL_NAMESPACES: Array[String]
 
+    def self.available_tools: () -> Array[String]
     def self.available_models: () -> Array[[String, Array[String]]]
 
     def actions: () -> ActiveRecord::Associations::CollectionProxy

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -77,6 +77,23 @@ RSpec.describe Orchestration::Agent do
     end
   end
 
+  describe ".available_tools" do
+    it "returns tool class name strings from app/tools/" do
+      tools = described_class.available_tools
+      expect(tools).to include("Emails::GetTool", "Records::ReadRowsTool")
+    end
+
+    it "only includes tools from allowed namespaces" do
+      namespaces = described_class.available_tools.map { |t| t.split("::").first }.uniq
+      expect(Orchestration::Agent::ALLOWED_TOOL_NAMESPACES).to include(*namespaces)
+    end
+
+    it "returns tools in sorted order" do
+      tools = described_class.available_tools
+      expect(tools).to eq(tools.sort)
+    end
+  end
+
   describe "#destroy" do
     let!(:persisted_agent) { create(:orchestration_agent, name: "Emails::ClassifyAgent") }
 

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -92,6 +92,17 @@ RSpec.describe Orchestration::Agent do
       tools = described_class.available_tools
       expect(tools).to eq(tools.sort)
     end
+
+    it "excludes non-tool helper files in allowed namespaces" do
+      tools = described_class.available_tools
+      expect(tools).not_to include("Records::FuzzyMatcher", "Records::ModelResolver")
+    end
+
+    it "only includes RubyLLM::Tool subclasses" do
+      described_class.available_tools.each do |class_name|
+        expect(class_name.constantize).to be < RubyLLM::Tool
+      end
+    end
   end
 
   describe "#destroy" do

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Orchestration::Agents" do
             name: "Emails::ClassifyAgent",
             description: "Classifies emails",
             model: "mistral-small",
-            tools: "[]",
+            tools: [],
             prompt: "Classify this payload",
             params: '{"mode":"strict"}',
             output_schema: '{"type":"object","required":["result"],"properties":{"result":{"type":"array"}}}'
@@ -76,7 +76,7 @@ RSpec.describe "Orchestration::Agents" do
         post orchestration_agents_path, params: {
           orchestration_agent: {
             name: "Emails::ClassifyAgent",
-            tools: '["Records::TempFileTool"]',
+            tools: [ "Records::TempFileTool" ],
             params: '{"mode":"strict"}',
             output_schema: "{invalid"
           }


### PR DESCRIPTION
## Summary

- Adds `Agent.available_tools` class method that scans `app/tools/**/*.rb` to enumerate all available tool class names, filtered to `ALLOWED_TOOL_NAMESPACES`
- Replaces the raw JSON array text field on the agent edit/new form with checkboxes grouped by namespace (Emails / Records)
- Controller now accepts `tools` as a native Rails array param (`tools: []`) instead of parsing a JSON string — the workaround is removed

## Test plan

- [ ] Visit `/orchestration/agents/new` — confirm checkboxes render grouped under Emails and Records headers
- [ ] Check a few tools, save — confirm selected tools are persisted correctly
- [ ] Edit an agent with existing tools — confirm pre-checked state matches saved tools
- [ ] Save with no tools checked — confirm `tools` clears to `[]`
- [ ] All 35 agent model + request specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)