### PR TITLE
feat: remove runner_class, evaluator_classes, and legacy runner infrastructure

### DIFF
--- a/app/jobs/evaluation/evaluation_job.rb
+++ b/app/jobs/evaluation/evaluation_job.rb
@@ -4,8 +4,6 @@ module Evaluation
   class EvaluationJob < ApplicationJob
     queue_as :default
 
-    ALLOWED_EVALUATORS = %w[Evaluation::Evaluators::LLMJudgeEval].freeze
-
     retry_on RubyLLM::Error, attempts: 3 do |job, _error|
       experiment = Evaluation::Experiment.find_by(id: job.arguments[0])
       next unless experiment
@@ -17,7 +15,7 @@ module Evaluation
       experiment = Evaluation::Experiment.find(experiment_id)
       sample = Evaluation::Sample.find(sample_id)
 
-      evaluators_for(experiment).each { |e| e.evaluate_and_store(experiment, sample) }
+      Evaluation::Evaluators::LLMJudgeEval.new.evaluate_and_store(experiment, sample)
 
       decrement_and_maybe_complete(experiment)
     end
@@ -26,16 +24,6 @@ module Evaluation
       experiment.with_lock do
         experiment.decrement!(:pending_evaluations_count)
         experiment.complete! if experiment.pending_evaluations_count.zero? && experiment.may_complete?
-      end
-    end
-
-    private
-
-    def evaluators_for(experiment)
-      experiment.evaluator_classes.compact.reject(&:empty?).map do |klass|
-        raise ArgumentError, "Unrecognised evaluator class: #{klass}" unless ALLOWED_EVALUATORS.include?(klass)
-
-        klass.constantize.new
       end
     end
   end

--- a/app/jobs/evaluation/prompt_auto_eval_job.rb
+++ b/app/jobs/evaluation/prompt_auto_eval_job.rb
@@ -21,7 +21,6 @@ module Evaluation
         name: "Auto-eval for #{prompt.name} v#{prompt.version}",
         dataset: previous_experiment.dataset,
         prompt: prompt,
-        evaluator_classes: [ "Evaluation::Evaluators::LLMJudgeEval" ],
         metadata: { triggered_by: "prompt_change" }
       )
 

--- a/app/models/evaluation/experiment.rb
+++ b/app/models/evaluation/experiment.rb
@@ -9,9 +9,8 @@ module Evaluation
     has_many :samples, class_name: "Evaluation::Sample", dependent: :destroy
     has_many :evaluation_results, through: :samples, class_name: "Evaluation::EvaluationResult"
 
-    validates :name, :dataset, :evaluator_classes, presence: true
+    validates :name, :dataset, presence: true
 
-    serialize :evaluator_classes, coder: JSON, type: Array
     serialize :metadata, coder: JSON
 
     aasm column: :status do

--- a/app/services/evaluation/create_experiment_from_draft.rb
+++ b/app/services/evaluation/create_experiment_from_draft.rb
@@ -44,13 +44,12 @@ module Evaluation
 
     def create_experiment!
       Experiment.create!(
-        name:              payload["experiment_name"].presence || "Manual eval",
-        dataset_id:        payload["dataset_id"],
-        prompt_id:         @prompt_id,
-        evaluator_classes: [ "Evaluation::Evaluators::LLMJudgeEval" ],
-        metadata:          { "triggered_by" => "manual" },
-        sample_model:      payload["sample_model"].presence,
-        evaluation_model:  payload["evaluation_model"].presence
+        name:             payload["experiment_name"].presence || "Manual eval",
+        dataset_id:       payload["dataset_id"],
+        prompt_id:        @prompt_id,
+        metadata:         { "triggered_by" => "manual" },
+        sample_model:     payload["sample_model"].presence,
+        evaluation_model: payload["evaluation_model"].presence
       )
     end
   end

--- a/db/migrate/20260523080923_drop_runner_class_and_evaluator_classes_from_experiments.rb
+++ b/db/migrate/20260523080923_drop_runner_class_and_evaluator_classes_from_experiments.rb
@@ -1,0 +1,6 @@
+class DropRunnerClassAndEvaluatorClassesFromExperiments < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :evaluation_experiments, :runner_class, :string
+    remove_column :evaluation_experiments, :evaluator_classes, :text
+  end
+end

