### PR TITLE
refactor: extract AgentResolutionPolicy from RuntimeAgentBuilder

### DIFF
--- a/app/services/orchestration/agent_resolution_policy.rb
+++ b/app/services/orchestration/agent_resolution_policy.rb
@@ -1,0 +1,72 @@
+module Orchestration
+  class AgentResolutionPolicy
+    Result = Data.define(:model, :prompt, :tools, :params, :output_schema, :generation_schema)
+
+    def self.call(action:, pipeline_model: nil, prompt_override: nil, step_params: nil, tool_classes: nil)
+      new(action:, pipeline_model:, prompt_override:, step_params:, tool_classes:).call
+    end
+
+    def initialize(action:, pipeline_model: nil, prompt_override: nil, step_params: nil, tool_classes: nil)
+      @action = action
+      @pipeline_model = pipeline_model
+      @prompt_override = prompt_override
+      @step_params = step_params || {}
+      @tool_classes = tool_classes
+    end
+
+    def call
+      Result.new(
+        model: resolved_model,
+        prompt: resolved_prompt,
+        tools: resolved_tools,
+        params: resolved_params,
+        output_schema: resolved_output_schema,
+        generation_schema: resolved_generation_schema
+      )
+    end
+
+    private
+
+    def agent_record
+      @action.agent || raise(ArgumentError, "No agent associated with action #{@action.id}")
+    end
+
+    def resolved_model
+      @pipeline_model.presence || agent_record.model
+    end
+
+    def resolved_prompt
+      @prompt_override.presence || agent_record.prompt
+    end
+
+    def resolved_tools
+      return @tool_classes if @tool_classes.present?
+
+      configured_tools = agent_record.tools
+      configured_tools&.map do |tool|
+        next tool if tool.is_a?(Class)
+
+        namespace = tool.to_s.split("::").first
+        unless Orchestration::Agent::ALLOWED_TOOL_NAMESPACES.include?(namespace)
+          raise ArgumentError, "Tool '#{tool}' is outside allowed namespaces (#{Orchestration::Agent::ALLOWED_TOOL_NAMESPACES.join(', ')})"
+        end
+
+        tool.constantize
+      rescue NameError
+        raise ArgumentError, "Unknown tool class: #{tool}"
+      end
+    end
+
+    def resolved_params
+      (agent_record.params || {}).merge(@step_params || {})
+    end
+
+    def resolved_output_schema
+      agent_record.output_schema.presence
+    end
+
+    def resolved_generation_schema
+      agent_record.output_schema.presence
+    end
+  end
+end

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -70,31 +70,37 @@ module Orchestration
     def execute_action(action_run)
       action_run.update!(status: "running", started_at: Time.current)
       action = action_run.step_action.action
-      execution = run_agent(action_run)
-      # Service-kind actions return output from a controlled Ruby class; no schema validation needed.
-      validate_output!(action, execution[:output], raw_content: execution[:raw_content]) if action.agent?
+      policy = action.agent? ? resolve_policy(action_run) : nil
+      execution = run_agent(action_run, policy: policy)
+      if action.agent?
+        raise ArgumentError, "policy missing for agent action" unless policy
+        validate_output!(execution[:output], policy: policy, raw_content: execution[:raw_content])
+      end
       action_run.update!(status: "completed", output: execution[:output], error: nil, error_details: nil, finished_at: Time.current)
     rescue StandardError => error
       handle_action_failure(action_run, error, raw_content: execution&.dig(:raw_content))
     end
 
-    def run_agent(action_run)
+    def run_agent(action_run, policy: nil)
       action = action_run.step_action.action
       input  = action_run.input || {} # : Hash[String, untyped]
 
       if action.agent?
-        builder = RuntimeAgentBuilder.new(
-          action: action,
-          pipeline_model: @pipeline_run.pipeline.model,
-          prompt_override: prompt_for(action.agent&.name),
-          step_params: action_run.step_action.params
-        )
+        raise ArgumentError, "policy missing for agent action" unless policy
+        builder = RuntimeAgentBuilder.new(policy: policy)
         agent = builder.build
         chat_id = agent.respond_to?(:chat) ? agent.chat&.id : agent.id
