### PR TITLE
feat: add token usage summary to ralph PR descriptions

### DIFF
--- a/bin/token-usage.sh
+++ b/bin/token-usage.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Reads a Claude Code session transcript (JSONL) and prints a token usage summary.
+# Usage: token-usage.sh [transcript_path]
+# If no path is given, auto-detects the latest transcript for the current working directory.
+
+set -euo pipefail
+
+TRANSCRIPT="${1:-}"
+
+if [ -z "$TRANSCRIPT" ]; then
+  slug=$(pwd | sed 's|[/._]|-|g')
+  TRANSCRIPT=$(ls -t ~/.claude/projects/"${slug}"/*.jsonl 2>/dev/null | head -1 || true)
+fi
+
+if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
+  echo "unavailable"
+  exit 0
+fi
+
+jq -sr '
+  [.[] | select(.type == "assistant" and .message.usage != null)] |
+  unique_by(.message.id) |
+  [.[].message.usage] |
+  {
+    input:       (map(.input_tokens                 // 0) | add // 0),
+    output:      (map(.output_tokens                // 0) | add // 0),
+    cache_read:  (map(.cache_read_input_tokens      // 0) | add // 0),
+    cache_write: (map(.cache_creation_input_tokens  // 0) | add // 0)
+  } |
+  "input=\(.input), output=\(.output), cache_read=\(.cache_read), cache_write=\(.cache_write)"
+' "$TRANSCRIPT"

--- a/spec/bin/token_usage_spec.rb
+++ b/spec/bin/token_usage_spec.rb
@@ -1,0 +1,77 @@
+# rubocop:disable RSpec/DescribeClass
+require "open3"
+require "tmpdir"
+require "json"
+
+RSpec.describe "bin/token-usage.sh" do
+  let(:script) { File.expand_path("../../bin/token-usage.sh", __dir__) }
+
+  def run(path = nil)
+    args = path ? [ script, path ] : [ script ]
+    stdout, _stderr, _status = Open3.capture3(*args)
+    stdout.chomp
+  end
+
+  def write_transcript(entries, dir: Dir.mktmpdir)
+    path = File.join(dir, "session.jsonl")
+    File.write(path, entries.map { JSON.generate(_1) }.join("\n"))
+    path
+  end
+
+  def usage_entry(id:, input:, output:, cache_read: 0, cache_write: 0)
+    {
+      type: "assistant",
+      message: {
+        id: id,
+        usage: {
+          input_tokens: input,
+          output_tokens: output,
+          cache_read_input_tokens: cache_read,
+          cache_creation_input_tokens: cache_write
+        }
+      }
+    }
+  end
+
+  context "when transcript path does not exist" do
+    it 'returns "unavailable"' do
+      expect(run("/nonexistent/path/session.jsonl")).to eq("unavailable")
+    end
+  end
+
+  context "when transcript has no usage entries" do
+    it "returns zeros for all counters" do
+      path = write_transcript([ { type: "permission-mode", permissionMode: "default" } ])
+      expect(run(path)).to eq("input=0, output=0, cache_read=0, cache_write=0")
+    end
+  end
+
+  context "when transcript has one usage entry" do
+    it "returns the exact token counts" do
+      path = write_transcript([ usage_entry(id: "msg_1", input: 100, output: 50, cache_read: 200, cache_write: 300) ])
+      expect(run(path)).to eq("input=100, output=50, cache_read=200, cache_write=300")
+    end
+  end
+
+  context "when transcript has multiple usage entries with distinct IDs" do
+    it "sums token counts across all entries" do
+      path = write_transcript([
+        usage_entry(id: "msg_1", input: 100, output: 50, cache_read: 200, cache_write: 300),
+        usage_entry(id: "msg_2", input: 50, output: 75, cache_read: 100, cache_write: 150)
+      ])
+      expect(run(path)).to eq("input=150, output=125, cache_read=300, cache_write=450")
+    end
+  end
+
+  context "when transcript has duplicate message IDs" do
+    it "counts each unique message only once" do
+      path = write_transcript([
+        usage_entry(id: "msg_1", input: 100, output: 50),
+        usage_entry(id: "msg_1", input: 100, output: 50),
+        usage_entry(id: "msg_2", input: 40, output: 20)
+      ])
+      expect(run(path)).to eq("input=140, output=70, cache_read=0, cache_write=0")
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## Summary
- Adds `bin/token-usage.sh` that reads the Claude Code session transcript JSONL and outputs cumulative input/output/cache token counts (deduplicating by message ID)
- Updates `~/.claude/commands/ralph.md` to call the script and replace the `{{token_usage}}` placeholder with real data before opening a PR
- Covers the script with 5 RSpec examples including the deduplication edge case

Closes #106

## Test plan
- [x] Relevant new tests pass (5 examples in `spec/bin/token_usage_spec.rb`)
- [x] Existing relevant tests still pass (1821 examples, 0 failures)
- [x] Linting passes (738 files inspected, no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=46, output=21871, cache_read=1681772, cache_write=45786