### PR TITLE
test: close alive mutations in 7 orchestration service specs

### DIFF
--- a/spec/services/orchestration/ingestion_executor_spec.rb
+++ b/spec/services/orchestration/ingestion_executor_spec.rb
@@ -206,5 +206,126 @@ RSpec.describe Orchestration::IngestionExecutor do
           .to raise_error(ArgumentError, /unknown operation type: explode/)
       end
     end
+
+    context 'when filter_by_ids yields no matches' do
+      let(:params) do
+        {
+          "operations" => [
+            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" }
+          ]
+        }
+      end
+
+      it 'returns an empty array for the output key' do
+        result = described_class.call({ "emails" => emails, "result" => [] }, params)
+        expect(result["emails"]).to eq([])
+      end
+    end
+
+    context 'when source items have no id key (item_id returns empty string)' do
+      let(:params) do
+        {
+          "operations" => [
+            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" }
+          ]
+        }
+      end
+      let(:emails_without_id) { [ { "subject" => "A" }, { "subject" => "B" } ] }
+
+      it 'excludes items with no id from the filtered output' do
+        result = described_class.call({ "emails" => emails_without_id, "result" => [] }, params)
+        expect(result["emails"]).to eq([])
+      end
+    end
+
+    context 'when ids_from contains non-Hash items' do
+      let(:params) do
+        {
+          "operations" => [
+            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" }
+          ]
+        }
+      end
+
+      it 'ignores non-Hash items in ids_from when building the allowed set' do
+        result = described_class.call({ "emails" => emails, "result" => [ "e1", "e3" ] }, params)
+        expect(result["emails"]).to eq([])
+      end
+    end
+
+    context 'when merge_by_index op keys are non-string (Symbol)' do
+      let(:merge_input) do
+        {
+          "emails"     => [ { "email_id" => "abc", "company" => "Acme" } ],
+          "stored_ids" => [ 99 ]
+        }
+      end
+
+      it 'coerces Symbol source key to string for lookup' do
+        params = {
+          "operations" => [
+            { "type" => "merge_by_index", "source" => :emails, "ids" => "stored_ids",
+              "inject" => "id", "output" => "records" }
+          ]
+        }
+        result = described_class.call(merge_input, params)
+        expect(result["records"]).to eq([ { "id" => 99, "email_id" => "abc", "company" => "Acme" } ])
+      end
+
+      it 'coerces Symbol inject key to string in the merged hash' do
+        params = {
+          "operations" => [
+            { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids",
+              "inject" => :id, "output" => "records" }
+          ]
+        }
+        result = described_class.call(merge_input, params)
+        expect(result["records"].first).to have_key("id")
+        expect(result["records"].first).not_to have_key(:id)
+      end
+
+      it 'coerces Symbol dest key to string' do
+        params = {
+          "operations" => [
+            { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids",
+              "inject" => "id", "output" => :records }
+          ]
+        }
+        result = described_class.call(merge_input, params)
+        expect(result).to have_key("records")
+        expect(result).not_to have_key(:records)
+      end
+    end
+
+    context 'when rename op keys are non-string (Symbol)' do
+      it 'coerces Symbol from key to string before comparing' do
+        params = { "operations" => [ { "type" => "rename", "from" => :emails, "to" => "messages" } ] }
+        result = described_class.call(input, params)
+        expect(result).to have_key("messages")
+        expect(result).not_to have_key("emails")
+      end
+
+      it 'coerces Symbol to key to string in the output' do
+        params = { "operations" => [ { "type" => "rename", "from" => "emails", "to" => :messages } ] }
+        result = described_class.call(input, params)
+        expect(result).to have_key("messages")
+        expect(result).not_to have_key(:messages)
+      end
+    end
+
+    context 'when dig_path has a nil intermediate node' do
+      let(:params) do
+        {
+          "operations" => [
+            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result.ids", "output" => "emails" }
+          ]
+        }
+      end
+
+      it 'returns empty when an intermediate path segment is nil' do
+        result = described_class.call({ "emails" => emails, "result" => nil }, params)
+        expect(result["emails"]).to eq([])
+      end
+    end
   end
 end

