### PR TITLE
feat: extract form objects from orchestration controllers

### DIFF
--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -32,31 +32,14 @@ module Orchestration
     end
 
     def run
-      # TODO: move out the logic to a form object
+      form = Orchestration::PipelineRunForm.new(pipeline: @pipeline, initial_input_params: params[:initial_input])
       path = orchestration_pipeline_path(@pipeline)
-      runs = @pipeline.pipeline_runs
 
-      if runs.exists?(status: %w[pending running])
-        redirect_to path, alert: "A run is already pending."
-        return
-      end
-
-      initial_input = extract_initial_input
-      if @pipeline.initial_input_schema.present?
-        begin
-          Orchestration::SchemaValidator.new(@pipeline.initial_input_schema).validate!(initial_input)
-        rescue Orchestration::SchemaValidator::Error => e
-          redirect_to path, alert: e.message
-          return
-        end
-      end
-
-      pipeline_run = runs.create(status: "pending", triggered_by: "manual", initial_input: initial_input)
-      if pipeline_run.persisted?
-        PipelineRunJob.perform_later(pipeline_run.id)
+      if form.save
+        PipelineRunJob.perform_later(form.pipeline_run.id)
         redirect_to path, notice: "Pipeline run triggered."
       else
-        redirect_to path, alert: "Failed to trigger pipeline run."
+        redirect_to path, alert: form.errors.full_messages.first || "Failed to trigger pipeline run."
       end
     end
 
@@ -90,12 +73,6 @@ module Orchestration
 
     def pipeline_params
       params.require(:orchestration_pipeline).permit(:name, :description, :enabled, :cron_expression, :model)
-    end
-
-    def extract_initial_input
-      return nil if @pipeline.initial_input_schema.blank?
-
-      params[:initial_input].to_unsafe_h.deep_stringify_keys
     end
   end
 end

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -6,45 +6,33 @@ module Orchestration
     before_action :set_step
 
     def create
-      # TODO: move out the logic to a form object
-      action = Orchestration::Action.find_by(id: params.dig(:orchestration_step_action, :action_id))
-      unless action
-        redirect_to orchestration_pipeline_path(@pipeline), alert: "Invalid action." and return
-      end
+      raw = params.dig(:orchestration_step_action, :params)
+      form = Orchestration::StepActionCreateForm.new(
+        step: @step,
+        action_id: params.dig(:orchestration_step_action, :action_id),
+        params_json: raw
+      )
 
-      parsed = step_action_params
-      unless parsed
-        redirect_to orchestration_pipeline_path(@pipeline), alert: "Params must be valid JSON." and return
-      end
-
-      next_position = (@step.step_actions.maximum(:position) || 0) + 1
-      key = Orchestration::OutputKeyDeriver.call(action_name: action.name, step: @step)
-      @step_action = @step.step_actions.build(parsed.merge(position: next_position, output_key: key))
-
-      begin
-        saved = @step_action.save
-      rescue ActiveRecord::RecordNotUnique
-        @step_action.output_key = "#{key}_#{SecureRandom.hex(3)}"
-        saved = @step_action.save
-      end
-
-      if saved
+      if form.save
         redirect_to orchestration_pipeline_path(@pipeline), notice: "Action attached."
       else
-        redirect_to orchestration_pipeline_path(@pipeline), alert: "Could not attach action."
+        redirect_to orchestration_pipeline_path(@pipeline), alert: form.errors.full_messages.first || "Could not attach action."
       end
     end
 
     def update
       @step_action = @step.step_actions.find(params[:id])
-      mapping, key_error = parse_input_mapping
-      if key_error
-        redirect_to orchestration_pipeline_path(@pipeline), alert: key_error and return
-      end
+      sa_params = params[:orchestration_step_action]
+      form = Orchestration::InputMappingForm.new(
+        step_action: @step_action,
+        input_mapping: sa_params&.fetch(:input_mapping, nil),
+        new_key:  sa_params&.dig(:new_key),
+        new_from: sa_params&.dig(:new_from),
+        new_path: sa_params&.dig(:new_path)
+      )
 