-        action_run.update_columns(chat_id: chat_id, agent_snapshot: builder.snapshot)
-        result = agent.ask(builder.resolved_params.merge(input).to_json)
-        output = parse_content(result.content, structured_output_expected?(action))
-        normalized_output = action.agent&.output_schema.present? ? output : { "result" => output }
+        snapshot = {
+          model: policy.model,
+          prompt: policy.prompt,
+          tools: policy.tools&.map(&:to_s) || [],
+          params: policy.params,
+          output_schema: policy.output_schema
+        }
+        action_run.update_columns(chat_id: chat_id, agent_snapshot: snapshot)
+        result = agent.ask(policy.params.merge(input).to_json)
+        output = parse_content(result.content, policy.output_schema.present?)
+        normalized_output = policy.output_schema.present? ? output : { "result" => output }
         { output: normalized_output, raw_content: result.content }
       else
         klass = action.agent_class&.constantize
@@ -103,6 +109,16 @@ module Orchestration
         params = (action.params || {}).merge(action_run.step_action.params || {})
         { output: klass.call(input, params), raw_content: nil }
       end
+    end
+
+    def resolve_policy(action_run)
+      action = action_run.step_action.action
+      AgentResolutionPolicy.call(
+        action: action,
+        pipeline_model: @pipeline_run.pipeline.model,
+        prompt_override: prompt_for(action.agent&.name),
+        step_params: action_run.step_action.params
+      )
     end
 
     def parse_content(content, structured_output_expected)
@@ -115,11 +131,10 @@ module Orchestration
       content
     end
 
-    def validate_output!(action, output, raw_content:)
-      schema = action.agent&.output_schema
-      SchemaValidator.new(schema).validate!(output)
+    def validate_output!(output, policy:, raw_content:)
+      SchemaValidator.new(policy.output_schema).validate!(output)
     rescue SchemaValidator::Error => error
-      raise error unless structured_output_expected?(action)
+      raise error unless policy.output_schema.present?
 
       raise InvalidModelOutputError.new("Invalid model output: #{error.message}", raw_content: raw_content)
     end
@@ -151,10 +166,6 @@ module Orchestration
           summary: failure.summary
         }.to_json
       )
-    end
-
-    def structured_output_expected?(action)
-      action.agent&.output_schema.present?
     end
 
     def prompt_for(agent_class)

--- a/app/services/orchestration/runtime_agent_builder.rb
+++ b/app/services/orchestration/runtime_agent_builder.rb
@@ -1,45 +1,23 @@
 module Orchestration
   class RuntimeAgentBuilder
-    def initialize(action:, chat: nil, pipeline_model: nil, prompt_override: nil, step_params: nil, tool_classes: nil)
-      @action = action
+    def initialize(policy:, chat: nil)
+      @policy = policy
       @chat = chat
-      @pipeline_model = pipeline_model
-      @prompt_override = prompt_override
-      @step_params = step_params || {}
-      @tool_classes = tool_classes
     end
 
     def build
       agent = base_agent
-      agent.with_model(resolved_model) if resolved_model.present?
+      agent.with_model(@policy.model) if @policy.model.present?
 
-      tools = resolved_tools
+      tools = @policy.tools
       agent.with_tools(*tools, replace: true) if tools.present?
 
-      schema = resolved_generation_schema
+      schema = @policy.generation_schema
       agent.with_schema(schema) if schema.present?
 
-      prompt = resolved_prompt
+      prompt = @policy.prompt
       agent.chat.with_instructions(prompt) if prompt.present?
       agent
-    end
-
-    def resolved_output_schema
-      agent_record.output_schema.presence
-    end
-
-    def resolved_params
-      (agent_record.params || {}).merge(@step_params || {})
-    end
-
-    def snapshot
-      {
-        model: resolved_model,
-        prompt: resolved_prompt,
-        tools: resolved_tools&.map(&:to_s) || [],
-        params: resolved_params,
-        output_schema: resolved_output_schema
-      }
     end
 
     private