--- a/spec/services/orchestration/input_mapping_updater_spec.rb
+++ b/spec/services/orchestration/input_mapping_updater_spec.rb
@@ -117,12 +117,10 @@ RSpec.describe Orchestration::InputMappingUpdater do
 
     context "when the step_action does not appear in the validator results" do
       it "treats missing step_result as no errors and no warnings" do
-        other_step = create(:orchestration_step, pipeline: pipeline)
-        other_action = create(:orchestration_action, name: "Other Action")
-        other_step_action = create(:orchestration_step_action, step: other_step, action: other_action, output_key: "other")
+        allow(Orchestration::Pipeline::Validator).to receive(:call).and_return([])
 
         result = described_class.call(
-          step_action: other_step_action,
+          step_action: step_action,
           input_mapping: {}
         )
 

--- a/spec/services/orchestration/input_mapping_updater_spec.rb
+++ b/spec/services/orchestration/input_mapping_updater_spec.rb
@@ -104,5 +104,31 @@ RSpec.describe Orchestration::InputMappingUpdater do
         expect(step_action.reload.input_mapping).to have_key("email")
       end
     end
+
+    context "when the input_mapping is empty" do
+      it "saves and returns empty errors and warnings" do
+        result = described_class.call(step_action: step_action, input_mapping: {})
+
+        expect(result.saved).to be true
+        expect(result.errors).to be_empty
+        expect(result.warnings).to be_empty
+      end
+    end
+
+    context "when the step_action does not appear in the validator results" do
+      it "treats missing step_result as no errors and no warnings" do
+        other_step = create(:orchestration_step, pipeline: pipeline)
+        other_action = create(:orchestration_action, name: "Other Action")
+        other_step_action = create(:orchestration_step_action, step: other_step, action: other_action, output_key: "other")
+
+        result = described_class.call(
+          step_action: other_step_action,
+          input_mapping: {}
+        )
+
+        expect(result.errors).to be_empty
+        expect(result.warnings).to be_empty
+      end
+    end
   end
 end

--- a/spec/services/orchestration/normalize_action_run_failure_spec.rb
+++ b/spec/services/orchestration/normalize_action_run_failure_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Orchestration::NormalizeActionRunFailure do
   describe ".call" do
