### PR TITLE
fix: mutation score parsed from SimpleCov line coverage instead of mutant

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,7 +37,7 @@ jobs:
             'Orchestration::NormalizeActionRunFailure' \
             'Orchestration::IngestionExecutor' \
             'Orchestration::InputMappingResolver' 2>&1 | tee mutant_output.txt || true
-          score=$(grep "Coverage:" mutant_output.txt | tail -1 | grep -oE '[0-9]+(\.[0-9]+)?')
+          score=$(grep "Coverage:" mutant_output.txt | grep -v "Line Coverage" | grep -oE '[0-9]+(\.[0-9]+)?%' | tr -d '%')
           echo "Mutation score: ${score}%"
           if [ -z "$score" ]; then
             echo "::error::Could not parse mutation score from output"


### PR DESCRIPTION
## Summary

- `grep "Coverage:"` matched both mutant's `Coverage: 95.15%` and SimpleCov's `Line Coverage: 42.44%`
- `tail -1` picked SimpleCov's line (last in file), causing the threshold check to fail against 42% instead of 95%
- Fix: add `grep -v "Line Coverage"` to exclude SimpleCov output, and tighten extraction to match only the `%`-suffixed token

## Test plan

- [ ] Trigger the nightly workflow via `workflow_dispatch` and verify the score is parsed from mutant's `Coverage:` line (95%+)
- [ ] Confirm no regression: `grep "Coverage:" mutant_output.txt | grep -v "Line Coverage" | grep -oE '[0-9]+(\.[0-9]+)?%' | tr -d '%'` returns a single number on sample output

🤖 Generated with [Claude Code](https://claude.com/claude-code)