@@ -52,40 +30,6 @@ module Orchestration
 
     def runtime_chat
       @chat || Chat.create!
-    end
-
-    def agent_record
-      @action.agent || raise(ArgumentError, "No agent associated with action #{@action.id}")
-    end
-
-    def resolved_model
-      @pipeline_model.presence || agent_record.model
-    end
-
-    def resolved_prompt
-      @prompt_override.presence || agent_record.prompt
-    end
-
-    def resolved_tools
-      return @tool_classes if @tool_classes.present?
-
-      configured_tools = agent_record.tools
-      configured_tools&.map do |tool|
-        next tool if tool.is_a?(Class)
-
-        namespace = tool.to_s.split("::").first
-        unless Orchestration::Agent::ALLOWED_TOOL_NAMESPACES.include?(namespace)
-          raise ArgumentError, "Tool '#{tool}' is outside allowed namespaces (#{Orchestration::Agent::ALLOWED_TOOL_NAMESPACES.join(', ')})"
-        end
-
-        tool.constantize
-      rescue NameError
-        raise ArgumentError, "Unknown tool class: #{tool}"
-      end
-    end
-
-    def resolved_generation_schema
-      agent_record.output_schema.presence
     end
   end
 end

--- a/docs/adr/0003-extract-agent-resolution-policy.md
+++ b/docs/adr/0003-extract-agent-resolution-policy.md
@@ -1,0 +1,13 @@
+---
+status: proposed
+---
+
+# Extract agent resolution policy from RuntimeAgentBuilder
+
+The cascade rule — pipeline model overrides agent defaults, which override action defaults — is core domain logic for how an agent gets configured at run time. Currently it lives inside `RuntimeAgentBuilder` alongside the mechanics of actually constructing the RubyLLM agent. Callers invoke `.build()` then inspect `.snapshot` and `.resolved_params` as two separate attributes; the cascade order is invisible at the call site. This conflation of policy and construction is why `PipelineRunner`'s test suite is 6× its implementation.
+
+Extract the resolution policy into a dedicated module. `RuntimeAgentBuilder` becomes a thin wrapper that invokes the policy and passes the result to RubyLLM. Tests for the cascade permutations (which level wins, what happens when a level is absent) run against the policy module alone, without mocking `PipelineRunner`'s other collaborators.
+
+## Considered options
+
+Keep the cascade inside `RuntimeAgentBuilder`: rejected because the resolution logic and the construction logic don't change for the same reasons. Policy changes (adding a user-level override) and construction changes (switching LLM client) are orthogonal.

--- a/docs/adr/0004-upstream-schema-index.md
+++ b/docs/adr/0004-upstream-schema-index.md
@@ -1,0 +1,9 @@
+---
+status: proposed
+---
+
+# Name and extract the upstream schema index
+
+"What schemas are available upstream of this step?" is the same question asked in at least three places: `Pipeline::Validator`, Rails model validation on `Pipeline`, `InputMappingUpdater` after an update, and `StepActionsController` to populate dropdowns. Each call site re-walks the full pipeline independently. The schema index has no home.
+
+Extract the schema-walking logic into a named module (e.g., `UpstreamSchemaIndex`) that builds the map once from a pipeline and exposes a query interface. `Pipeline::Validator` becomes a consumer of that index rather than the owner of the walk. The dropdown renderer and the validator share the same index without duplicating fixture setup in their respective tests.

--- a/docs/adr/0005-executable-action-dispatch-registry.md
+++ b/docs/adr/0005-executable-action-dispatch-registry.md
@@ -1,0 +1,9 @@
+---
+status: proposed
+---
+
+# Replace string-based executor dispatch with an explicit registry
+
+`PipelineRunner` dispatches to `Executable` services by calling `constantize` on a stored class name string. The `Executable` concern documents `.call(input, params) → Hash` but does not enforce it — it is a comment-only contract. Four executors exist, making this a real seam, but adding a fifth requires touching the concern, the new file, and `PipelineRunner`'s dispatch logic. Tests must stub `constantize` rather than satisfy an interface.
+
+Register executors explicitly (a hash or a small registry object) and remove the `constantize` call. `PipelineRunner` calls through the registry without knowing the class name. Test doubles satisfy the actual `#call` interface. Adding a new executor is one class plus one registration entry.

