### PR TITLE
test: verify DatasetSample seeding paths for input and expected_tool_calls

### DIFF
--- a/spec/jobs/evaluation/synthetic_dataset_job_spec.rb
+++ b/spec/jobs/evaluation/synthetic_dataset_job_spec.rb
@@ -73,7 +73,9 @@ RSpec.describe Evaluation::SyntheticDatasetJob do
     it "leaves expected_tool_calls nil on created DatasetSamples" do
       described_class.perform_now(**params)
 
-      expect(Evaluation::DatasetSample.last(generated_inputs.size).map(&:expected_tool_calls)).to all(be_nil)
+      Evaluation::DatasetSample.last(generated_inputs.size).each do |sample|
+        expect(sample.expected_tool_calls).to be_nil
+      end
     end
 
     it "updates WizardDraft payload with complete status and dataset_id" do

--- a/spec/jobs/evaluation/synthetic_dataset_job_spec.rb
+++ b/spec/jobs/evaluation/synthetic_dataset_job_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Evaluation::SyntheticDatasetJob do
       expect(first_sample.input).to eq(generated_inputs.first)
     end
 
+    it "leaves expected_tool_calls nil on created DatasetSamples" do
+      described_class.perform_now(**params)
+
+      expect(Evaluation::DatasetSample.last(generated_inputs.size).map(&:expected_tool_calls)).to all(be_nil)
+    end
+
     it "updates WizardDraft payload with complete status and dataset_id" do
       described_class.perform_now(**params)
 

--- a/spec/services/evaluation/dataset_seeder_spec.rb
+++ b/spec/services/evaluation/dataset_seeder_spec.rb
@@ -34,6 +34,25 @@ RSpec.describe Evaluation::DatasetSeeder do
       expect(dataset.dataset_samples.first.source_run_id).to eq(action_run.id)
     end
 
+    it "copies input from the action run's input field" do
+      action_run = build_action_run
+      described_class.call(agent_name: agent_name, sample_size: 10)
+
+      sample = Evaluation::Dataset.find_by!(name: agent_name).dataset_samples.first
+      expect(sample.input).to eq(action_run.input)
+    end
+
+    it "stores expected_tool_calls extracted via ToolCallExtractor" do
+      tool_calls = [ { "tool_name" => "search", "arguments" => { "q" => "jobs" }, "result" => "ok" } ]
+      allow(Evaluation::ToolCallExtractor).to receive(:call).and_return(tool_calls)
+
+      build_action_run
+      described_class.call(agent_name: agent_name, sample_size: 10)
+
+      sample = Evaluation::Dataset.find_by!(name: agent_name).dataset_samples.first
+      expect(sample.expected_tool_calls).to eq(tool_calls)
+    end
+
     it "skips action runs with status other than completed" do
       build_action_run(status: "failed")
       described_class.call(agent_name: agent_name, sample_size: 10)


### PR DESCRIPTION
## Summary
- The `DatasetSeeder` and `SyntheticDatasetJob` implementations already produce `DatasetSample` rows correctly; `ToolStubRegistry` was never present
- Added spec asserting `DatasetSeeder` copies `input` from the `ActionRun` and stores `expected_tool_calls` via `ToolCallExtractor`
- Added spec asserting `SyntheticDatasetJob` leaves `expected_tool_calls` nil on all created samples

Closes #131

## Test plan
- [x] New tests covering both seeding paths pass (36 examples, 0 failures)
- [x] Existing specs still pass
- [x] Linting passes (rubocop: no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=19, output=9679, cache_read=579592, cache_write=33115