### PR TITLE
refactor: remove redundant LLM config columns from Orchestration::Action

### DIFF
--- a/app/components/orchestration/steps_list_component.rb
+++ b/app/components/orchestration/steps_list_component.rb
@@ -17,7 +17,7 @@ module Orchestration
       @steps.each_with_object({}) do |step, result|
         result[step.id] = seen.dup
         step.step_actions.sort_by(&:position).each do |sa|
-          seen[sa.output_key] = sa.action.output_schema
+          seen[sa.output_key] = sa.action.agent&.output_schema
         end
       end
     end

--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -67,9 +67,8 @@ module Orchestration
 
     def action_params
       permitted = params.require(:orchestration_action).permit(
-        :name, :description, :kind, :agent_id, :agent_class, :tools, :prompt, :params
+        :name, :description, :kind, :agent_id, :agent_class, :params
       )
-      parse_json_field(permitted, :tools)
       parse_json_field(permitted, :params)
       permitted
     rescue JSON::ParserError

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -26,7 +26,7 @@ module Orchestration
     end
 
     def show
-      @steps = @pipeline.steps.includes(step_actions: :action)
+      @steps = @pipeline.steps.includes(step_actions: { action: :agent })
       @actions = Orchestration::Action.order(:name)
       @latest_run = @pipeline.pipeline_runs.order(created_at: :desc).first
     end

--- a/app/controllers/orchestration/steps_controller.rb
+++ b/app/controllers/orchestration/steps_controller.rb
@@ -57,7 +57,7 @@ module Orchestration
     end
 
     def render_pipeline_show
-      @steps = @pipeline.steps.includes(step_actions: :action)
+      @steps = @pipeline.steps.includes(step_actions: { action: :agent })
       @actions = Orchestration::Action.order(:name)
       render "orchestration/pipelines/show", status: :unprocessable_entity
     end

--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -36,7 +36,7 @@ module Orchestration
       private
 
       def ordered_step_actions
-        @pipeline.steps.includes(step_actions: :action).flat_map do |step|
+        @pipeline.steps.includes(step_actions: { action: :agent }).flat_map do |step|
           step.step_actions.sort_by(&:position)
         end
       end

--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -19,7 +19,6 @@ module Orchestration
           warnings = [] # : Array[Issue]
 
           validate_input_mapping(sa, known_schemas, errors, warnings)
-          validate_input_schema(sa, errors)
 
           results << StepResult.new(
             step_action_id: sa.id,
@@ -28,7 +27,7 @@ module Orchestration
             warnings: warnings
           )
 
-          known_schemas[sa.output_key] = sa.action.output_schema
+          known_schemas[sa.output_key] = sa.action.agent&.output_schema
         end
 
         results
@@ -111,29 +110,6 @@ module Orchestration
         end
 
         true
-      end
-
-      def validate_input_schema(step_action, errors)
-        schema = step_action.action.input_schema
-        return if schema.nil?
-
-        required_keys = schema["required"]
-        return unless required_keys.is_a?(Array)
-        return if required_keys.empty?
-
-        covered = Set.new((step_action.input_mapping || {}).keys + merge_params(step_action).keys)
-
-        required_keys.each do |key|
-          next if covered.include?(key)
-
-          errors << Issue.new(
-            code: :missing_required_key,
-            message: "required input_schema key #{key.inspect} is not provided by input_mapping or params",
-            mapping_key: nil,
-            from: nil,
-            path: nil
-          )
-        end
       end
 
       def merge_params(step_action)

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -70,11 +70,8 @@ module Orchestration
     def execute_action(action_run)
       action_run.update!(status: "running", started_at: Time.current)
       action = action_run.step_action.action
-      input  = action_run.input || {} # : Hash[String, untyped]
-      effective_input = action.agent? ? (action_run.step_action.params || {}).merge(input) : input
-      validate_input!(action, effective_input)
       execution = run_agent(action_run)
-      validate_output!(action, execution[:output], raw_content: execution[:raw_content])
+      validate_output!(action, execution[:output], raw_content: execution[:raw_content]) if action.agent?
       action_run.update!(status: "completed", output: execution[:output], error: nil, error_details: nil, finished_at: Time.current)
     rescue StandardError => error
       handle_action_failure(action_run, error, raw_content: execution&.dig(:raw_content))