--- a/docs/adr/0006-extract-dataset-synthesis-workflow.md
+++ b/docs/adr/0006-extract-dataset-synthesis-workflow.md
@@ -1,0 +1,9 @@
+---
+status: proposed
+---
+
+# Extract dataset synthesis workflow from SyntheticDatasetJob
+
+`SyntheticDatasetJob` chains seven steps: fetch system prompt → fetch few-shot samples → build user message → call LLM → parse JSON → create dataset records → update wizard draft status. All of that lives inside the job. The workflow cannot be invoked without enqueuing, cannot be tested synchronously, and cannot be reused if a second entry point (a manual trigger, an API action) ever needs the same flow.
+
+Extract the workflow into a dedicated service. The job's only responsibility becomes enqueuing and handling job-infrastructure errors. The service can be tested synchronously without job infrastructure and called from any entry point.

--- a/docs/adr/0007-imap-adapter-seam.md
+++ b/docs/adr/0007-imap-adapter-seam.md
@@ -1,0 +1,9 @@
+---
+status: proposed
+---
+
+# Name the IMAP seam between BaseAdapter and provider-specific connectors
+
+Both email connectors (Gmail, Yahoo Mail) use IMAP-like protocols but re-implement search criteria, pagination, and message parsing independently. `BaseAdapter` defines seven `NotImplementedError` methods but captures no shared IMAP behaviour. The real seam — between "IMAP protocol" and "provider-specific auth and label names" — is unnamed despite two concrete adapters existing (which makes it a real seam, not a hypothetical one).
+
+Extract an intermediate IMAP adapter between `BaseAdapter` and the two concrete connectors, pushing shared search, pagination, and body-parsing logic there. Each concrete connector implements only auth, label names, and provider-specific quirks. Shared logic is tested once against the IMAP adapter with a mock IMAP client; adding a third IMAP connector requires only auth and labels.

--- a/lib/evaluation/runners/stubbed_agent_run.rb
+++ b/lib/evaluation/runners/stubbed_agent_run.rb
@@ -16,12 +16,13 @@ module Evaluation
         tool_classes = resolve_tools(agent_record)
         stubbed_tools = tool_classes.map { |tool_class| stub_tool(tool_class, registry) }
         pipeline_model = @experiment&.sample_model
-        agent = Orchestration::RuntimeAgentBuilder.new(
+        policy = Orchestration::AgentResolutionPolicy.call(
           action: action,
           tool_classes: stubbed_tools,
           pipeline_model: pipeline_model,
           prompt_override: @prompt&.system_prompt
-        ).build
+        )
+        agent = Orchestration::RuntimeAgentBuilder.new(policy: policy).build
 
         result = agent.ask(record.input.to_json)
 

