### PR TITLE
feat: enforce metrics as prerequisite for experiment creation

### DIFF
--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -22,14 +22,12 @@ module Evaluation
         session.delete(:wizard_token)
         redirect_to evaluation_experiment_path(experiment), notice: "Experiment '#{experiment.name}' started."
       elsif @wizard_form.complete?
-        flash.now[:alert] = @wizard_form.errors.full_messages.to_sentence
-        render :new, status: :unprocessable_entity
+        render_wizard_error
       else
         if @wizard_form.advance!(@wizard_form.step, wizard_params)
           redirect_to new_evaluation_experiment_path(step: @wizard_form.step + 1)
         else
-          flash.now[:alert] = @wizard_form.errors.full_messages.to_sentence
-          render :new, status: :unprocessable_entity
+          render_wizard_error
         end
       end
     end
@@ -119,6 +117,11 @@ module Evaluation
 
     def wizard_params
       params.fetch(:wizard, {}).permit(:agent_name, :prompt_id, :experiment_name, :sample_model, :evaluation_model, :dataset_id).to_h
+    end
+
+    def render_wizard_error
+      flash.now[:alert] = @wizard_form.errors.full_messages.to_sentence
+      render :new, status: :unprocessable_entity
     end
   end
 end

--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -25,8 +25,12 @@ module Evaluation
         flash.now[:alert] = @wizard_form.errors.full_messages.to_sentence
         render :new, status: :unprocessable_entity
       else
-        @wizard_form.advance!(@wizard_form.step, wizard_params)
-        redirect_to new_evaluation_experiment_path(step: @wizard_form.step + 1)
+        if @wizard_form.advance!(@wizard_form.step, wizard_params)
+          redirect_to new_evaluation_experiment_path(step: @wizard_form.step + 1)
+        else
+          flash.now[:alert] = @wizard_form.errors.full_messages.to_sentence
+          render :new, status: :unprocessable_entity
+        end
       end
     end
 

--- a/app/forms/evaluation/wizard_form.rb
+++ b/app/forms/evaluation/wizard_form.rb
@@ -7,6 +7,7 @@ module Evaluation
     WIZARD_STEPS = 4
 
     validate :dataset_selected
+    validate :active_metrics_present, if: :complete?
 
     def initialize(wizard_token:, step_param: nil)
       @wizard_token = wizard_token
@@ -51,6 +52,13 @@ module Evaluation
 
     def dataset_selected
       errors.add(:dataset, "must be selected") if (draft.payload || {})["dataset_id"].blank?
+    end
+
+    def active_metrics_present
+      agent_name = (draft.payload || {})["agent_name"]
+      return if agent_name.blank?
+      return if Evaluation::Metric.for_agent(agent_name).active.any?
+      errors.add(:base, "No active metrics exist for this agent. Please go back to the Metrics step and generate or add metrics.")
     end
 
     def draft

--- a/app/forms/evaluation/wizard_form.rb
+++ b/app/forms/evaluation/wizard_form.rb
@@ -22,7 +22,15 @@ module Evaluation
     end
 
     def advance!(step, payload)
+      if step == 2
+        agent_name = (draft.payload || {})["agent_name"]
+        if agent_name.present? && Evaluation::Metric.for_agent(agent_name).active.none?
+          errors.add(:base, "Please generate or add at least one active metric before continuing.")
+          return false
+        end
+      end
       draft.advance!(step + 1, payload)
+      true
     end
 
     def complete!

--- a/app/services/evaluation/create_experiment_from_draft.rb
+++ b/app/services/evaluation/create_experiment_from_draft.rb
@@ -13,7 +13,7 @@ module Evaluation
     def call
       # TODO: add transaction
       resolve_prompt
-      maybe_auto_generate_metrics
+      raise NoMetricsError, "No active metrics for #{@agent_name}" if no_active_metrics?
       experiment = create_experiment!
       ExperimentJob.perform_later(experiment)
       draft.destroy