--- a/db/queue_structure.sql
+++ b/db/queue_structure.sql
@@ -1,5 +1,5 @@
-CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
 CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
 CREATE TABLE IF NOT EXISTS "solid_queue_jobs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "queue_name" varchar NOT NULL, "class_name" varchar NOT NULL, "arguments" text, "priority" integer DEFAULT 0 NOT NULL, "active_job_id" varchar, "scheduled_at" datetime(6), "finished_at" datetime(6), "concurrency_key" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE INDEX "index_solid_queue_jobs_on_active_job_id" ON "solid_queue_jobs" ("active_job_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_solid_queue_jobs_on_class_name" ON "solid_queue_jobs" ("class_name") /*application='ApplicationPipeline'*/;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -139,16 +139,17 @@ FOREIGN KEY ("sample_id")
 CREATE INDEX "index_evaluation_evaluation_results_on_experiment_id" ON "evaluation_evaluation_results" ("experiment_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_evaluation_evaluation_results_on_dataset_sample_id" ON "evaluation_evaluation_results" ("dataset_sample_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_evaluation_evaluation_results_on_sample_id" ON "evaluation_evaluation_results" ("sample_id") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "evaluation_experiments" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "description" text, "dataset_id" integer NOT NULL, "prompt_id" integer, "metadata" text, "runner_class" varchar, "evaluator_classes" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "sample_model" varchar, "evaluation_model" varchar, "status" varchar DEFAULT 'pending' NOT NULL /*application='ApplicationPipeline'*/, "pending_samples_count" integer DEFAULT 0 NOT NULL /*application='ApplicationPipeline'*/, "pending_evaluations_count" integer DEFAULT 0 NOT NULL /*application='ApplicationPipeline'*/, CONSTRAINT "fk_rails_84b997d884"
-FOREIGN KEY ("prompt_id")
-  REFERENCES "evaluation_prompts" ("id")
-, CONSTRAINT "fk_rails_8dce28380f"
+CREATE TABLE IF NOT EXISTS "evaluation_experiments" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "description" text, "dataset_id" integer NOT NULL, "prompt_id" integer, "metadata" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "sample_model" varchar, "evaluation_model" varchar, "status" varchar DEFAULT 'pending' NOT NULL, "pending_samples_count" integer DEFAULT 0 NOT NULL, "pending_evaluations_count" integer DEFAULT 0 NOT NULL, CONSTRAINT "fk_rails_8dce28380f"
 FOREIGN KEY ("dataset_id")
   REFERENCES "evaluation_datasets" ("id")
+, CONSTRAINT "fk_rails_84b997d884"
+FOREIGN KEY ("prompt_id")
+  REFERENCES "evaluation_prompts" ("id")
 );
 CREATE INDEX "index_evaluation_experiments_on_prompt_id" ON "evaluation_experiments" ("prompt_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_evaluation_experiments_on_dataset_id" ON "evaluation_experiments" ("dataset_id") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260523080923'),
 ('20260522000001'),
 ('20260521000005'),
 ('20260521000004'),

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -111,8 +111,6 @@ namespace :evaluation do
       name: "#{agent_name} eval w/ #{model_label} (#{Date.today})",
       dataset: dataset,
       prompt: prompt,
-      runner_class: "Evaluation::Sampler",
-      evaluator_classes: [ "Evaluation::Evaluators::LLMJudgeEval" ],
       metadata: args[:model].presence ? { "pipeline_model" => args[:model] } : nil
     )
 
@@ -142,7 +140,6 @@ namespace :evaluation do
         name: "#{agent_name} eval w/ #{model_label} (#{Date.today})",
         dataset: dataset,
         prompt: prompt,
-        evaluator_classes: [ "LLMJudgeEval" ],
         metadata: model ? { "pipeline_model" => model } : nil
       )
 

--- a/sig/app/jobs/evaluation/evaluation_job.rbs
+++ b/sig/app/jobs/evaluation/evaluation_job.rbs
@@ -2,9 +2,5 @@ module Evaluation
   class EvaluationJob < ApplicationJob
     def perform: (Integer experiment_id, Integer sample_id) -> void
     def decrement_and_maybe_complete: (Evaluation::Experiment experiment) -> void
-
-    private
-
-    def evaluators_for: (Evaluation::Experiment experiment) -> Array[untyped]
   end
 end

--- a/sig/app/models/evaluation/experiment.rbs
+++ b/sig/app/models/evaluation/experiment.rbs
@@ -14,10 +14,6 @@ module Evaluation
     def name: () -> String?
     def name=: (String?) -> String?
     def description: () -> String?
-    def runner_class: () -> String?
-    def runner_class=: (String?) -> String?
-    def evaluator_classes: () -> Array[String]
-    def evaluator_classes=: (Array[String]) -> Array[String]
     def metadata: () -> Hash[String, untyped]?
     def metadata=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def status: () -> String

--- a/spec/factories/leva.rb
+++ b/spec/factories/leva.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
   factory :evaluation_experiment, class: "Evaluation::Experiment" do
     sequence(:name) { |n| "experiment_#{n}" }
     status { :pending }