+    let(:model) { "gpt-4.1-mini" }
+
     let(:action_run) do
       create(
         :orchestration_action_run,
@@ -14,7 +16,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when the failure is a provider HTTP error" do
-      let(:model) { "gpt-4.1-mini" }
       let(:response) do
         instance_double(
           Faraday::Response,
@@ -53,7 +54,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when a provider HTTP error has a nested error.message (no top-level message)" do
-      let(:model) { "gpt-4.1-mini" }
       let(:response) do
         Data.define(:status, :body).new(
           status: 400,
@@ -69,7 +69,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when the provider HTTP response body is not valid JSON" do
-      let(:model) { "gpt-4.1-mini" }
       let(:response) { Data.define(:status, :body).new(status: 503, body: "Service Unavailable") }
       let(:error) { RubyLLM::ServiceUnavailableError.new(response, "unavailable") }
 
@@ -81,7 +80,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when the provider HTTP response body is a JSON array" do
-      let(:model) { "gpt-4.1-mini" }
       let(:response) { Data.define(:status, :body).new(status: 400, body: '["err1","err2"]') }
       let(:error) { RubyLLM::BadRequestError.new(response, "array errors") }
 
@@ -92,7 +90,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when the provider HTTP response has no message or error keys" do
-      let(:model) { "gpt-4.1-mini" }
       let(:response) { Data.define(:status, :body).new(status: 429, body: '{"code":42}') }
       let(:error) { RubyLLM::RateLimitError.new(response, "rate limited fallback") }
 
@@ -103,7 +100,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when the parsed message is 'An unknown error occurred'" do
-      let(:model) { "gpt-4.1-mini" }
       let(:response) { Data.define(:status, :body).new(status: 500, body: '{"message":"An unknown error occurred"}') }
       let(:error) { RubyLLM::ServerError.new(response, "real server error") }
 
@@ -114,7 +110,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when the agent_snapshot contains sensitive keys" do
-      let(:model) { "gpt-4.1-mini" }
       let(:action_run) do
         create(
           :orchestration_action_run,
@@ -135,7 +130,6 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
     end
 
     context "when the agent_snapshot is blank" do
-      let(:model) { "gpt-4.1-mini" }
       let(:action_run) { create(:orchestration_action_run, chat: create(:chat), agent_snapshot: nil) }
       let(:response) { Data.define(:status, :body).new(status: 429, body: '{"message":"Rate limit"}') }
       let(:error) { RubyLLM::RateLimitError.new(response, "Rate limit exceeded") }

--- a/spec/services/orchestration/normalize_action_run_failure_spec.rb
+++ b/spec/services/orchestration/normalize_action_run_failure_spec.rb
@@ -52,6 +52,100 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
       end
     end
 
+    context "when a provider HTTP error has a nested error.message (no top-level message)" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:response) do
+        Data.define(:status, :body).new(
+          status: 400,
+          body: { "error" => { "code" => "invalid_input", "error" => { "message" => "Nested detail" } } }.to_json
+        )
+      end
+      let(:error) { RubyLLM::BadRequestError.new(response, "An unknown error occurred") }
+
+      it "digs into the nested error.message" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.summary).to include("Nested detail")
+      end
+    end
+
+    context "when the provider HTTP response body is not valid JSON" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:response) { Data.define(:status, :body).new(status: 503, body: "Service Unavailable") }
+      let(:error) { RubyLLM::ServiceUnavailableError.new(response, "unavailable") }
+
+      it "returns nil parsed_error and falls back to the error message" do # rubocop:disable RSpec/MultipleExpectations
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.details["parsed_error"]).to be_nil
+        expect(result.summary).to include("unavailable")
+      end
+    end
+
+    context "when the provider HTTP response body is a JSON array" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:response) { Data.define(:status, :body).new(status: 400, body: '["err1","err2"]') }
+      let(:error) { RubyLLM::BadRequestError.new(response, "array errors") }
+
+      it "preserves the array as parsed_error" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.details["parsed_error"]).to eq([ "err1", "err2" ])
+      end
+    end
+
+    context "when the provider HTTP response has no message or error keys" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:response) { Data.define(:status, :body).new(status: 429, body: '{"code":42}') }
+      let(:error) { RubyLLM::RateLimitError.new(response, "rate limited fallback") }
+
+      it "falls back to the error message" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.summary).to include("rate limited fallback")
+      end
+    end
+
+    context "when the parsed message is 'An unknown error occurred'" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:response) { Data.define(:status, :body).new(status: 500, body: '{"message":"An unknown error occurred"}') }
+      let(:error) { RubyLLM::ServerError.new(response, "real server error") }
+
+      it "skips the sentinel and falls back to the error message" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.summary).to include("real server error")
+      end
+    end
+
+    context "when the agent_snapshot contains sensitive keys" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:action_run) do
+        create(
+          :orchestration_action_run,
+          chat: create(:chat),
+          agent_snapshot: { "model" => model, "api_key" => "sk-secret", "token" => "tok_abc" }
+        )
+      end
+      let(:response) { Data.define(:status, :body).new(status: 429, body: '{"message":"Rate limit"}') }
+      let(:error) { RubyLLM::RateLimitError.new(response, "Rate limit exceeded") }
+
+      it "redacts sensitive keys in request_context.agent_snapshot" do # rubocop:disable RSpec/MultipleExpectations
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        snapshot = result.details["request_context"]["agent_snapshot"]
+        expect(snapshot["api_key"]).to eq("[REDACTED]")
+        expect(snapshot["token"]).to eq("[REDACTED]")
+        expect(snapshot["model"]).to eq("gpt-4.1-mini")
+      end
+    end
+
+    context "when the agent_snapshot is blank" do
+      let(:model) { "gpt-4.1-mini" }
+      let(:action_run) { create(:orchestration_action_run, chat: create(:chat), agent_snapshot: nil) }
+      let(:response) { Data.define(:status, :body).new(status: 429, body: '{"message":"Rate limit"}') }
+      let(:error) { RubyLLM::RateLimitError.new(response, "Rate limit exceeded") }
+
+      it "returns nil request_context" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.details["request_context"]).to be_nil
+      end
+    end
+
     context "when the failure is a transport error" do
       let(:model) { "mistral-small-latest" }
       let(:error) { Faraday::TimeoutError.new("execution expired") }