@@ -38,26 +38,8 @@ module Evaluation
       @agent_name = Prompt.find_by(id: @prompt_id)&.name
     end
 
-    def maybe_auto_generate_metrics
-      return unless @agent_name.present? && Metric.for_agent(@agent_name).active.none?
-
-      begin
-        auto_generate_metrics(@agent_name)
-      rescue MetricSuggester::Error => e
-        Rails.logger.warn("MetricSuggester failed for #{@agent_name}: #{e.message} — proceeding without auto-generated metrics")
-      end
-    end
-
-    def auto_generate_metrics(agent_name)
-      suggestions = MetricSuggester.call(agent_name: agent_name, model: nil)
-      suggestions.each do |s|
-        Metric.find_or_initialize_by(agent_name: agent_name, name: s[:name]).tap do |m|
-          m.description = s[:description]
-          m.weight      = s[:weight]
-          m.active      = true
-          m.save!
-        end
-      end
+    def no_active_metrics?
+      @agent_name.present? && Metric.for_agent(@agent_name).active.none?
     end
 
     def create_experiment!

--- a/app/services/evaluation/no_metrics_error.rb
+++ b/app/services/evaluation/no_metrics_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Evaluation
+  class NoMetricsError < StandardError; end
+end

--- a/app/services/evaluation/no_metrics_error.rb
+++ b/app/services/evaluation/no_metrics_error.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Evaluation
+  # Raised by CreateExperimentFromDraft when the resolved agent has no active metrics.
+  # The wizard guard in WizardForm#advance! prevents this in the normal flow; this error
+  # is a defence-in-depth check for race conditions (metrics deactivated after step 2)
+  # or direct API access that bypasses the wizard.
   class NoMetricsError < StandardError; end
 end

--- a/sig/app/forms/evaluation/wizard_form.rbs
+++ b/sig/app/forms/evaluation/wizard_form.rbs
@@ -8,7 +8,7 @@ module Evaluation
 
     def step: () -> Integer
     def complete?: () -> bool
-    def advance!: (Integer step, Hash[String, untyped] payload) -> void
+    def advance!: (Integer step, Hash[String, untyped] payload) -> bool
     def complete!: () -> Experiment
     def step_form: (Integer step) -> (Wizard::Step1Form | Wizard::Step2Form | Wizard::Step3Form | Wizard::Step4Form)?
   end

--- a/sig/app/services/evaluation/create_experiment_from_draft.rbs
+++ b/sig/app/services/evaluation/create_experiment_from_draft.rbs
@@ -1,4 +1,7 @@
 module Evaluation
+  class NoMetricsError < StandardError
+  end
+
   class CreateExperimentFromDraft
     def self.call: (draft: Evaluation::WizardDraft) -> Evaluation::Experiment
 
@@ -12,8 +15,7 @@ module Evaluation
 
     def payload: () -> Hash[String, untyped]
     def resolve_prompt: () -> void
-    def maybe_auto_generate_metrics: () -> void
-    def auto_generate_metrics: (String agent_name) -> void
+    def no_active_metrics?: () -> bool
     def create_experiment!: () -> Evaluation::Experiment
   end
 end

--- a/spec/forms/evaluation/wizard_form_spec.rb
+++ b/spec/forms/evaluation/wizard_form_spec.rb
@@ -39,13 +39,51 @@ RSpec.describe Evaluation::WizardForm do
   end
 
   describe "#advance!" do
-    before { create(:evaluation_wizard_draft, session_token: token, step: 1) }
+    context "when advancing from step 1" do
+      before { create(:evaluation_wizard_draft, session_token: token, step: 1) }
 