--- a/sig/app/services/orchestration/agent_resolution_policy.rbs
+++ b/sig/app/services/orchestration/agent_resolution_policy.rbs
@@ -1,0 +1,49 @@
+module Orchestration
+  class AgentResolutionPolicy
+    class Result
+      attr_reader model: String?
+      attr_reader prompt: String?
+      attr_reader tools: Array[untyped]?
+      attr_reader params: Hash[String, untyped]
+      attr_reader output_schema: Hash[String, untyped]?
+      attr_reader generation_schema: Hash[String, untyped]?
+
+      def initialize: (
+        model: String?,
+        prompt: String?,
+        tools: Array[untyped]?,
+        params: Hash[String, untyped],
+        output_schema: Hash[String, untyped]?,
+        generation_schema: Hash[String, untyped]?
+      ) -> void
+    end
+
+    def self.call: (
+      action: Action,
+      ?pipeline_model: String?,
+      ?prompt_override: String?,
+      ?step_params: Hash[String, untyped]?,
+      ?tool_classes: Array[untyped]?
+    ) -> Result
+
+    def initialize: (
+      action: Action,
+      ?pipeline_model: String?,
+      ?prompt_override: String?,
+      ?step_params: Hash[String, untyped]?,
+      ?tool_classes: Array[untyped]?
+    ) -> void
+
+    def call: () -> Result
+
+    private
+
+    def agent_record: () -> Agent
+    def resolved_model: () -> String?
+    def resolved_prompt: () -> String?
+    def resolved_tools: () -> Array[untyped]?
+    def resolved_params: () -> Hash[String, untyped]
+    def resolved_output_schema: () -> Hash[String, untyped]?
+    def resolved_generation_schema: () -> Hash[String, untyped]?
+  end
+end

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -8,12 +8,12 @@ module Orchestration
     def run_step: (Step step, Hash[String, Hash[String, untyped]] previous_outputs) -> Array[ActionRun]
     def run_actions_in_parallel: (Array[ActionRun] action_runs) -> void
     def execute_action: (ActionRun action_run) -> void
-    def run_agent: (ActionRun action_run) -> Hash[Symbol, untyped]
+    def run_agent: (ActionRun action_run, ?policy: AgentResolutionPolicy::Result?) -> Hash[Symbol, untyped]
+    def resolve_policy: (ActionRun action_run) -> AgentResolutionPolicy::Result
     def parse_content: (String | untyped content, bool structured_output_expected) -> untyped
-    def validate_output!: (Action action, untyped output, raw_content: untyped) -> void
+    def validate_output!: (untyped output, policy: AgentResolutionPolicy::Result, raw_content: untyped) -> void
     def handle_action_failure: (ActionRun action_run, StandardError error, raw_content: untyped) -> void
     def log_action_failure: (ActionRun action_run, NormalizeActionRunFailure::Result failure) -> void
-    def structured_output_expected?: (Action action) -> bool
     def prompt_for: (String? agent_name) -> String?
   end
 end

--- a/sig/app/services/orchestration/runtime_agent_builder.rbs
+++ b/sig/app/services/orchestration/runtime_agent_builder.rbs
@@ -1,27 +1,11 @@
 module Orchestration
   class RuntimeAgentBuilder
-    def initialize: (
-      action: Action,
-      ?chat: untyped,
-      ?pipeline_model: String?,
-      ?prompt_override: String?,
-      ?step_params: Hash[String, untyped]?,
-      ?tool_classes: Array[untyped]?
-    ) -> void
+    def initialize: (policy: AgentResolutionPolicy::Result, ?chat: untyped) -> void
     def build: () -> untyped
-    def resolved_output_schema: () -> Hash[String, untyped]?
-    def resolved_params: () -> Hash[String, untyped]
-    # Returns symbol-keyed hash at runtime; keys become strings after JSON round-trip on ActionRun#agent_snapshot.
-    def snapshot: () -> Hash[Symbol, untyped]
 
     private
 
     def base_agent: () -> untyped
     def runtime_chat: () -> untyped
-    def agent_record: () -> Agent
-    def resolved_model: () -> String?
-    def resolved_prompt: () -> String?
-    def resolved_tools: () -> Array[untyped]?
-    def resolved_generation_schema: () -> untyped
   end
 end

--- a/spec/lib/evaluation/runners/stubbed_agent_run_spec.rb
+++ b/spec/lib/evaluation/runners/stubbed_agent_run_spec.rb
@@ -141,10 +141,10 @@ RSpec.describe Evaluation::Runners::StubbedAgentRun do # rubocop:disable RSpec/M
 
       before { runner.instance_variable_set(:@prompt, evaluation_prompt) }
 
-      it "passes the prompt system_prompt as prompt_override to RuntimeAgentBuilder" do
-        allow(Orchestration::RuntimeAgentBuilder).to receive(:new).and_call_original
+      it "passes the prompt system_prompt as prompt_override to AgentResolutionPolicy" do
+        allow(Orchestration::AgentResolutionPolicy).to receive(:call).and_call_original
         runner.execute(action_run)