@@ -68,6 +162,26 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
           "status_code" => nil
         )
         expect(result.details["raw_response_excerpt"]).to be_nil
+      end
+    end
+
+    context "when the failure is a Faraday::ConnectionFailed transport error" do
+      let(:model) { "mistral-small-latest" }
+      let(:error) { Faraday::ConnectionFailed.new("Connection refused - connect(2)") }
+
+      it "classifies as transport_error" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.details["category"]).to eq("transport_error")
+      end
+    end
+
+    context "when the failure is a Faraday::SSLError transport error" do
+      let(:model) { "mistral-small-latest" }
+      let(:error) { Faraday::SSLError.new("SSL_connect SYSCALL returned=5") }
+
+      it "classifies as transport_error" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.details["category"]).to eq("transport_error")
       end
     end
 
@@ -92,6 +206,55 @@ RSpec.describe Orchestration::NormalizeActionRunFailure do
         )
         expect(result.details["raw_response_excerpt"]).to include("[REDACTED_EMAIL]")
         expect(result.details["raw_response_excerpt"]).to include("[REDACTED]")
+      end
+    end
+
+    context "when invalid model output has a Hash as raw content (stringify path)" do
+      let(:model) { "claude-3-5-haiku-latest" }
+      let(:error) do
+        Orchestration::InvalidModelOutputError.new(
+          "Schema mismatch",
+          raw_content: { "result" => [ 1, 2, 3 ], "count" => 3 }
+        )
+      end
+
+      it "converts the hash to a JSON string for the excerpt" do
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.details["raw_response_excerpt"]).to include("result")
+      end
+    end
+
+    context "when the failure is a generic (unclassified) error" do
+      let(:model) { "mistral-small-latest" }
+      let(:error) { RuntimeError.new("Something unexpected broke") }
+
+      it "returns the sanitized message with nil details" do # rubocop:disable RSpec/MultipleExpectations
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.summary).to eq("Something unexpected broke")
+        expect(result.details).to be_nil
+      end
+    end
+
+    context "when the error message contains a Bearer token" do
+      let(:model) { "mistral-small-latest" }
+      let(:error) { RuntimeError.new("Unauthorized: Bearer sk-abc123def456ghi") }
+
+      it "redacts the Bearer token from the summary" do # rubocop:disable RSpec/MultipleExpectations
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.summary).to include("[REDACTED]")
+        expect(result.summary).not_to include("sk-abc123def456ghi")
+      end
+    end
+
+    context "when the error message exceeds MAX_EXCERPT_LENGTH characters" do
+      let(:model) { "mistral-small-latest" }
+      let(:long_message) { "x" * (Orchestration::NormalizeActionRunFailure::MAX_EXCERPT_LENGTH + 10) }
+      let(:error) { RuntimeError.new(long_message) }
+
+      it "truncates to MAX_EXCERPT_LENGTH and appends ellipsis" do # rubocop:disable RSpec/MultipleExpectations
+        result = described_class.call(error:, action_run:, raw_content: nil)
+        expect(result.summary).to end_with("...")
+        expect(result.summary.length).to eq(Orchestration::NormalizeActionRunFailure::MAX_EXCERPT_LENGTH + 3)
       end
     end
   end

--- a/spec/services/orchestration/output_key_deriver_spec.rb
+++ b/spec/services/orchestration/output_key_deriver_spec.rb
@@ -41,4 +41,8 @@ RSpec.describe Orchestration::OutputKeyDeriver do
     create(:orchestration_step_action, step: other_step, output_key: "classify_emails", position: 1)
     expect(call("Classify Emails")).to eq("classify_emails")
   end