-    it "advances the draft to the next step and persists the payload" do
-      form.advance!(1, { "agent_name" => "MyAgent" })
-      draft = Evaluation::WizardDraft.find_by(session_token: token)
-      expect(draft.step).to eq(2)
-      expect(draft.payload["agent_name"]).to eq("MyAgent")
+      it "advances the draft to the next step and persists the payload" do
+        form.advance!(1, { "agent_name" => "MyAgent" })
+        draft = Evaluation::WizardDraft.find_by(session_token: token)
+        expect(draft.step).to eq(2)
+        expect(draft.payload["agent_name"]).to eq("MyAgent")
+      end
+    end
+
+    context "when advancing from step 2 with active metrics" do
+      before do
+        create(:evaluation_metric, agent_name: "MyAgent", active: true)
+        create(:evaluation_wizard_draft, session_token: token, step: 2,
+               payload: { "agent_name" => "MyAgent" })
+      end
+
+      it "returns true and advances the draft" do
+        result = form.advance!(2, {})
+        expect(result).to be(true)
+        expect(Evaluation::WizardDraft.find_by(session_token: token).step).to eq(3)
+      end
+    end
+
+    context "when advancing from step 2 with no active metrics" do
+      before do
+        create(:evaluation_wizard_draft, session_token: token, step: 2,
+               payload: { "agent_name" => "MyAgent" })
+      end
+
+      it "returns false" do
+        result = form.advance!(2, {})
+        expect(result).to be(false)
+      end
+
+      it "adds a base error" do
+        form.advance!(2, {})
+        expect(form.errors[:base]).to be_present
+      end
+
+      it "does not advance the draft step" do
+        form.advance!(2, {})
+        expect(Evaluation::WizardDraft.find_by(session_token: token).step).to eq(2)
+      end
     end
   end
 