-        expect(Orchestration::RuntimeAgentBuilder).to have_received(:new)
+        expect(Orchestration::AgentResolutionPolicy).to have_received(:call)
           .with(hash_including(prompt_override: "Custom instructions for evaluation."))
       end
     end
@@ -158,10 +158,10 @@ RSpec.describe Evaluation::Runners::StubbedAgentRun do # rubocop:disable RSpec/M
 
       before { runner.instance_variable_set(:@experiment, experiment) }
 
-      it "passes sample_model as pipeline_model to RuntimeAgentBuilder" do
-        allow(Orchestration::RuntimeAgentBuilder).to receive(:new).and_call_original
+      it "passes sample_model as pipeline_model to AgentResolutionPolicy" do
+        allow(Orchestration::AgentResolutionPolicy).to receive(:call).and_call_original
         runner.execute(action_run)
-        expect(Orchestration::RuntimeAgentBuilder).to have_received(:new)
+        expect(Orchestration::AgentResolutionPolicy).to have_received(:call)
           .with(hash_including(pipeline_model: "mistral-small-latest"))
       end
     end

--- a/spec/services/orchestration/agent_resolution_policy_spec.rb
+++ b/spec/services/orchestration/agent_resolution_policy_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Orchestration::AgentResolutionPolicy do
+  subject(:policy) do
+    described_class.call(
+      action: action,
+      pipeline_model: "mistral-large",
+      step_params: { "limit" => 5 }
+    )
+  end
+
   let(:agent_record) do
     create(:orchestration_agent,
            model: "mistral-small",
@@ -10,14 +18,6 @@ RSpec.describe Orchestration::AgentResolutionPolicy do
            output_schema: { "type" => "object" })
   end
   let(:action) { create(:orchestration_action, agent: agent_record) }
-
-  subject(:policy) do
-    described_class.call(
-      action: action,
-      pipeline_model: "mistral-large",
-      step_params: { "limit" => 5 }
-    )
-  end
 
   describe '#model' do
     it 'prefers pipeline_model over agent model' do