+
+  it "treats nil action_name as blank and returns 'action'" do
+    expect(call(nil)).to eq("action")
+  end
 end

--- a/spec/services/orchestration/query_executor_spec.rb
+++ b/spec/services/orchestration/query_executor_spec.rb
@@ -124,5 +124,16 @@ RSpec.describe Orchestration::QueryExecutor do
           .to raise_error(KeyError)
       end
     end
+
+    context 'when an intermediate node in column_values_from path is nil' do
+      let(:params) do
+        { "table" => "application_mails", "column_name" => "id", "column_values_from" => "result.ids" }
+      end
+
+      it 'returns an empty array rather than raising' do
+        result = described_class.call({ "result" => nil }, params)
+        expect(result["application_mails"]).to eq([])
+      end
+    end
   end
 end

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Orchestration::RuntimeAgentBuilder do
   subject(:builder) { described_class.new(policy: policy, chat: chat) }
 
-  let!(:chat) { create(:chat) }
+  let(:chat) { create(:chat) }
 
   let(:policy) do
     Orchestration::AgentResolutionPolicy::Result.new(
@@ -24,6 +24,8 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
       expect(builder.build.chat).to eq(chat)
     end
 
+    # RubyLLM::Agent uses `def_delegators :chat`, so `agent.with_model` → `chat.with_model`.
+    # We stub the chat directly rather than the agent to avoid creating test doubles.
     it 'applies the policy model to the agent' do
       allow(chat).to receive(:with_model).and_return(chat)
       builder.build
@@ -48,7 +50,7 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
       expect(chat).to have_received(:with_instructions).with("Classify this email")
     end
 
-    context 'when policy model is blank' do
+    context 'when all policy fields are blank' do
       let(:policy) do
         Orchestration::AgentResolutionPolicy::Result.new(
           model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
@@ -60,41 +62,17 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
         described_class.new(policy: policy, chat: chat).build
         expect(chat).not_to have_received(:with_model)
       end
-    end
-
-    context 'when policy tools are empty' do
-      let(:policy) do
-        Orchestration::AgentResolutionPolicy::Result.new(
-          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
-        )
-      end
 
       it 'does not call with_tools' do
         allow(chat).to receive(:with_tools)
         described_class.new(policy: policy, chat: chat).build
         expect(chat).not_to have_received(:with_tools)
       end
-    end
-
-    context 'when policy output_schema is nil' do
-      let(:policy) do
-        Orchestration::AgentResolutionPolicy::Result.new(
-          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
-        )
-      end
 
       it 'does not call with_schema' do
         allow(chat).to receive(:with_schema)
         described_class.new(policy: policy, chat: chat).build
         expect(chat).not_to have_received(:with_schema)
-      end
-    end
-
-    context 'when policy prompt is blank' do
-      let(:policy) do
-        Orchestration::AgentResolutionPolicy::Result.new(
-          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
-        )
       end
 
       it 'does not call with_instructions' do

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Orchestration::RuntimeAgentBuilder do
-  subject(:builder) { described_class.new(policy: policy) }
+  subject(:builder) { described_class.new(policy: policy, chat: chat) }
+
+  let!(:chat) { create(:chat) }
 
   let(:policy) do
     Orchestration::AgentResolutionPolicy::Result.new(
@@ -16,6 +18,98 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
   describe '#build' do
     it 'returns a RubyLLM::Agent instance' do
       expect(builder.build).to be_a(RubyLLM::Agent)
+    end
+
+    it 'uses the provided chat' do
+      expect(builder.build.chat).to eq(chat)
+    end
+
+    it 'applies the policy model to the agent' do
+      allow(chat).to receive(:with_model).and_return(chat)
+      builder.build
+      expect(chat).to have_received(:with_model).with("mistral-large-latest")
+    end
+
+    it 'applies the policy tools to the agent' do
+      allow(chat).to receive(:with_tools).and_return(chat)
+      builder.build
+      expect(chat).to have_received(:with_tools).with(Records::TempFileTool, replace: true)
+    end
+
+    it 'applies the policy output schema to the agent' do
+      allow(chat).to receive(:with_schema).and_return(chat)
+      builder.build
+      expect(chat).to have_received(:with_schema).with({ "type" => "object" })
+    end
+
+    it 'applies the policy prompt as chat instructions' do
+      allow(chat).to receive(:with_instructions).and_return(chat)
+      builder.build
+      expect(chat).to have_received(:with_instructions).with("Classify this email")
+    end
+
+    context 'when policy model is blank' do
+      let(:policy) do
+        Orchestration::AgentResolutionPolicy::Result.new(
+          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
+        )
+      end
+
+      it 'does not call with_model' do
+        allow(chat).to receive(:with_model)
+        described_class.new(policy: policy, chat: chat).build
+        expect(chat).not_to have_received(:with_model)
+      end
+    end
+
+    context 'when policy tools are empty' do
+      let(:policy) do
+        Orchestration::AgentResolutionPolicy::Result.new(
+          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
+        )
+      end
+
+      it 'does not call with_tools' do
+        allow(chat).to receive(:with_tools)
+        described_class.new(policy: policy, chat: chat).build
+        expect(chat).not_to have_received(:with_tools)
+      end
+    end
+
+    context 'when policy output_schema is nil' do
+      let(:policy) do
+        Orchestration::AgentResolutionPolicy::Result.new(
+          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
+        )
+      end
+
+      it 'does not call with_schema' do
+        allow(chat).to receive(:with_schema)
+        described_class.new(policy: policy, chat: chat).build
+        expect(chat).not_to have_received(:with_schema)
+      end
+    end
+
+    context 'when policy prompt is blank' do
+      let(:policy) do
+        Orchestration::AgentResolutionPolicy::Result.new(
+          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
+        )
+      end
+
+      it 'does not call with_instructions' do
+        allow(chat).to receive(:with_instructions)
+        described_class.new(policy: policy, chat: chat).build
+        expect(chat).not_to have_received(:with_instructions)
+      end
+    end
+
+    context 'when no chat is provided' do
+      it 'creates a new Chat record via Chat.create!' do
+        expect {
+          described_class.new(policy: policy).build
+        }.to change(Chat, :count).by(1)
+      end
     end
 
     it 'always uses RubyLLM::Agent.new regardless of agent name' do

--- a/spec/services/orchestration/schema_validator_spec.rb
+++ b/spec/services/orchestration/schema_validator_spec.rb
@@ -148,5 +148,44 @@ RSpec.describe Orchestration::SchemaValidator do
           .to raise_error(described_class::Error, /must be a boolean/)
       end
     end
+
+    context 'with an object schema that has no properties key' do
+      let(:schema) { { "type" => "object", "required" => [ "id" ] } }
+
+      it 'validates required keys without iterating properties' do
+        expect { validator.validate!({ "id" => 1, "extra" => "ok" }) }.not_to raise_error
+      end
+
+      it 'raises when a required key is missing' do
+        expect { validator.validate!({}) }
+          .to raise_error(described_class::Error, /missing required key: id/)
+      end
+    end
+
+    context 'when a schema property key is absent from the data' do
+      let(:schema) do
+        {
+          "type" => "object",
+          "properties" => { "name" => { "type" => "string" } }
+        }
+      end
+
+      it 'skips validation for the absent property' do
+        expect { validator.validate!({}) }.not_to raise_error
+      end
+    end
+
+    context 'when a nested sub-schema has no type key' do
+      let(:schema) do
+        {
+          "type" => "object",
+          "properties" => { "meta" => {} }
+        }
+      end
+
+      it 'passes without raising for any value' do
+        expect { validator.validate!({ "meta" => "anything" }) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Expanded 7 orchestration service specs from 71 → 111 examples to kill the 304 alive mutations identified in issue #117
- Fixed RuntimeAgentBuilder SQLite locking by providing chat in test setup
- Added targeted tests for each conditional guard, sanitization path, coercion, and edge case called out in the issue

Closes #117

## Test plan

- [x] All 7 new spec files pass (111 examples, 0 failures)
- [x] Full suite passes (1884 examples, 0 failures)
- [x] RuboCop passes with no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=65, output=74254, cache_read=5234548, cache_write=124872