-    evaluator_classes { [ "Evaluation::Evaluators::LLMJudgeEval" ] }
     association :dataset, factory: :evaluation_dataset
     association :prompt, factory: :orchestration_prompt
   end

--- a/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
+++ b/spec/jobs/evaluation/prompt_auto_eval_job_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
     create(:evaluation_experiment,
       prompt: previous_prompt,
       dataset: dataset,
-      status: :completed,
-      evaluator_classes: [ "Evaluation::Evaluators::LLMJudgeEval" ])
+      status: :completed)
   end
   let(:new_prompt) { create(:orchestration_prompt, name: agent_name) }
 
@@ -27,12 +26,6 @@ RSpec.describe Evaluation::PromptAutoEvalJob do
       described_class.perform_now(prompt_id: new_prompt.id)
       new_exp = Evaluation::Experiment.where(prompt: new_prompt).first
       expect(new_exp.dataset).to eq(dataset)
-    end
-
-    it "sets evaluator_classes on the new experiment" do
-      described_class.perform_now(prompt_id: new_prompt.id)
-      new_exp = Evaluation::Experiment.where(prompt: new_prompt).first
-      expect(new_exp.evaluator_classes).to eq([ "Evaluation::Evaluators::LLMJudgeEval" ])
     end
 
     it "tags the experiment metadata with triggered_by: prompt_change" do

--- a/spec/lib/evaluation/evaluators/llm_judge_eval_spec.rb
+++ b/spec/lib/evaluation/evaluators/llm_judge_eval_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Evaluation::Evaluators::LLMJudgeEval do
   describe "#evaluate_and_store" do
     let!(:evaluation_prompt) { Evaluation::Prompt.create!(name: agent_name, system_prompt: "You are a classifier.", user_prompt: "Classify: {{input}}") }
     let!(:evaluation_dataset) { Evaluation::Dataset.create!(name: "test_dataset") }
-    let!(:evaluation_experiment) { Evaluation::Experiment.create!(name: "test_exp", dataset: evaluation_dataset, status: :pending, prompt: evaluation_prompt, evaluator_classes: [ "Evaluation::Evaluators::LLMJudgeEval" ]) }
+    let!(:evaluation_experiment) { Evaluation::Experiment.create!(name: "test_exp", dataset: evaluation_dataset, status: :pending, prompt: evaluation_prompt) }
     let!(:evaluation_dataset_sample) { Evaluation::DatasetSample.create!(dataset: evaluation_dataset, input: { "email" => "test" }) }
     let!(:evaluation_sample) do
       Evaluation::Sample.create!(

--- a/spec/models/evaluation/experiment_spec.rb
+++ b/spec/models/evaluation/experiment_spec.rb
@@ -3,6 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Evaluation::Experiment do
+  describe "schema" do
+    it "does not have a runner_class column" do
+      expect(described_class.column_names).not_to include("runner_class")
+    end
+
+    it "does not have an evaluator_classes column" do
+      expect(described_class.column_names).not_to include("evaluator_classes")
+    end
+  end
+
   describe "AASM state machine" do
     subject(:experiment) { create(:evaluation_experiment, status: "pending") }
 

--- a/spec/tasks/evaluation_run_spec.rb
+++ b/spec/tasks/evaluation_run_spec.rb
@@ -19,11 +19,6 @@ RSpec.describe "evaluation:run rake task" do # rubocop:disable RSpec/DescribeCla
         .to change(Evaluation::Experiment, :count).by(1)
     end
 
-    it "sets evaluator_classes to Evaluation::Evaluators::LLMJudgeEval" do
-      Rake::Task[task_name].invoke(agent_name, nil)
-      expect(Evaluation::Experiment.last.evaluator_classes).to eq([ "Evaluation::Evaluators::LLMJudgeEval" ])
-    end
-
     it "links the experiment to the active prompt" do
       Rake::Task[task_name].invoke(agent_name, nil)
       expect(Evaluation::Experiment.last.prompt_id).to eq(prompt.id)


### PR DESCRIPTION
## Summary
- Drop `runner_class` and `evaluator_classes` columns from `evaluation_experiments` via migration
- Hardcode `LLMJudgeEval` in `EvaluationJob` instead of reading from the now-removed column
- Remove all references from model validation/serialization, rake tasks, jobs, services, wizard, and RBS signatures
- `ToolCallExtractor` retained — still used by `DatasetSeeder`; `RunEvalJob` was already absent

Closes #133

## Test plan
- [x] Schema tests assert columns no longer exist on `evaluation_experiments`
- [x] All 1905 existing specs pass
- [x] Rubocop clean
- [x] RBS signatures validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=74, output=17930, cache_read=3580885, cache_write=60204