--- a/spec/services/orchestration/agent_resolution_policy_spec.rb
+++ b/spec/services/orchestration/agent_resolution_policy_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Orchestration::AgentResolutionPolicy do
+  let(:agent_record) do
+    create(:orchestration_agent,
+           model: "mistral-small",
+           tools: [ "Records::TempFileTool" ],
+           prompt: "Classify this email",
+           params: { "mode" => "fast" },
+           output_schema: { "type" => "object" })
+  end
+  let(:action) { create(:orchestration_action, agent: agent_record) }
+
+  subject(:policy) do
+    described_class.call(
+      action: action,
+      pipeline_model: "mistral-large",
+      step_params: { "limit" => 5 }
+    )
+  end
+
+  describe '#model' do
+    it 'prefers pipeline_model over agent model' do
+      expect(policy.model).to eq("mistral-large")
+    end
+
+    it 'falls back to agent model when pipeline_model is absent' do
+      result = described_class.call(action: action)
+      expect(result.model).to eq("mistral-small")
+    end
+  end
+
+  describe '#prompt' do
+    it 'returns the agent prompt' do
+      expect(policy.prompt).to eq("Classify this email")
+    end
+
+    it 'prefers prompt_override over agent prompt' do
+      result = described_class.call(action: action, prompt_override: "Override prompt")
+      expect(result.prompt).to eq("Override prompt")
+    end
+  end
+
+  describe '#tools' do
+    it 'returns constantized tool classes' do
+      expect(policy.tools).to eq([ Records::TempFileTool ])
+    end
+
+    it 'returns tool_classes directly when provided' do
+      result = described_class.call(action: action, tool_classes: [ Records::TempFileTool ])
+      expect(result.tools).to eq([ Records::TempFileTool ])
+    end
+
+    it 'raises ArgumentError when a tool is outside allowed namespaces' do
+      allow(agent_record).to receive(:tools).and_return([ "Kernel::Exec" ])
+      expect { policy }.to raise_error(ArgumentError, /outside allowed namespaces/)
+    end
+
+    it 'raises ArgumentError when a tool class cannot be found' do
+      allow(agent_record).to receive(:tools).and_return([ "Records::NonExistentTool" ])
+      expect { policy }.to raise_error(ArgumentError, /NonExistentTool/)
+    end
+  end
+
+  describe '#params' do
+    it 'merges agent params with step_params (step_params win)' do
+      expect(policy.params).to eq({ "mode" => "fast", "limit" => 5 })
+    end
+
+    it 'returns only step_params when agent has no params' do
+      allow(agent_record).to receive(:params).and_return(nil)
+      result = described_class.call(action: action, step_params: { "limit" => 3 })
+      expect(result.params).to eq({ "limit" => 3 })
+    end
+  end
+
+  describe '#output_schema' do
+    it 'returns the agent output schema' do
+      expect(policy.output_schema).to eq({ "type" => "object" })
+    end
+
+    it 'returns nil when agent has no output schema' do
+      allow(agent_record).to receive(:output_schema).and_return(nil)
+      expect(described_class.call(action: action).output_schema).to be_nil
+    end
+  end
+
+  describe '#generation_schema' do
+    it 'returns the agent output schema' do
+      expect(policy.generation_schema).to eq({ "type" => "object" })
+    end
+  end
+end

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Orchestration::RuntimeAgentBuilder do
+  subject(:builder) { described_class.new(policy: policy) }
+
   let(:policy) do
     Orchestration::AgentResolutionPolicy::Result.new(
       model: "mistral-large-latest",
@@ -11,8 +13,6 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
       generation_schema: { "type" => "object" }
     )
   end