-      result = Orchestration::InputMappingUpdater.call(step_action: @step_action, input_mapping: mapping)
-
-      if result.saved
+      if form.save
+        result = form.result
         notice = if result.warnings.any?
           "Mapping saved. Warning: #{result.warnings.map { |w| "#{w.code}: #{w.message}" }.join("; ")}"
         else
@@ -52,7 +40,11 @@ module Orchestration
         end
         redirect_to orchestration_pipeline_path(@pipeline), notice: notice
       else
-        error_summary = result.errors.map(&:message).join("; ").presence || "Invalid mapping."
+        error_summary = if form.result
+          form.result.errors.map(&:message).join("; ").presence || "Invalid mapping."
+        else
+          form.errors.full_messages.first || "Invalid mapping."
+        end
         redirect_to orchestration_pipeline_path(@pipeline), alert: error_summary
       end
     end
@@ -71,35 +63,6 @@ module Orchestration
 
     def set_step
       @step = @pipeline.steps.find(params[:step_id])
-    end
-
-    def step_action_params
-      permitted = params.require(:orchestration_step_action).permit(:action_id, :params)
-      raw = permitted[:params]
-      permitted[:params] = JSON.parse(raw) if raw.present?
-      permitted
-    rescue JSON::ParserError
-      nil
-    end
-
-    def parse_input_mapping
-      permitted = params.require(:orchestration_step_action).permit(input_mapping: {})
-      mapping   = (permitted[:input_mapping]&.to_h || {}).deep_stringify_keys
-
-      new_key  = params.dig(:orchestration_step_action, :new_key).presence
-      new_from = params.dig(:orchestration_step_action, :new_from).presence
-
-      if new_key
-        unless new_key.match?(Orchestration::StepAction::OUTPUT_KEY_FORMAT)
-          return [ {}, "Key #{new_key.inspect} is invalid: must only contain lowercase letters, digits, and underscores, and start with a letter." ]
-        end
-        if new_from
-          new_path = params.dig(:orchestration_step_action, :new_path).presence
-          mapping[new_key] = { "from" => new_from, "path" => new_path }.compact
-        end
-      end
-
-      [ mapping, nil ]
     end
   end
 end

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -25,7 +25,7 @@ module Orchestration
       sa_params = params[:orchestration_step_action]
       form = Orchestration::InputMappingForm.new(
         step_action: @step_action,
-        input_mapping: sa_params&.fetch(:input_mapping, nil),
+        input_mapping: sa_params&.[](:input_mapping),
         new_key:  sa_params&.dig(:new_key),
         new_from: sa_params&.dig(:new_from),
         new_path: sa_params&.dig(:new_path)

--- a/app/forms/orchestration/input_mapping_form.rb
+++ b/app/forms/orchestration/input_mapping_form.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class InputMappingForm
+    include ActiveModel::Model
+
+    attr_reader :result
+
+    validate :new_key_format_valid
+
+    def initialize(step_action:, input_mapping:, new_key: nil, new_from: nil, new_path: nil)
+      @step_action = step_action
+      raw = input_mapping || {}
+      @base_mapping = (raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h).deep_stringify_keys
+      @new_key = new_key.presence
+      @new_from = new_from.presence
+      @new_path = new_path.presence
+    end
+
+    def save
+      return false unless valid?
+
+      @result = Orchestration::InputMappingUpdater.call(
+        step_action: @step_action,
+        input_mapping: build_mapping
+      )
+      @result.saved
+    end
+
+    private
+
+    def new_key_format_valid
+      return unless @new_key
+      return if @new_key.match?(Orchestration::StepAction::OUTPUT_KEY_FORMAT)
+
+      errors.add(:base, "Key #{@new_key.inspect} is invalid: must only contain lowercase letters, digits, and underscores, and start with a letter.")
+    end
+
+    def build_mapping
+      mapping = @base_mapping.dup
+      if @new_key && @new_from
+        mapping[@new_key] = { "from" => @new_from, "path" => @new_path }.compact
+      end
+      mapping
+    end
+  end
+end

--- a/app/forms/orchestration/input_mapping_form.rb
+++ b/app/forms/orchestration/input_mapping_form.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
 module Orchestration
-  class InputMappingForm
-    include ActiveModel::Model
-
+  class InputMappingForm < ::BaseForm
     attr_reader :result
 
     validate :new_key_format_valid
 
     def initialize(step_action:, input_mapping:, new_key: nil, new_from: nil, new_path: nil)
       @step_action = step_action
-      raw = input_mapping || {}
-      @base_mapping = (raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h).deep_stringify_keys
+      @base_mapping = (input_mapping&.to_unsafe_h || {}).deep_stringify_keys
       @new_key = new_key.presence
       @new_from = new_from.presence
       @new_path = new_path.presence

--- a/app/forms/orchestration/pipeline_run_form.rb
+++ b/app/forms/orchestration/pipeline_run_form.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class PipelineRunForm
+    include ActiveModel::Model
+
+    attr_reader :pipeline_run
+
+    validate :no_active_run
+    validate :initial_input_valid
+
+    def initialize(pipeline:, initial_input_params: nil)
+      @pipeline = pipeline
+      @initial_input_params = initial_input_params
+    end
+
+    def save
+      return false unless valid?
+
+      @pipeline_run = @pipeline.pipeline_runs.create(
+        status: "pending",
+        triggered_by: "manual",
+        initial_input: extract_initial_input
+      )
+      @pipeline_run.persisted?
+    end
+
+    private
+
+    def no_active_run
+      return unless @pipeline.pipeline_runs.exists?(status: %w[pending running])
+
+      errors.add(:base, "A run is already pending.")
+    end
+
+    def initial_input_valid
+      return unless @pipeline.initial_input_schema.present?
+
+      Orchestration::SchemaValidator.new(@pipeline.initial_input_schema).validate!(extract_initial_input)
+    rescue Orchestration::SchemaValidator::Error => e
+      errors.add(:base, e.message)
+    end
+
+    def extract_initial_input
+      return nil if @pipeline.initial_input_schema.blank?
+
+      @initial_input_params&.to_unsafe_h&.deep_stringify_keys
+    end
+  end
+end

--- a/app/forms/orchestration/pipeline_run_form.rb
+++ b/app/forms/orchestration/pipeline_run_form.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module Orchestration
-  class PipelineRunForm
-    include ActiveModel::Model
-
+  class PipelineRunForm < ::BaseForm
     attr_reader :pipeline_run
 
     validate :no_active_run
@@ -42,9 +40,13 @@ module Orchestration
     end
 
     def extract_initial_input
-      return nil if @pipeline.initial_input_schema.blank?
+      return @extracted_input if defined?(@extracted_input)
 
-      @initial_input_params&.to_unsafe_h&.deep_stringify_keys
+      @extracted_input = if @pipeline.initial_input_schema.blank?
+        nil
+      else
+        @initial_input_params&.to_unsafe_h&.deep_stringify_keys
+      end
     end
   end
 end

--- a/app/forms/orchestration/step_action_create_form.rb
+++ b/app/forms/orchestration/step_action_create_form.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class StepActionCreateForm
+    include ActiveModel::Model
+
+    attr_reader :step_action
+
+    validate :action_exists
+    validate :params_json_valid
+
+    def initialize(step:, action_id:, params_json: nil)
+      @step = step
+      @action_id = action_id.to_i
+      @params_json = params_json.presence
+    end
+
+    def save
+      return false unless valid?
+
+      next_position = (@step.step_actions.maximum(:position) || 0) + 1
+      key = Orchestration::OutputKeyDeriver.call(action_name: action.name, step: @step)
+      @step_action = @step.step_actions.build(
+        action_id: action.id,
+        params: parsed_params,
+        position: next_position,
+        output_key: key
+      )
+
+      begin
+        saved = @step_action.save
+      rescue ActiveRecord::RecordNotUnique
+        @step_action.output_key = "#{key}_#{SecureRandom.hex(3)}"
+        saved = @step_action.save
+      end
+
+      saved
+    end
+
+    private
+
+    def action_exists
+      errors.add(:base, "Invalid action.") unless action
+    end
+
+    def params_json_valid
+      return if @params_json.nil?
+
+      JSON.parse(@params_json)
+    rescue JSON::ParserError
+      errors.add(:base, "Params must be valid JSON.")
+    end
+
+    def action
+      @action ||= Orchestration::Action.find_by(id: @action_id)
+    end
+
+    def parsed_params
+      return nil if @params_json.nil?
+
+      JSON.parse(@params_json)
+    end
+  end
+end

--- a/app/forms/orchestration/step_action_create_form.rb
+++ b/app/forms/orchestration/step_action_create_form.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module Orchestration
-  class StepActionCreateForm
-    include ActiveModel::Model
-
+  class StepActionCreateForm < ::BaseForm
     attr_reader :step_action
 
     validate :action_exists
@@ -12,7 +10,14 @@ module Orchestration
     def initialize(step:, action_id:, params_json: nil)
       @step = step
       @action_id = action_id.to_i
-      @params_json = params_json.presence
+      raw = params_json.presence
+      if raw
+        begin
+          @parsed_params = JSON.parse(raw)
+        rescue JSON::ParserError
+          @params_parse_error = true
+        end
+      end
     end
 
     def save
@@ -22,7 +27,7 @@ module Orchestration
       key = Orchestration::OutputKeyDeriver.call(action_name: action.name, step: @step)
       @step_action = @step.step_actions.build(
         action_id: action.id,
-        params: parsed_params,
+        params: @parsed_params,
         position: next_position,
         output_key: key
       )
@@ -44,21 +49,13 @@ module Orchestration
     end
 
     def params_json_valid
-      return if @params_json.nil?
-
-      JSON.parse(@params_json)
-    rescue JSON::ParserError
-      errors.add(:base, "Params must be valid JSON.")
+      errors.add(:base, "Params must be valid JSON.") if @params_parse_error
     end
 
     def action
-      @action ||= Orchestration::Action.find_by(id: @action_id)
-    end
+      return @action if defined?(@action)
 
-    def parsed_params
-      return nil if @params_json.nil?
-
-      JSON.parse(@params_json)
+      @action = Orchestration::Action.find_by(id: @action_id)
     end
   end
 end

--- a/spec/forms/orchestration/input_mapping_form_spec.rb
+++ b/spec/forms/orchestration/input_mapping_form_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::InputMappingForm do
+  let(:pipeline)    { create(:orchestration_pipeline) }
+  let(:step)        { create(:orchestration_step, pipeline: pipeline) }
+  let(:action)      { create(:orchestration_action, name: "Classify Emails") }
+  let(:step_action) { create(:orchestration_step_action, step: step, action: action, output_key: "classify_emails") }
+
+  def build_form(input_mapping: {}, new_key: nil, new_from: nil, new_path: nil)
+    described_class.new(
+      step_action: step_action,
+      input_mapping: ActionController::Parameters.new(input_mapping),
+      new_key: new_key,
+      new_from: new_from,
+      new_path: new_path
+    )
+  end
+
+  describe "#save" do
+    context "with a valid input_mapping" do
+      let(:mapping) { { "email" => { "from" => "_initial", "path" => "" } } }
+
+      it "returns true" do
+        expect(build_form(input_mapping: mapping).save).to be true
+      end
+
+      it "saves the input_mapping to the step_action" do
+        build_form(input_mapping: mapping).save
+        expect(step_action.reload.input_mapping).to eq("email" => { "from" => "_initial", "path" => "" })
+      end
+
+      it "exposes the InputMappingUpdater result" do
+        form = build_form(input_mapping: mapping)
+        form.save
+        expect(form.result).to respond_to(:saved)
+      end
+    end
+
+    context "when appending a new mapping entry" do
+      it "merges new_key/new_from into the mapping and saves" do
+        build_form(new_key: "result", new_from: "_initial").save
+        expect(step_action.reload.input_mapping).to have_key("result")
+      end
+
+      it "includes new_path when provided" do
+        build_form(new_key: "result", new_from: "_initial", new_path: "data.0").save
+        expect(step_action.reload.input_mapping["result"]).to eq("from" => "_initial", "path" => "data.0")
+      end
+
+      it "omits path from entry when new_path is absent" do
+        build_form(new_key: "result", new_from: "_initial").save
+        expect(step_action.reload.input_mapping["result"]).to eq("from" => "_initial")
+      end
+    end
+
+    context "when new_key has an invalid format" do
+      it "returns false" do
+        expect(build_form(new_key: "Bad Key!", new_from: "_initial").save).to be false
+      end
+
+      it "adds an error describing the invalid key" do
+        form = build_form(new_key: "Bad Key!", new_from: "_initial")
+        form.save
+        expect(form.errors.full_messages.first).to include("is invalid")
+      end
+
+      it "does not update the step_action" do
+        original = step_action.input_mapping
+        build_form(new_key: "Bad Key!", new_from: "_initial").save
+        expect(step_action.reload.input_mapping).to eq(original)
+      end
+    end
+
+    context "when InputMappingUpdater returns errors" do
+      it "returns false" do
+        expect(build_form(input_mapping: { "email" => { "from" => "nonexistent_key" } }).save).to be false
+      end
+    end
+  end
+end

--- a/spec/forms/orchestration/pipeline_run_form_spec.rb
+++ b/spec/forms/orchestration/pipeline_run_form_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::PipelineRunForm do
+  let(:pipeline) { create(:orchestration_pipeline) }
+  let(:form) { described_class.new(pipeline: pipeline) }
+
+  describe "#save" do
+    context "when no active run exists" do
+      before { allow(PipelineRunJob).to receive(:perform_later) }
+
+      it "creates a pipeline run with status pending and triggered_by manual" do
+        expect { form.save }.to change(Orchestration::PipelineRun, :count).by(1)
+        run = Orchestration::PipelineRun.last
+        expect(run.status).to eq("pending")
+        expect(run.triggered_by).to eq("manual")
+      end
+
+      it "returns true" do
+        expect(form.save).to be true
+      end
+
+      it "exposes the created pipeline run" do
+        form.save
+        expect(form.pipeline_run).to be_a(Orchestration::PipelineRun)
+        expect(form.pipeline_run).to be_persisted
+      end
+    end
+
+    context "when a pending run already exists" do
+      before { create(:orchestration_pipeline_run, pipeline: pipeline, status: "pending") }
+
+      it "does not create a new run" do
+        expect { form.save }.not_to change(Orchestration::PipelineRun, :count)
+      end
+
+      it "returns false" do
+        expect(form.save).to be false
+      end
+
+      it "adds an error message" do
+        form.save
+        expect(form.errors.full_messages).to include("A run is already pending.")
+      end
+    end
+
+    context "when a running run already exists" do
+      before { create(:orchestration_pipeline_run, pipeline: pipeline, status: "running") }
+
+      it "does not create a new run and is invalid" do
+        form.save
+        expect(form.errors).not_to be_empty
+      end
+    end
+
+    context "with initial_input_schema" do
+      let(:schema) do
+        { "type" => "object", "required" => ["date"],
+          "properties" => { "date" => { "type" => "string" } } }
+      end
+      let(:pipeline) { create(:orchestration_pipeline, initial_input_schema: schema) }
+
+      context "when initial_input is valid" do
+        let(:raw_params) { ActionController::Parameters.new("date" => "2026-05-20") }
+        let(:form) { described_class.new(pipeline: pipeline, initial_input_params: raw_params) }
+
+        before { allow(PipelineRunJob).to receive(:perform_later) }
+
+        it "creates the run with initial_input set" do
+          form.save
+          expect(Orchestration::PipelineRun.last.initial_input).to eq("date" => "2026-05-20")
+        end
+      end
+
+      context "when initial_input is missing a required field" do
+        let(:raw_params) { ActionController::Parameters.new({}) }
+        let(:form) { described_class.new(pipeline: pipeline, initial_input_params: raw_params) }
+
+        it "returns false" do
+          expect(form.save).to be false
+        end
+
+        it "adds a schema validation error" do
+          form.save
+          expect(form.errors.full_messages.first).to include("missing required key")
+        end
+      end
+    end
+
+    context "without initial_input_schema" do
+      let(:form) do
+        raw = ActionController::Parameters.new("anything" => "value")
+        described_class.new(pipeline: pipeline, initial_input_params: raw)
+      end
+
+      before { allow(PipelineRunJob).to receive(:perform_later) }
+
+      it "stores nil as initial_input regardless of params" do
+        form.save
+        expect(Orchestration::PipelineRun.last.initial_input).to be_nil
+      end
+    end
+  end
+end

--- a/spec/forms/orchestration/pipeline_run_form_spec.rb
+++ b/spec/forms/orchestration/pipeline_run_form_spec.rb
@@ -54,37 +54,39 @@ RSpec.describe Orchestration::PipelineRunForm do
       end
     end
 
-    context "with initial_input_schema" do
+    context "when pipeline has a schema and initial_input is valid" do
       let(:schema) do
-        { "type" => "object", "required" => ["date"],
+        { "type" => "object", "required" => [ "date" ],
           "properties" => { "date" => { "type" => "string" } } }
       end
       let(:pipeline) { create(:orchestration_pipeline, initial_input_schema: schema) }
+      let(:raw_params) { ActionController::Parameters.new("date" => "2026-05-20") }
+      let(:form) { described_class.new(pipeline: pipeline, initial_input_params: raw_params) }
 
-      context "when initial_input is valid" do
-        let(:raw_params) { ActionController::Parameters.new("date" => "2026-05-20") }
-        let(:form) { described_class.new(pipeline: pipeline, initial_input_params: raw_params) }
+      before { allow(PipelineRunJob).to receive(:perform_later) }
 
-        before { allow(PipelineRunJob).to receive(:perform_later) }
+      it "creates the run with initial_input set" do
+        form.save
+        expect(Orchestration::PipelineRun.last.initial_input).to eq("date" => "2026-05-20")
+      end
+    end
 
-        it "creates the run with initial_input set" do
-          form.save
-          expect(Orchestration::PipelineRun.last.initial_input).to eq("date" => "2026-05-20")
-        end
+    context "when pipeline has a schema and initial_input is missing a required field" do
+      let(:schema) do
+        { "type" => "object", "required" => [ "date" ],
+          "properties" => { "date" => { "type" => "string" } } }
+      end
+      let(:pipeline) { create(:orchestration_pipeline, initial_input_schema: schema) }
+      let(:raw_params) { ActionController::Parameters.new({}) }
+      let(:form) { described_class.new(pipeline: pipeline, initial_input_params: raw_params) }
+
+      it "returns false" do
+        expect(form.save).to be false
       end
 
-      context "when initial_input is missing a required field" do
-        let(:raw_params) { ActionController::Parameters.new({}) }
-        let(:form) { described_class.new(pipeline: pipeline, initial_input_params: raw_params) }
-
-        it "returns false" do
-          expect(form.save).to be false
-        end
-
-        it "adds a schema validation error" do
-          form.save
-          expect(form.errors.full_messages.first).to include("missing required key")
-        end
+      it "adds a schema validation error" do
+        form.save
+        expect(form.errors.full_messages.first).to include("missing required key")
       end
     end
 

--- a/spec/forms/orchestration/step_action_create_form_spec.rb
+++ b/spec/forms/orchestration/step_action_create_form_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::StepActionCreateForm do
+  let(:pipeline) { create(:orchestration_pipeline) }
+  let(:step)     { create(:orchestration_step, pipeline: pipeline) }
+  let(:action)   { create(:orchestration_action, name: "Classify Emails") }
+
+  def build_form(action_id: action.id, params_json: nil)
+    described_class.new(step: step, action_id: action_id, params_json: params_json)
+  end
+
+  describe "#save" do
+    context "with a valid action" do
+      it "returns true" do
+        expect(build_form.save).to be true
+      end
+
+      it "creates a step_action" do
+        expect { build_form.save }.to change(Orchestration::StepAction, :count).by(1)
+      end
+
+      it "derives output_key from the action name" do
+        build_form.save
+        expect(step.step_actions.last.output_key).to eq("classify_emails")
+      end
+
+      it "assigns the correct position" do
+        build_form.save
+        expect(step.step_actions.last.position).to eq(1)
+      end
+
+      it "increments position when step already has actions" do
+        create(:orchestration_step_action, step: step, action: action, position: 1, output_key: "first")
+        build_form.save
+        expect(step.step_actions.last.position).to eq(2)
+      end
+
+      it "exposes the created step_action" do
+        form = build_form
+        form.save
+        expect(form.step_action).to be_a(Orchestration::StepAction)
+        expect(form.step_action).to be_persisted
+      end
+    end
+
+    context "with valid JSON params" do
+      it "parses and stores them" do
+        build_form(params_json: '{"threshold": 0.8}').save
+        expect(step.step_actions.last.params).to eq("threshold" => 0.8)
+      end
+    end
+
+    context "with an invalid action_id" do
+      it "returns false" do
+        expect(build_form(action_id: 0).save).to be false
+      end
+
+      it "does not create a step_action" do
+        expect { build_form(action_id: 0).save }.not_to change(Orchestration::StepAction, :count)
+      end
+
+      it "adds an error message" do
+        form = build_form(action_id: 0)
+        form.save
+        expect(form.errors.full_messages).to include("Invalid action.")
+      end
+    end
+
+    context "with invalid JSON in params" do
+      it "returns false" do
+        expect(build_form(params_json: "{not json}").save).to be false
+      end
+
+      it "does not create a step_action" do
+        expect { build_form(params_json: "{not json}").save }.not_to change(Orchestration::StepAction, :count)
+      end
+
+      it "adds an error message about valid JSON" do
+        form = build_form(params_json: "{not json}")
+        form.save
+        expect(form.errors.full_messages.first).to include("valid JSON")
+      end
+    end
+
+    context "when a unique-key collision occurs (race condition)" do
+      before do
+        allow(Orchestration::OutputKeyDeriver).to receive(:call).and_return("classify_emails")
+
+        first_call = true
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Orchestration::StepAction).to receive(:save).and_wrap_original do |m, **opts|
+          if first_call
+            first_call = false
+            raise ActiveRecord::RecordNotUnique, "UNIQUE constraint failed"
+          end
+          m.call(**opts)
+        end
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it "saves with a hex-suffixed key" do
+        expect { build_form.save }.to change(Orchestration::StepAction, :count).by(1)
+        expect(step.step_actions.last.output_key).to match(/\Aclassify_emails_[0-9a-f]+\z/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Introduces `Orchestration::PipelineRunForm` to encapsulate the `run` action's active-run guard, schema validation, and pipeline run creation
- Introduces `Orchestration::StepActionCreateForm` to encapsulate action lookup, JSON params parsing, position/output-key assignment, and unique-key retry logic
- Introduces `Orchestration::InputMappingForm` to encapsulate input_mapping coercion and `new_key` format validation

Both controllers now delegate all parameter coercion and business-rule validation to form objects; controllers contain only coordination logic.

Closes #109

## Test plan
- [x] 35 new unit specs for the three form objects (all green)
- [x] Existing request specs for pipelines and step_actions still pass (82 examples)
- [x] Full suite: 1792 examples, 0 failures
- [x] Rubocop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)