@@ -118,15 +115,10 @@ module Orchestration
     end
 
     def validate_output!(action, output, raw_content:)
-      schema = if action.agent?
-        action.agent&.output_schema.presence || action.output_schema
-      else
-        action.output_schema
-      end
-
+      schema = action.agent&.output_schema
       SchemaValidator.new(schema).validate!(output)
     rescue SchemaValidator::Error => error
-      raise error unless action.agent? && structured_output_expected?(action)
+      raise error unless structured_output_expected?(action)
 
       raise InvalidModelOutputError.new("Invalid model output: #{error.message}", raw_content: raw_content)
     end
@@ -160,19 +152,8 @@ module Orchestration
       )
     end
 
-    def validate_input!(action, input)
-      schema = action.input_schema
-      return unless schema.present?
-
-      SchemaValidator.new(schema).validate!(input)
-    end
-
     def structured_output_expected?(action)
-      action.agent? && (
-        action.agent&.output_schema.present? ||
-        action.output_schema.present? ||
-        action.schema_class.present?
-      )
+      action.agent&.output_schema.present?
     end
 
     def prompt_for(agent_class)

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -71,6 +71,7 @@ module Orchestration
       action_run.update!(status: "running", started_at: Time.current)
       action = action_run.step_action.action
       execution = run_agent(action_run)
+      # Service-kind actions return output from a controlled Ruby class; no schema validation needed.
       validate_output!(action, execution[:output], raw_content: execution[:raw_content]) if action.agent?
       action_run.update!(status: "completed", output: execution[:output], error: nil, error_details: nil, finished_at: Time.current)
     rescue StandardError => error

--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -25,7 +25,7 @@ module Orchestration
     end
 
     def resolved_output_schema
-      agent_record.output_schema
+      agent_record.output_schema.presence
     end
 
     def resolved_params

--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -25,12 +25,11 @@ module Orchestration
     end
 
     def resolved_output_schema
-      agent_record.output_schema.presence || @action.output_schema
+      agent_record.output_schema
     end
 
     def resolved_params
-      base_params = agent_record.params.presence || @action.params || {}
-      base_params.merge(@step_params || {})
+      (agent_record.params || {}).merge(@step_params || {})
     end
 
     def snapshot
@@ -60,17 +59,17 @@ module Orchestration
     end
 
     def resolved_model
-      @pipeline_model.presence || agent_record.model.presence || @action.model
+      @pipeline_model.presence || agent_record.model
     end
 
     def resolved_prompt
-      @prompt_override.presence || agent_record.prompt.presence || @action.prompt
+      @prompt_override.presence || agent_record.prompt
     end
 
     def resolved_tools
       return @tool_classes if @tool_classes.present?
 
-      configured_tools = agent_record.tools.presence || @action.tools
+      configured_tools = agent_record.tools
       configured_tools&.map do |tool|
         next tool if tool.is_a?(Class)
 
@@ -86,10 +85,7 @@ module Orchestration
     end
 
     def resolved_generation_schema
-      return agent_record.output_schema if agent_record.output_schema.present?
-      return @action.schema_class.constantize if @action.schema_class.present?
-
-      nil
+      agent_record.output_schema.presence
     end
   end
 end

--- a/app/views/orchestration/actions/_form.html.erb
+++ b/app/views/orchestration/actions/_form.html.erb
@@ -42,11 +42,6 @@
   </div>
 
   <div>
-    <%= f.label :prompt, class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_area :prompt, rows: 4, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
-  </div>
-
-  <div>
     <%= f.label :params, "Params (JSON)", class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_area :params, value: action.params ? action.params.to_json : "", rows: 3, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: '{"key": "value"}' %>
   </div>

--- a/app/views/orchestration/actions/index.html.erb
+++ b/app/views/orchestration/actions/index.html.erb
@@ -13,7 +13,6 @@
         end
       }
     },
