### PR TITLE
feat: configure mutation testing CI job for high-logic subsystems

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+env:
+  MUTATION_SCORE_THRESHOLD: "90.0"
+
 jobs:
   mutation:
     name: Mutation Testing
@@ -28,15 +31,18 @@ jobs:
 
       - name: Run mutation testing
         run: |
+          # Run only the focused high-logic subjects; positional args override .mutant.yml matcher.
           bundle exec mutant run --jobs 4 \
             'Orchestration::PipelineRunner' \
             'Orchestration::NormalizeActionRunFailure' \
             'Orchestration::IngestionExecutor' \
-            'Orchestration::InputMappingResolver' | tee mutant_output.txt || true
-          score=$(grep "Coverage:" mutant_output.txt | grep -oE '[0-9]+\.[0-9]+')
+            'Orchestration::InputMappingResolver' 2>&1 | tee mutant_output.txt || true
+          score=$(grep "Coverage:" mutant_output.txt | tail -1 | grep -oE '[0-9]+(\.[0-9]+)?')
           echo "Mutation score: ${score}%"
           if [ -z "$score" ]; then
             echo "::error::Could not parse mutation score from output"
             exit 1
           fi
-          awk -v s="$score" 'BEGIN { if (s+0 < 90.0) { print "::error::Mutation score " s "% is below the 90% minimum threshold"; exit 1 } }'
+          awk -v s="$score" -v t="$MUTATION_SCORE_THRESHOLD" \
+            'BEGIN { if (s+0 < t+0) { print "::error::Mutation score " s "% is below the " t "% minimum threshold"; exit 1 } }' \
+            || exit 1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,42 @@
+name: Mutation Testing (Nightly)
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  mutation:
+    name: Mutation Testing
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libsqlite3-dev
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Set up database
+        run: bundle exec rails db:schema:load
+
+      - name: Run mutation testing
+        run: |
+          bundle exec mutant run --jobs 4 \
+            'Orchestration::PipelineRunner' \
+            'Orchestration::NormalizeActionRunFailure' \
+            'Orchestration::IngestionExecutor' \
+            'Orchestration::InputMappingResolver' | tee mutant_output.txt || true
+          score=$(grep "Coverage:" mutant_output.txt | grep -oE '[0-9]+\.[0-9]+')
+          echo "Mutation score: ${score}%"
+          if [ -z "$score" ]; then
+            echo "::error::Could not parse mutation score from output"
+            exit 1
+          fi
+          awk -v s="$score" 'BEGIN { if (s+0 < 90.0) { print "::error::Mutation score " s "% is below the 90% minimum threshold"; exit 1 } }'

--- a/.mutant.yml
+++ b/.mutant.yml
@@ -1,6 +1,8 @@
 integration: rspec
 usage: opensource
 jobs: 2
+# Minimum mutation score threshold: 90% (enforced in .github/workflows/mutation.yml for focused subjects)
+# Raise this after establishing a stable baseline.
 includes:
   - app/agents
   - app/controllers
@@ -35,3 +37,18 @@ matcher:
     - Emails::Adapters::GmailMessageParser
     - Emails::Adapters::YahooMessageParser
     - Emails::GmailAuth
+    # AI classifier classes: LLM-boundary mutations produce noise, not signal
+    - Emails::ClassifyAgent
+    - Emails::ClassifyTool
+    # Controllers: UI routing layer, low mutation testing value
+    - ApplicationController
+    - ApplicationMailsController
+    - InterviewsController
+    - Orchestration::ActionsController
+    - Orchestration::AgentsController
+    - Orchestration::AllPipelineRunsController
+    - Orchestration::PipelineRunsController
+    - Orchestration::PipelinesController
+    - Orchestration::SchemaBuildersController
+    - Orchestration::StepActionsController
+    - Orchestration::StepsController

--- a/.mutant.yml
+++ b/.mutant.yml
@@ -1,8 +1,8 @@
 integration: rspec
 usage: opensource
 jobs: 2
-# Minimum mutation score threshold: 90% (enforced in .github/workflows/mutation.yml for focused subjects)
-# Raise this after establishing a stable baseline.
+# Minimum mutation score threshold: 90% (MUTATION_SCORE_THRESHOLD in .github/workflows/mutation.yml)
+# Raise MUTATION_SCORE_THRESHOLD after establishing a stable baseline.
 includes:
   - app/agents
   - app/controllers

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,10 @@ end
 group :development do
   gem "mutant", require: false
   gem "mutant-rspec", require: false
+  # parser 3.x does not yet support Ruby 4.0 — emits a parser/current warning on every mutant run.
+  # Upgrade parser to 4.x once upstream releases Ruby 4.0 support:
+  # https://github.com/whitequark/parser#compatibility-with-ruby-mri
+  gem "parser", require: false
   gem "rubycritic", require: false
   gem "brakeman", require: false
   gem "rubocop", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -58,9 +58,9 @@ group :development do
   gem "mutant", require: false
   gem "mutant-rspec", require: false
   # parser 3.x does not yet support Ruby 4.0 — emits a parser/current warning on every mutant run.
-  # Upgrade parser to 4.x once upstream releases Ruby 4.0 support:
+  # Upgrade to 4.x once upstream releases Ruby 4.0 support:
   # https://github.com/whitequark/parser#compatibility-with-ruby-mri
-  gem "parser", require: false
+  gem "parser", "~> 3.3", require: false
   gem "rubycritic", require: false
   gem "brakeman", require: false
   gem "rubocop", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -728,7 +728,7 @@ DEPENDENCIES
   mutant-rspec
   net-imap (~> 0.4)
   pagy
-  parser
+  parser (~> 3.3)
   propshaft
   pry
   pry-nav

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -728,6 +728,7 @@ DEPENDENCIES
   mutant-rspec
   net-imap (~> 0.4)
   pagy
+  parser
   propshaft
   pry
   pry-nav


### PR DESCRIPTION
## Summary
- Add nightly `mutation.yml` workflow targeting `Orchestration::PipelineRunner`, `NormalizeActionRunFailure`, `IngestionExecutor`, `InputMappingResolver` with a 90% coverage threshold
- Exclude controllers and AI classifier classes (`Emails::ClassifyAgent`, `Emails::ClassifyTool`) from `.mutant.yml` — low mutation-testing value
- Pin `parser` gem explicitly with comment tracking Ruby 4.0 compatibility warning for future upgrade

Closes #114

## Test plan
- [ ] Relevant new tests pass
- [ ] Existing relevant tests still pass
- [ ] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=632, output=25878, cache_read=3771460, cache_write=55979