--- a/spec/forms/evaluation/wizard_form_spec.rb
+++ b/spec/forms/evaluation/wizard_form_spec.rb
@@ -134,6 +134,22 @@ create(:evaluation_wizard_draft,
         expect(form.errors[:dataset]).to be_present
       end
     end
+
+    context "when at step 4 (complete) with no active metrics for the agent" do
+      before do
+        create(:evaluation_wizard_draft, session_token: token, step: 4,
+               payload: { "experiment_name" => "Eval", "dataset_id" => "7", "agent_name" => "SomeAgent" })
+      end
+
+      it "returns false" do
+        expect(form.valid?).to be false
+      end
+
+      it "adds a base error about metrics" do
+        form.valid?
+        expect(form.errors[:base]).to be_present
+      end
+    end
   end
 
   describe "#complete?" do

--- a/spec/requests/evaluation/experiments_spec.rb
+++ b/spec/requests/evaluation/experiments_spec.rb
@@ -258,6 +258,23 @@ RSpec.describe "Evaluation::Experiments" do
       end
     end
 
+    context "when metrics are deactivated between step 2 and step 4 (race condition)" do
+      let!(:dataset) { create(:evaluation_dataset) }
+      let!(:prompt)  { create(:orchestration_prompt) }
+
+      before { allow(Evaluation::ExperimentJob).to receive(:perform_later) }
+
+      it "re-renders with unprocessable_content instead of raising 500" do
+        metric = create(:evaluation_metric, agent_name: prompt.name, active: true)
+        post evaluation_experiments_path, params: { current_step: 1, wizard: { agent_name: prompt.name, experiment_name: "Race", prompt_id: prompt.id.to_s } }
+        post evaluation_experiments_path, params: { current_step: 2 }
+        post evaluation_experiments_path, params: { current_step: 3, wizard: { dataset_id: dataset.id.to_s } }
+        metric.update!(active: false)
+        post evaluation_experiments_path, params: { current_step: 4 }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
     context "when posting step 2 with no active metrics for the agent" do
       let!(:prompt) { create(:orchestration_prompt) }
 

--- a/spec/requests/evaluation/experiments_spec.rb
+++ b/spec/requests/evaluation/experiments_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "Evaluation::Experiments" do
       expect(draft.payload["agent_name"]).to eq("Emails::ClassifyAgent")
     end
 
-    it "redirects to step 3 after step 2 (no payload)" do
+    it "redirects to step 3 after step 2 (no agent in draft)" do
       post evaluation_experiments_path, params: { current_step: 2 }
       expect(response).to redirect_to(new_evaluation_experiment_path(step: 3))
     end
@@ -225,12 +225,14 @@ RSpec.describe "Evaluation::Experiments" do
     context "when submitting step 4 (final review)" do
       let!(:dataset) { create(:evaluation_dataset) }
       let!(:prompt)  { create(:orchestration_prompt) }
-      let!(:metric)  { create(:evaluation_metric, agent_name: prompt.name) }
 
-      before { allow(Evaluation::ExperimentJob).to receive(:perform_later) }
+      before do
+        create(:evaluation_metric, agent_name: prompt.name, active: true)
+        allow(Evaluation::ExperimentJob).to receive(:perform_later)
+      end
 
       def navigate_to_step4(prompt:, dataset:)
-        post evaluation_experiments_path, params: { current_step: 1, wizard: { agent_name: "Agent", experiment_name: "Eval Exp", prompt_id: prompt.id.to_s } }
+        post evaluation_experiments_path, params: { current_step: 1, wizard: { agent_name: prompt.name, experiment_name: "Eval Exp", prompt_id: prompt.id.to_s } }
         post evaluation_experiments_path, params: { current_step: 2 }
         post evaluation_experiments_path, params: { current_step: 3, wizard: { dataset_id: dataset.id.to_s } }
       end
@@ -254,29 +256,27 @@ RSpec.describe "Evaluation::Experiments" do
         post evaluation_experiments_path, params: { current_step: 4 }
         expect(session[:wizard_token]).to be_nil
       end
+    end
 
-      it "auto-generates metrics and creates the experiment when no active metrics exist" do
-        metric.update!(active: false)
-        allow(Evaluation::MetricSuggester).to receive(:call).and_return([
-          { name: "Accuracy", description: "Correct output", weight: 1.0 }
-        ])
-        navigate_to_step4(prompt: prompt, dataset: dataset)
-        expect {
-          post evaluation_experiments_path, params: { current_step: 4 }
-        }.to change(Evaluation::Experiment, :count).by(1)
-        expect(Evaluation::Metric.for_agent(prompt.name).active.count).to be >= 1
-        expect(response).to redirect_to(evaluation_experiment_path(Evaluation::Experiment.last))
+    context "when posting step 2 with no active metrics for the agent" do
+      let!(:prompt) { create(:orchestration_prompt) }
+
+      it "re-renders step 2 with unprocessable_entity status" do
+        post evaluation_experiments_path, params: {
+          current_step: 1, wizard: { agent_name: prompt.name, experiment_name: "Eval", prompt_id: prompt.id.to_s }
+        }
+        post evaluation_experiments_path, params: { current_step: 2 }
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
-      it "creates the experiment even when MetricSuggester fails" do
-        metric.update!(active: false)
-        allow(Evaluation::MetricSuggester).to receive(:call)
-          .and_raise(Evaluation::MetricSuggester::Error, "LLM unavailable")
-        navigate_to_step4(prompt: prompt, dataset: dataset)
-        expect {
-          post evaluation_experiments_path, params: { current_step: 4 }
-        }.to change(Evaluation::Experiment, :count).by(1)
-        expect(response).to redirect_to(evaluation_experiment_path(Evaluation::Experiment.last))
+      it "does not advance the draft past step 2" do
+        post evaluation_experiments_path, params: {
+          current_step: 1, wizard: { agent_name: prompt.name, experiment_name: "Eval", prompt_id: prompt.id.to_s }
+        }
+        post evaluation_experiments_path, params: { current_step: 2 }
+        token = session[:wizard_token]
+        draft = Evaluation::WizardDraft.find_by(session_token: token)
+        expect(draft.step).to eq(2)
       end
     end
   end

--- a/spec/services/evaluation/create_experiment_from_draft_spec.rb
+++ b/spec/services/evaluation/create_experiment_from_draft_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Evaluation::CreateExperimentFromDraft do
 
       it "does not call MetricSuggester" do
         allow(Evaluation::MetricSuggester).to receive(:call)
-        described_class.call(draft: draft) rescue Evaluation::NoMetricsError
+        expect { described_class.call(draft: draft) }.to raise_error(Evaluation::NoMetricsError)
         expect(Evaluation::MetricSuggester).not_to have_received(:call)
       end
     end

--- a/spec/services/evaluation/create_experiment_from_draft_spec.rb
+++ b/spec/services/evaluation/create_experiment_from_draft_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Evaluation::CreateExperimentFromDraft do
   let!(:metric) { create(:evaluation_metric, agent_name: prompt.name, active: true) }
 
   def build_draft(payload)
-    draft = instance_double(Evaluation::WizardDraft, payload: payload)
-    allow(draft).to receive(:destroy)
-    draft
+    create(:evaluation_wizard_draft, payload: payload, step: 4)
   end
 
   before { allow(Evaluation::ExperimentJob).to receive(:perform_later) }
@@ -19,10 +17,10 @@ RSpec.describe Evaluation::CreateExperimentFromDraft do
     context "when prompt_id is present in the payload" do
       let(:draft) do
         build_draft(
-          "prompt_id"       => prompt.id.to_s,
-          "experiment_name" => "My Eval",
-          "dataset_id"      => dataset.id,
-          "sample_model"    => "gpt-4",
+          "prompt_id"        => prompt.id.to_s,
+          "experiment_name"  => "My Eval",
+          "dataset_id"       => dataset.id,
+          "sample_model"     => "gpt-4",
           "evaluation_model" => "gpt-4"
         )
       end
@@ -52,19 +50,20 @@ RSpec.describe Evaluation::CreateExperimentFromDraft do
       end
 
       it "destroys the draft" do
+        draft_id = draft.id
         described_class.call(draft: draft)
-        expect(draft).to have_received(:destroy)
+        expect(Evaluation::WizardDraft.find_by(id: draft_id)).to be_nil
       end
     end
 
     context "when prompt_id is absent but agent_name is present" do
       let(:draft) do
         build_draft(
-          "prompt_id"       => "",
-          "agent_name"      => prompt.name,
-          "experiment_name" => "Agent Eval",
-          "dataset_id"      => dataset.id,
-          "sample_model"    => nil,
+          "prompt_id"        => "",
+          "agent_name"       => prompt.name,
+          "experiment_name"  => "Agent Eval",
+          "dataset_id"       => dataset.id,
+          "sample_model"     => nil,
           "evaluation_model" => nil
         )
       end
@@ -82,10 +81,10 @@ RSpec.describe Evaluation::CreateExperimentFromDraft do
     context "when experiment_name is absent" do
       let(:draft) do
         build_draft(
-          "prompt_id"       => prompt.id.to_s,
-          "experiment_name" => "",
-          "dataset_id"      => dataset.id,
-          "sample_model"    => nil,
+          "prompt_id"        => prompt.id.to_s,
+          "experiment_name"  => "",
+          "dataset_id"       => dataset.id,
+          "sample_model"     => nil,
           "evaluation_model" => nil
         )
       end
@@ -101,59 +100,37 @@ RSpec.describe Evaluation::CreateExperimentFromDraft do
 
       let(:draft) do
         build_draft(
-          "prompt_id"       => prompt.id.to_s,
-          "experiment_name" => "No Metrics Eval",
-          "dataset_id"      => dataset.id,
-          "sample_model"    => nil,
+          "prompt_id"        => prompt.id.to_s,
+          "experiment_name"  => "No Metrics Eval",
+          "dataset_id"       => dataset.id,
+          "sample_model"     => nil,
           "evaluation_model" => nil
         )
       end
 
-      it "auto-generates metrics via MetricSuggester" do
-        allow(Evaluation::MetricSuggester).to receive(:call).and_return([
-          { name: "Accuracy", description: "Correct output", weight: 1.0 }
-        ])
-        described_class.call(draft: draft)
-        expect(Evaluation::MetricSuggester).to have_received(:call).with(agent_name: prompt.name, model: nil)
-        expect(Evaluation::Metric.for_agent(prompt.name).active.count).to be >= 1
-      end
-    end
-
-    context "when MetricSuggester raises MetricSuggester::Error" do
-      before { metric.update!(active: false) }
-
-      let(:draft) do
-        build_draft(
-          "prompt_id"       => prompt.id.to_s,
-          "experiment_name" => "Fallback Eval",
-          "dataset_id"      => dataset.id,
-          "sample_model"    => nil,
-          "evaluation_model" => nil
-        )
+      it "raises Evaluation::NoMetricsError" do
+        expect { described_class.call(draft: draft) }.to raise_error(Evaluation::NoMetricsError)
       end
 
-      it "still creates the experiment" do
+      it "does not create an experiment" do
+        expect { described_class.call(draft: draft) }.to raise_error(Evaluation::NoMetricsError)
+        expect(Evaluation::Experiment.count).to eq(0)
+      end
+
+      it "does not call MetricSuggester" do
         allow(Evaluation::MetricSuggester).to receive(:call)
-          .and_raise(Evaluation::MetricSuggester::Error, "LLM unavailable")
-        expect { described_class.call(draft: draft) }.to change(Evaluation::Experiment, :count).by(1)
-      end
-
-      it "logs a warning" do
-        allow(Evaluation::MetricSuggester).to receive(:call)
-          .and_raise(Evaluation::MetricSuggester::Error, "LLM unavailable")
-        allow(Rails.logger).to receive(:warn)
-        described_class.call(draft: draft)
-        expect(Rails.logger).to have_received(:warn).with(a_string_including("MetricSuggester failed"))
+        described_class.call(draft: draft) rescue Evaluation::NoMetricsError
+        expect(Evaluation::MetricSuggester).not_to have_received(:call)
       end
     end
 
     context "when Experiment.create! raises ActiveRecord::RecordInvalid" do
       let(:draft) do
         build_draft(
-          "prompt_id"       => prompt.id.to_s,
-          "experiment_name" => "Bad Eval",
-          "dataset_id"      => nil,
-          "sample_model"    => nil,
+          "prompt_id"        => prompt.id.to_s,
+          "experiment_name"  => "Bad Eval",
+          "dataset_id"       => nil,
+          "sample_model"     => nil,
           "evaluation_model" => nil
         )
       end


### PR DESCRIPTION
## Summary

- `CreateExperimentFromDraft` now raises `Evaluation::NoMetricsError` when no active metrics exist for the agent, instead of silently auto-generating them as a side effect
- `WizardForm#advance!` blocks progression from step 2 when the agent has no active metrics, returning `false` and adding a descriptive error message
- The wizard already surfaces a "Generate metrics with AI" button on step 2 — the guard ensures the user must act on it before proceeding

Closes #129

## Test plan
- [x] `CreateExperimentFromDraft` raises `Evaluation::NoMetricsError` when no active metrics exist
- [x] `WizardForm#advance!` from step 2 returns `false` with an error when no active metrics exist
- [x] `WizardForm#advance!` from step 2 returns `true` when active metrics exist
- [x] Request spec confirms step 2 POST with no active metrics returns 422 and keeps draft at step 2
- [x] Full wizard flow (steps 1–4) still works when active metrics exist
- [x] All 1854 existing tests pass, rubocop clean, steep passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=73, output=53107, cache_read=5454533, cache_write=99781