-    { key: "model",          label: "Model",     variant: :muted, cell: ->(action) { action.model || "—" } },
     { key: "pipeline_count", label: "Pipelines", variant: :muted }
   ]) %>
   <% table.with_action_column(

--- a/db/migrate/20260519000001_drop_legacy_columns_from_actions.rb
+++ b/db/migrate/20260519000001_drop_legacy_columns_from_actions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class DropLegacyColumnsFromActions < ActiveRecord::Migration[8.1]
+  def up
+    remove_column :actions, :prompt
+    remove_column :actions, :model
+    remove_column :actions, :tools
+    remove_column :actions, :output_schema
+    remove_column :actions, :input_schema
+    remove_column :actions, :schema_class
+  end
+
+  def down
+    add_column :actions, :prompt,        :text
+    add_column :actions, :model,         :string
+    add_column :actions, :tools,         :json
+    add_column :actions, :output_schema, :json
+    add_column :actions, :input_schema,  :json
+    add_column :actions, :schema_class,  :string
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -321,7 +321,7 @@ steps = [
   { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent",                                           sa_input_mapping: CLASSIFY_EMAILS_INPUT_MAPPING  },
   { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent",  sa_params: FILTER_EMAILS_STEP_PARAMS,      sa_input_mapping: FILTER_EMAILS_INPUT_MAPPING    },
   { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor",  params: INGEST_EMAILS_PARAMS, sa_input_mapping: INGEST_EMAILS_INPUT_MAPPING   },
-  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",  schema_class: "ApplicationMailsSchema",   sa_input_mapping: MAP_EMAILS_INPUT_MAPPING       },
+  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",                                            sa_input_mapping: MAP_EMAILS_INPUT_MAPPING       },
   { name: "Store Emails",                   kind: :agent,   agent_name: "Records::StoreAgent",   sa_params: STORE_EMAILS_STEP_PARAMS,      sa_input_mapping: STORE_EMAILS_INPUT_MAPPING     },
   { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",  params: QUERY_EMAIL_RECORDS_PARAMS, sa_input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING },
   { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",  sa_params: NORMALIZE_EMAILS_STEP_PARAMS, sa_input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING },
@@ -344,12 +344,10 @@ action_records = steps.map do |attrs|
   end
 
   Orchestration::Action.find_or_initialize_by(name: attrs[:name]).tap do |a|
-    a.kind          = attrs[:kind]
-    a.agent         = agent_record
-    a.agent_class   = attrs[:agent_class]
-    a.output_schema = attrs[:output_schema]
-    a.params        = attrs[:params]
-    a.schema_class  = attrs[:schema_class]
+    a.kind        = attrs[:kind]
+    a.agent       = agent_record
+    a.agent_class = attrs[:agent_class]
+    a.params      = attrs[:params]
     a.save!
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -110,12 +110,6 @@ FOREIGN KEY ("evaluation_result_id")
 CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "prompt" text /*application='ApplicationPipeline'*/, "params" json DEFAULT '{}' NOT NULL /*application='ApplicationPipeline'*/, "output_schema" json /*application='ApplicationPipeline'*/);
 CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "model" varchar, "tools" json, "prompt" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "output_schema" json, "schema_class" varchar, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, "input_schema" json /*application='ApplicationPipeline'*/, CONSTRAINT "fk_rails_951418a714"
-FOREIGN KEY ("agent_id")
-  REFERENCES "orchestration_agents" ("id")
-);
-CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
-CREATE INDEX "index_actions_on_agent_id" ON "actions" ("agent_id") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "email_connectors" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "provider" varchar NOT NULL, "configuration" text, "enabled" boolean DEFAULT TRUE NOT NULL, "last_connected_at" datetime(6), "status" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE TABLE IF NOT EXISTS "step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "input_mapping" json, "output_key" varchar NOT NULL, CONSTRAINT "fk_rails_0b2a35e398"
 FOREIGN KEY ("action_id")
@@ -148,7 +142,14 @@ CREATE INDEX "index_evaluation_evaluation_results_on_runner_result_id" ON "evalu
 CREATE INDEX "index_evaluation_evaluation_results_on_dataset_record_id" ON "evaluation_evaluation_results" ("dataset_record_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_evaluation_evaluation_results_on_experiment_id" ON "evaluation_evaluation_results" ("experiment_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_evaluation_prompts_on_name" ON "evaluation_prompts" ("name") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, CONSTRAINT "fk_rails_951418a714"
+FOREIGN KEY ("agent_id")
+  REFERENCES "orchestration_agents" ("id")
+);
+CREATE INDEX "index_actions_on_agent_class" ON "actions" ("agent_class") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_actions_on_agent_id" ON "actions" ("agent_id") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260519000001'),
 ('20260516212546'),
 ('20260516185423'),
 ('20260514000002'),

--- a/sig/app/models/orchestration/action.rbs
+++ b/sig/app/models/orchestration/action.rbs
@@ -12,22 +12,10 @@ module Orchestration
     def agent_id=: (Integer?) -> Integer?
     def agent_class: () -> String?
     def agent_class=: (String?) -> String?
-    def schema_class: () -> String?
-    def schema_class=: (String?) -> String?
     def description: () -> String?
     def description=: (String?) -> String?
-    def model: () -> String?
-    def model=: (String?) -> String?
-    def tools: () -> Array[String]?
-    def tools=: (Array[String]?) -> Array[String]?
-    def prompt: () -> String?
-    def prompt=: (String?) -> String?
     def params: () -> Hash[String, untyped]?
     def params=: (Hash[String, untyped]?) -> Hash[String, untyped]?
-    def output_schema: () -> Hash[String, untyped]?
-    def output_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
-    def input_schema: () -> Hash[String, untyped]?
-    def input_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
 
     def step_actions: () -> ActiveRecord::Associations::CollectionProxy
     def agent: () -> Orchestration::Agent?

--- a/sig/app/services/orchestration/pipeline/validator.rbs
+++ b/sig/app/services/orchestration/pipeline/validator.rbs
@@ -29,7 +29,6 @@ module Orchestration
       def validate_input_mapping: (Orchestration::StepAction step_action, Hash[String, untyped] known_schemas, Array[Issue] errors, Array[Issue] warnings) -> void
       def validate_path_vs_schema: (String from, String? path, String mapping_key, Hash[String, untyped]? upstream_schema, Array[Issue] errors) -> void
       def path_valid_in_schema?: (String path, Hash[String, untyped] schema) -> bool
-      def validate_input_schema: (Orchestration::StepAction step_action, Array[Issue] errors) -> void
       def merge_params: (Orchestration::StepAction step_action) -> Hash[String, untyped]
     end
   end

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -10,7 +10,6 @@ module Orchestration
     def execute_action: (ActionRun action_run) -> void
     def run_agent: (ActionRun action_run) -> Hash[Symbol, untyped]
     def parse_content: (String | untyped content, bool structured_output_expected) -> untyped
-    def validate_input!: (Action action, Hash[String, untyped] input) -> void
     def validate_output!: (Action action, untyped output, raw_content: untyped) -> void
     def handle_action_failure: (ActionRun action_run, StandardError error, raw_content: untyped) -> void
     def log_action_failure: (ActionRun action_run, NormalizeActionRunFailure::Result failure) -> void

--- a/spec/components/orchestration/step_component_spec.rb
+++ b/spec/components/orchestration/step_component_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: { "email" => { "from" => "_initial", "path" => nil } },
-                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
         allow(s).to receive(:params).and_return(nil)
       end
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
@@ -193,7 +193,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: { "email" => { "from" => "prior_action", "path" => nil } },
-                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
         allow(s).to receive(:params).and_return(nil)
       end
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
@@ -221,7 +221,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: { "email" => { "from" => "_initial", "path" => nil } },
-                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
         allow(s).to receive(:params).and_return(nil)
       end
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
@@ -249,7 +249,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: {},
-                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
         allow(s).to receive(:params).and_return(nil)
       end
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
@@ -284,7 +284,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: {},
-                         action: build_stubbed(:orchestration_action, name: "My Action", output_schema: nil)).tap do |s|
+                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
         allow(s).to receive(:params).and_return(nil)
       end
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -69,22 +69,12 @@ RSpec.describe Orchestration::Action do
     end
   end
 
-  describe "input_schema column" do
-    it "round-trips a JSON object" do
-      schema = {
-        "type" => "object",
-        "required" => [ "emails" ],
-        "properties" => { "emails" => { "type" => "array" } }
-      }
-      action = create(:orchestration_action, input_schema: schema)
-      expect(action.reload.input_schema).to eq(schema)
-    end
-
-    it "is nullable" do
-      action = build(:orchestration_action, input_schema: nil)
-      expect(action).to be_valid
-      action.save!
-      expect(action.reload.input_schema).to be_nil
+  describe "columns" do
+    it "does not expose the dropped LLM config attributes" do
+      action = build(:orchestration_action)
+      %i[prompt model tools output_schema input_schema schema_class].each do |attr|
+        expect(action).not_to respond_to(attr)
+      end
     end
   end
 end

--- a/spec/services/orchestration/pipeline/validator_spec.rb
+++ b/spec/services/orchestration/pipeline/validator_spec.rb
@@ -59,13 +59,14 @@ RSpec.describe Orchestration::Pipeline::Validator do
     end
 
     context 'with a valid from but typo in path against upstream output_schema' do
-      let(:upstream_action) do
-        create(:orchestration_action,
+      let(:upstream_agent) do
+        create(:orchestration_agent,
                output_schema: {
                  "type" => "object",
                  "properties" => { "result" => { "type" => "string" } }
                })
       end
+      let(:upstream_action) { create(:orchestration_action, agent: upstream_agent) }
       let(:step2) { create(:orchestration_step, pipeline: pipeline, position: 2) }
 
       before do
@@ -119,73 +120,6 @@ RSpec.describe Orchestration::Pipeline::Validator do
       end
     end
 
-    context 'with a missing required input_schema key' do
-      let(:action) do
-        create(:orchestration_action,
-               input_schema: {
-                 "type" => "object",
-                 "required" => [ "emails", "date" ]
-               })
-      end
-
-      before do
-        create(:orchestration_step_action,
-               step: step, position: 1, output_key: "fetch",
-               action: action,
-               input_mapping: { "emails" => { "from" => "_initial" } })
-      end
-
-      it 'returns a missing_required_key error naming the missing key' do
-        results = validator.call
-        error = results.first.errors.first
-        expect(error.code).to eq(:missing_required_key)
-        expect(error.message).to include("date")
-      end
-
-      it 'does not error on covered keys' do
-        errors = validator.call.first.errors
-        expect(errors.none? { |e| e.message.include?("emails") }).to be true
-      end
-    end
-
-    context 'when a required input_schema key is covered by step_action params' do
-      let(:action) do
-        create(:orchestration_action,
-               input_schema: { "type" => "object", "required" => [ "date" ] })
-      end
-
-      before do
-        create(:orchestration_step_action,
-               step: step, position: 1, output_key: "fetch",
-               action: action,
-               params: { "date" => "2026-05-10" },
-               input_mapping: nil)
-      end
-
-      it 'returns no error' do
-        expect(validator.call.first.errors).to be_empty
-      end
-    end
-
-    context 'when a required input_schema key is covered by action default params' do
-      let(:action) do
-        create(:orchestration_action,
-               params: { "date" => "default" },
-               input_schema: { "type" => "object", "required" => [ "date" ] })
-      end
-
-      before do
-        create(:orchestration_step_action,
-               step: step, position: 1, output_key: "fetch",
-               action: action,
-               input_mapping: nil)
-      end
-
-      it 'returns no error' do
-        expect(validator.call.first.errors).to be_empty
-      end
-    end
-
     context 'with a key collision between input_mapping and params' do
       let(:action) do
         create(:orchestration_action, params: { "key1" => "default_value" })
@@ -230,23 +164,6 @@ RSpec.describe Orchestration::Pipeline::Validator do
 
       it 'returns no errors for the malformed entry' do
         expect(validator.call.first.errors).to be_empty
-      end
-    end
-
-    context 'with a non-Array required field in input_schema' do
-      let(:action) do
-        create(:orchestration_action,
-               input_schema: { "type" => "object", "required" => "emails" })
-      end
-
-      before do
-        create(:orchestration_step_action,
-               step: step, position: 1, output_key: "fetch",
-               action: action, input_mapping: nil)
-      end
-
-      it 'does not raise' do
-        expect { validator.call }.not_to raise_error
       end
     end
 

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -84,19 +84,6 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'when the action has a schema_class' do
-      before do
-        action.update!(schema_class: "ApplicationMailsSchema")
-        create(:orchestration_step_action, step: step1, action: action, position: 1)
-        allow(stub_agent).to receive(:with_schema).and_return(stub_agent)
-      end
-
-      it 'calls with_schema on the agent with the constantized class' do
-        described_class.new(pipeline_run).call
-        expect(stub_agent).to have_received(:with_schema).with(ApplicationMailsSchema)
-      end
-    end
-
     context 'with a serialized orchestration agent configuration' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:serialized_chat) { create(:chat) }
       let(:serialized_agent) do
@@ -240,47 +227,47 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'when an Evaluation::Prompt exists and action also has a prompt' do
+    context 'when an Evaluation::Prompt exists for the agent' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
       before do
         allow(stub_agent).to receive(:chat).and_return(chat)
         Evaluation::Prompt.create!(
           name: "Emails::ClassifyAgent",
-          system_prompt: "Leva wins over action prompt",
+          system_prompt: "Leva wins over agent prompt",
           user_prompt: "{{input}}"
         )
-        action.update!(prompt: "Action-level prompt")
+        action.agent.update!(prompt: "Agent-level prompt")
         create(:orchestration_step_action, step: step1, action: action, position: 1)
       end
 
-      it 'prefers the Evaluation::Prompt over the action prompt' do
+      it 'prefers the Evaluation::Prompt over the agent prompt' do
         described_class.new(pipeline_run).call
-        expect(chat).to have_received(:with_instructions).with("Leva wins over action prompt")
+        expect(chat).to have_received(:with_instructions).with("Leva wins over agent prompt")
       end
     end
 
-    context 'when no Evaluation::Prompt exists but the action has a prompt' do
+    context 'when no Evaluation::Prompt exists but the agent has a prompt' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
       before do
         allow(stub_agent).to receive(:chat).and_return(chat)
-        action.update!(prompt: "Action-level fallback prompt")
+        action.agent.update!(prompt: "Agent-level fallback prompt")
         create(:orchestration_step_action, step: step1, action: action, position: 1)
       end
 
-      it 'falls back to the action prompt' do
+      it 'falls back to the agent prompt' do
         described_class.new(pipeline_run).call
-        expect(chat).to have_received(:with_instructions).with("Action-level fallback prompt")
+        expect(chat).to have_received(:with_instructions).with("Agent-level fallback prompt")
       end
     end
 
-    context 'when no Evaluation::Prompt and no action prompt' do
+    context 'when no Evaluation::Prompt and no agent prompt' do
       let(:chat) { instance_spy(Chat, id: nil) }
 
       before do
         allow(stub_agent).to receive(:chat).and_return(chat)
-        action.update!(prompt: nil)
+        action.agent.update!(prompt: nil)
         create(:orchestration_step_action, step: step1, action: action, position: 1)
       end
 
@@ -467,10 +454,10 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'when the action has an output_schema and the output is invalid' do
+    context 'when the agent has an output_schema and the output is a non-JSON string' do
       before do
-        action.update!(output_schema: { "type" => "object", "required" => [ "result" ],
-                                        "properties" => { "result" => { "type" => "array" } } })
+        action.agent.update!(output_schema: { "type" => "object", "required" => [ "result" ],
+                                              "properties" => { "result" => { "type" => "array" } } })
         create(:orchestration_step_action, step: step1, action: action, position: 1)
         # agent returns a natural-language string — not parseable as a JSON array
         allow(stub_agent).to receive_messages(with_schema: stub_agent, ask: instance_double(RubyLLM::Message, content: "I need more information."))
@@ -515,12 +502,15 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'when the action has an output_schema and the output is valid JSON' do
+    context 'when the agent has an output_schema and the output is valid JSON' do
       before do
-        action.update!(output_schema: { "type" => "object", "required" => [ "result" ],
-                                        "properties" => { "result" => { "type" => "array" } } })
+        action.agent.update!(output_schema: { "type" => "object", "required" => [ "result" ],
+                                              "properties" => { "result" => { "type" => "array" } } })
         create(:orchestration_step_action, step: step1, action: action, position: 1)
-        allow(stub_agent).to receive_messages(with_schema: stub_agent, ask: instance_double(RubyLLM::Message, content: '[{"id":1}]'))
+        allow(stub_agent).to receive_messages(
+          with_schema: stub_agent,
+          ask: instance_double(RubyLLM::Message, content: { "result" => [ { "id" => 1 } ] })
+        )
       end
 
       it 'marks the ActionRun as completed with the parsed JSON result' do
@@ -638,29 +628,6 @@ RSpec.describe Orchestration::PipelineRunner do
           .find_by(steps: { name: "ingest" })
 
         expect(ingest_run.input).to eq({})
-      end
-    end
-
-    context 'when output_schema is on the action but not the agent (regression: Run #66)' do
-      let(:store_schema) do
-        { "type" => "object", "required" => [ "result" ], "properties" => { "result" => { "type" => "object" } } }
-      end
-
-      before do
-        store_agent_record = create(:orchestration_agent, name: "Records::StoreAgent")
-        store_action = create(:orchestration_action, agent: store_agent_record, output_schema: store_schema)
-        create(:orchestration_step_action, step: step1, action: store_action, position: 1)
-
-        allow(stub_agent).to receive(:ask)
-          .and_return(instance_double(RubyLLM::Message, content: [ 1, 2, 3 ]))
-      end
-
-      it 'wraps the raw output and fails validation when result is not an object' do
-        described_class.new(pipeline_run).call
-
-        store_run = Orchestration::ActionRun.last
-        expect(store_run.status).to eq("failed")
-        expect(store_run.error).to match(/data\.result must be an object/)
       end
     end
 
@@ -996,47 +963,6 @@ RSpec.describe Orchestration::PipelineRunner do
         described_class.new(pipeline_run).call
         expect(classify_agent).to have_received(:ask)
           .with(satisfy { |json| JSON.parse(json).fetch("emails") == [ { "id" => "e1" } ] })
-      end
-    end
-
-    context 'when the action has an input_schema and the resolved input violates it' do
-      before do
-        action.update!(input_schema: {
-          "type" => "object",
-          "required" => [ "emails" ],
-          "properties" => { "emails" => { "type" => "array" } }
-        })
-        create(:orchestration_step_action, step: step1, action: action, position: 1)
-      end
-
-      it 'marks the action_run failed with the schema error before invoking the agent' do
-        described_class.new(pipeline_run).call
-        action_run = Orchestration::ActionRun.last
-        expect(action_run.status).to eq("failed")
-        expect(action_run.error).to match(/missing required key: emails/)
-        expect(stub_agent).not_to have_received(:ask)
-      end
-
-      it 'marks the pipeline_run as failed' do
-        described_class.new(pipeline_run).call
-        expect(pipeline_run.reload.status).to eq("failed")
-      end
-    end
-
-    context 'when a required input_schema field is supplied via step_action params' do
-      before do
-        action.update!(input_schema: {
-          "type" => "object",
-          "required" => [ "mode" ],
-          "properties" => { "mode" => { "type" => "string" } }
-        })
-        create(:orchestration_step_action, step: step1, action: action, position: 1, params: { "mode" => "strict" })
-      end
-
-      it 'does not fail validation because params are merged with resolved input for agent actions' do
-        described_class.new(pipeline_run).call
-        expect(pipeline_run.reload.status).to eq("completed")
-        expect(stub_agent).to have_received(:ask)
       end
     end
 


### PR DESCRIPTION
## Summary
- Drop 6 columns (`prompt`, `model`, `tools`, `output_schema`, `input_schema`, `schema_class`) from the `actions` table via a reversible migration
- Agent configuration (model, prompt, tools, output schema) now lives exclusively on `Orchestration::Agent`; service-kind actions keep only `params`
- Removes the 3-level fallback cascade from `RuntimeAgentBuilder`, the `validate_input!` method from `PipelineRunner`, and the `validate_input_schema` method from `Pipeline::Validator`

Closes #101

## Test plan
- [x] New `describe "columns"` spec asserts the 6 attributes are no longer accessible on `Action`
- [x] All pipeline runner tests updated to use `action.agent.update!(output_schema:)` instead of `action.update!(output_schema:)`
- [x] Tests exercising action-level `prompt`, `schema_class`, and `input_schema` fallbacks removed (those paths no longer exist)
- [x] Validator spec updated to populate upstream schemas via agent, not action
- [x] 1744 examples, 0 failures; RuboCop clean; Steep no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)