-
-  subject(:builder) { described_class.new(policy: policy) }
 
   describe '#build' do
     it 'returns a RubyLLM::Agent instance' do

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -1,96 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Orchestration::RuntimeAgentBuilder do
-  subject(:builder) do
-    described_class.new(
-      action: action,
-      pipeline_model: "mistral-large",
-      step_params: { "limit" => 5 }
+  let(:policy) do
+    Orchestration::AgentResolutionPolicy::Result.new(
+      model: "mistral-large-latest",
+      prompt: "Classify this email",
+      tools: [ Records::TempFileTool ],
+      params: { "mode" => "fast" },
+      output_schema: { "type" => "object" },
+      generation_schema: { "type" => "object" }
     )
   end
 
-  let(:agent_record) do
-    create(:orchestration_agent,
-           name: "Reusable Classifier",
-           model: "mistral-small",
-           tools: [ "Records::TempFileTool" ],
-           prompt: "Classify this email",
-           params: { "mode" => "fast" },
-           output_schema: { "type" => "object" })
-  end
-  let(:action) { create(:orchestration_action, agent: agent_record) }
+  subject(:builder) { described_class.new(policy: policy) }
 
   describe '#build' do
     it 'returns a RubyLLM::Agent instance' do
-      valid_model_builder = described_class.new(action: action, pipeline_model: "mistral-large-latest")
-      result = valid_model_builder.build
-      expect(result).to be_a(RubyLLM::Agent)
+      expect(builder.build).to be_a(RubyLLM::Agent)
     end
 
-    it 'does not delegate to a legacy RubyLLM::Agent subclass even when the agent name matches one' do # rubocop:disable RSpec/ExampleLength
-      legacy_agent_record = create(:orchestration_agent, name: "Emails::ClassifyAgent")
-      legacy_action = create(:orchestration_action, agent: legacy_agent_record)
+    it 'always uses RubyLLM::Agent.new regardless of agent name' do
       allow(Emails::ClassifyAgent).to receive(:create)
 
       generic_agent = instance_double(RubyLLM::Agent)
       allow(RubyLLM::Agent).to receive(:new).and_return(generic_agent)
       allow(generic_agent).to receive_messages(with_model: generic_agent, with_tools: generic_agent,
-                                               with_params: generic_agent, with_schema: generic_agent,
+                                               with_schema: generic_agent,
                                                chat: instance_double(Chat, with_instructions: nil))
 
-      described_class.new(action: legacy_action).build
+      builder.build
 
       expect(Emails::ClassifyAgent).not_to have_received(:create)
       expect(RubyLLM::Agent).to have_received(:new)
-    end
-  end
-
-  describe '#resolved_tools (via #snapshot)' do
-    it 'raises ArgumentError when a tool is outside allowed namespaces' do
-      bad_agent = create(:orchestration_agent, name: "Bad Agent", tools: [])
-      bad_action = create(:orchestration_action, agent: bad_agent)
-      allow(bad_agent).to receive(:tools).and_return([ "Kernel::Exec" ])
-      allow(bad_action).to receive(:agent).and_return(bad_agent)
-
-      expect { described_class.new(action: bad_action).snapshot }
-        .to raise_error(ArgumentError, /outside allowed namespaces/)
-    end
-
-    it 'raises ArgumentError with the tool name when constantize fails' do
-      bad_agent = create(:orchestration_agent, name: "Bad Agent 2", tools: [])
-      bad_action = create(:orchestration_action, agent: bad_agent)
-      allow(bad_agent).to receive(:tools).and_return([ "Records::NonExistentTool" ])
-      allow(bad_action).to receive(:agent).and_return(bad_agent)
-
-      expect { described_class.new(action: bad_action).snapshot }
-        .to raise_error(ArgumentError, /NonExistentTool/)
-    end
-  end
-
-  describe '#snapshot' do
-    it 'returns a hash with the resolved model' do
-      expect(builder.snapshot[:model]).to eq("mistral-large")
-    end
-
-    it 'falls back to the agent model when pipeline model is absent' do
-      builder_no_pipeline_model = described_class.new(action: action)
-      expect(builder_no_pipeline_model.snapshot[:model]).to eq("mistral-small")
-    end
-
-    it 'returns the resolved prompt' do
-      expect(builder.snapshot[:prompt]).to eq("Classify this email")
-    end
-
-    it 'returns tools as an array of strings' do
-      expect(builder.snapshot[:tools]).to eq([ "Records::TempFileTool" ])
-    end
-
-    it 'returns merged params (agent defaults overridden by step params)' do
-      expect(builder.snapshot[:params]).to eq({ "mode" => "fast", "limit" => 5 })
-    end
-
-    it 'returns the output schema' do
-      expect(builder.snapshot[:output_schema]).to eq({ "type" => "object" })
     end
   end
 end


### PR DESCRIPTION
## Summary

- Extracted `AgentResolutionPolicy` — a new `.call` service that owns the cascade rule (pipeline_model > agent defaults) and returns a typed `Data.define` Result with `model`, `prompt`, `tools`, `params`, `output_schema`, and `generation_schema`
- Slimmed `RuntimeAgentBuilder` down to a pure construction wrapper: takes `policy:` + `chat:`, no resolution logic
- Updated `PipelineRunner` to resolve once in `execute_action`, flow the Result into `run_agent` and `validate_output!` — removing the inline schema re-implementation that had previously duplicated the cascade
- Added `AgentResolutionPolicy` RBS signature; updated `RuntimeAgentBuilder` and `PipelineRunner` signatures; Steep clean
- Also adds ADRs 0003–0007 (architecture decision records from the `/improve-architecture` session)

## Test plan

- [ ] `bundle exec rspec spec/services/orchestration/agent_resolution_policy_spec.rb` — 13 new examples covering model/prompt/tool/params/schema resolution and tool validation
- [ ] `bundle exec rspec spec/services/orchestration/runtime_agent_builder_spec.rb` — 2 focused construction-only examples
- [ ] `bundle exec rspec spec/services/orchestration/pipeline_runner_spec.rb` — 54 existing integration examples, all passing unchanged
- [ ] `bundle exec steep check app/services/orchestration/` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)