### PR TITLE
refactor: extract Orchestration::UpstreamSchemaIndex

### DIFF
--- a/app/components/orchestration/steps_list_component.rb
+++ b/app/components/orchestration/steps_list_component.rb
@@ -14,13 +14,11 @@ module Orchestration
     private
 
     def derive_upstream_schemas_per_step
+      last_schemas = { "_initial" => @pipeline.initial_input_schema }
       @steps.each_with_object({}) do |step, result|
         first_action = step.step_actions.min_by(&:position)
-        result[step.id] = if first_action
-          @index.schemas_before(first_action)
-        else
-          { "_initial" => @pipeline.initial_input_schema }
-        end
+        last_schemas = @index.schemas_before(first_action) if first_action
+        result[step.id] = last_schemas
       end
     end
 

--- a/app/components/orchestration/steps_list_component.rb
+++ b/app/components/orchestration/steps_list_component.rb
@@ -2,28 +2,30 @@
 
 module Orchestration
   class StepsListComponent < ViewComponent::Base
-    def initialize(pipeline:, steps:, actions:)
+    def initialize(pipeline:, steps:, actions:, index:)
       @pipeline = pipeline
       @steps    = steps
       @actions  = actions
-      @upstream_schemas_per_step  = compute_upstream_schemas_per_step
+      @index    = index
+      @upstream_schemas_per_step  = derive_upstream_schemas_per_step
       @validator_results_per_step = compute_validator_results_per_step
     end
 
     private
 
-    def compute_upstream_schemas_per_step
-      seen = { "_initial" => @pipeline.initial_input_schema }
+    def derive_upstream_schemas_per_step
       @steps.each_with_object({}) do |step, result|
-        result[step.id] = seen.dup
-        step.step_actions.sort_by(&:position).each do |sa|
-          seen[sa.output_key] = sa.action.agent&.output_schema
+        first_action = step.step_actions.min_by(&:position)
+        result[step.id] = if first_action
+          @index.schemas_before(first_action)
+        else
+          { "_initial" => @pipeline.initial_input_schema }
         end
       end
     end
 
     def compute_validator_results_per_step
-      all_results = @pipeline.validate_steps
+      all_results = @pipeline.validate_steps(index: @index)
       step_action_id_to_step_id = @steps.each_with_object({}) do |step, map|
         step.step_actions.each { |sa| map[sa.id] = step.id }
       end

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -29,6 +29,7 @@ module Orchestration
       @steps = @pipeline.steps.includes(step_actions: { action: :agent })
       @actions = Orchestration::Action.order(:name)
       @latest_run = @pipeline.pipeline_runs.order(created_at: :desc).first
+      @index = Orchestration::UpstreamSchemaIndex.build(@pipeline)
     end
 
     def run

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -29,7 +29,7 @@ module Orchestration
       @steps = @pipeline.steps.includes(step_actions: { action: :agent })
       @actions = Orchestration::Action.order(:name)
       @latest_run = @pipeline.pipeline_runs.order(created_at: :desc).first
-      @index = Orchestration::UpstreamSchemaIndex.build(@pipeline)
+      @index = Orchestration::UpstreamSchemaIndex.build_from_steps(@pipeline, @steps)
     end
 
     def run

--- a/app/models/orchestration/pipeline.rb
+++ b/app/models/orchestration/pipeline.rb
@@ -8,8 +8,8 @@ module Orchestration
     validates :name, presence: true
     validate :cron_expression_parseable, if: -> { cron_expression.present? }
 
-    def validate_steps
-      Pipeline::Validator.call(self)
+    def validate_steps(index: nil)
+      Pipeline::Validator.call(self, index:)
     end
 
     def next_run_at(from: Time.current)

--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -4,21 +4,24 @@ module Orchestration
       Issue = Data.define(:code, :message, :mapping_key, :from, :path)
       StepResult = Data.define(:step_action_id, :output_key, :errors, :warnings)
 
-      def self.call(pipeline) = new(pipeline).call
+      def self.call(pipeline, index: nil)
+        index ||= UpstreamSchemaIndex.build(pipeline)
+        new(pipeline, index).call
+      end
 
-      def initialize(pipeline)
+      def initialize(pipeline, index)
         @pipeline = pipeline
+        @index    = index
       end
 
       def call
-        known_schemas = { "_initial" => @pipeline.initial_input_schema }
         results = [] # : Array[StepResult]
 
         ordered_step_actions.each do |sa|
           errors   = [] # : Array[Issue]
           warnings = [] # : Array[Issue]
 
-          validate_input_mapping(sa, known_schemas, errors, warnings)
+          validate_input_mapping(sa, @index.schemas_before(sa), errors, warnings)
 
           results << StepResult.new(
             step_action_id: sa.id,
@@ -26,8 +29,6 @@ module Orchestration
             errors: errors,
             warnings: warnings
           )
-
-          known_schemas[sa.output_key] = sa.action.agent&.output_schema
         end
 
         results
@@ -36,7 +37,7 @@ module Orchestration
       private
 
       def ordered_step_actions
-        @pipeline.steps.includes(step_actions: { action: :agent }).flat_map do |step|
+        @pipeline.steps.flat_map do |step|
           step.step_actions.sort_by(&:position)
         end
       end

--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -36,6 +36,7 @@ module Orchestration
 
       private
 
+      # step_actions/action associations must already be preloaded (e.g. via UpstreamSchemaIndex.build)
       def ordered_step_actions
         @pipeline.steps.flat_map do |step|
           step.step_actions.sort_by(&:position)

--- a/app/services/orchestration/upstream_schema_index.rb
+++ b/app/services/orchestration/upstream_schema_index.rb
@@ -1,10 +1,14 @@
 module Orchestration
   class UpstreamSchemaIndex
     def self.build(pipeline)
-      accumulator = { "_initial" => pipeline.initial_input_schema }
-      index = {}
+      build_from_steps(pipeline, pipeline.steps.includes(step_actions: { action: :agent }))
+    end
 
-      pipeline.steps.includes(step_actions: { action: :agent }).each do |step|
+    def self.build_from_steps(pipeline, steps)
+      accumulator = { "_initial" => pipeline.initial_input_schema }
+      index = {} # : Hash[Integer, Hash[String, untyped]]
+
+      steps.each do |step|
         step.step_actions.sort_by(&:position).each do |sa|
           index[sa.id] = accumulator.dup
           accumulator[sa.output_key] = sa.action.agent&.output_schema
@@ -19,7 +23,8 @@ module Orchestration
     end
 
     def schemas_before(step_action)
-      @index.fetch(step_action.id, { "_initial" => nil })
+      not_found = {} # : Hash[String, untyped]
+      @index.fetch(step_action.id, not_found)
     end
   end
 end

--- a/app/services/orchestration/upstream_schema_index.rb
+++ b/app/services/orchestration/upstream_schema_index.rb
@@ -1,0 +1,25 @@
+module Orchestration
+  class UpstreamSchemaIndex
+    def self.build(pipeline)
+      accumulator = { "_initial" => pipeline.initial_input_schema }
+      index = {}
+
+      pipeline.steps.includes(step_actions: { action: :agent }).each do |step|
+        step.step_actions.sort_by(&:position).each do |sa|
+          index[sa.id] = accumulator.dup
+          accumulator[sa.output_key] = sa.action.agent&.output_schema
+        end
+      end
+
+      new(index)
+    end
+
+    def initialize(index)
+      @index = index
+    end
+
+    def schemas_before(step_action)
+      @index.fetch(step_action.id, { "_initial" => nil })
+    end
+  end
+end

--- a/app/views/orchestration/pipelines/show.html.erb
+++ b/app/views/orchestration/pipelines/show.html.erb
@@ -86,7 +86,8 @@
           <%= render Orchestration::StepsListComponent.new(
                 pipeline: @pipeline,
                 steps: @steps,
-                actions: @actions
+                actions: @actions,
+                index: @index
               ) %>
         </div>
       <% end %>

--- a/sig/app/components/orchestration/steps_list_component.rbs
+++ b/sig/app/components/orchestration/steps_list_component.rbs
@@ -1,5 +1,5 @@
 module Orchestration
   class StepsListComponent < ViewComponent::Base
-    def initialize: (pipeline: Pipeline, steps: untyped, actions: untyped) -> void
+    def initialize: (pipeline: Pipeline, steps: untyped, actions: untyped, index: Orchestration::UpstreamSchemaIndex) -> void
   end
 end

--- a/sig/app/models/orchestration/pipeline.rbs
+++ b/sig/app/models/orchestration/pipeline.rbs
@@ -15,7 +15,7 @@ module Orchestration
     def initial_input_schema: () -> Hash[String, untyped]?
     def initial_input_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
 
-    def validate_steps: () -> Array[Pipeline::Validator::StepResult]
+    def validate_steps: (?index: Orchestration::UpstreamSchemaIndex?) -> Array[Pipeline::Validator::StepResult]
 
     def next_run_at: (?from: Time) -> Time?
 

--- a/sig/app/services/orchestration/pipeline/validator.rbs
+++ b/sig/app/services/orchestration/pipeline/validator.rbs
@@ -18,9 +18,9 @@ module Orchestration
         attr_reader warnings: Array[Issue]
       end
 
-      def self.call: (Orchestration::Pipeline pipeline) -> Array[StepResult]
+      def self.call: (Orchestration::Pipeline pipeline, ?index: Orchestration::UpstreamSchemaIndex?) -> Array[StepResult]
 
-      def initialize: (Orchestration::Pipeline pipeline) -> void
+      def initialize: (Orchestration::Pipeline pipeline, Orchestration::UpstreamSchemaIndex index) -> void
       def call: () -> Array[StepResult]
 
       private

--- a/sig/app/services/orchestration/upstream_schema_index.rbs
+++ b/sig/app/services/orchestration/upstream_schema_index.rbs
@@ -1,0 +1,9 @@
+module Orchestration
+  class UpstreamSchemaIndex
+    def self.build: (Orchestration::Pipeline pipeline) -> UpstreamSchemaIndex
+
+    def initialize: (Hash[Integer, Hash[String, untyped]] index) -> void
+
+    def schemas_before: (Orchestration::StepAction step_action) -> Hash[String, untyped]
+  end
+end

--- a/sig/app/services/orchestration/upstream_schema_index.rbs
+++ b/sig/app/services/orchestration/upstream_schema_index.rbs
@@ -2,6 +2,8 @@ module Orchestration
   class UpstreamSchemaIndex
     def self.build: (Orchestration::Pipeline pipeline) -> UpstreamSchemaIndex
 
+    def self.build_from_steps: (Orchestration::Pipeline pipeline, untyped steps) -> UpstreamSchemaIndex
+
     def initialize: (Hash[Integer, Hash[String, untyped]] index) -> void
 
     def schemas_before: (Orchestration::StepAction step_action) -> Hash[String, untyped]

--- a/spec/components/previews/orchestration/steps_list_component_preview.rb
+++ b/spec/components/previews/orchestration/steps_list_component_preview.rb
@@ -6,11 +6,13 @@ module Orchestration
       pipeline = Orchestration::Pipeline.new(id: 1, name: "Demo Pipeline", initial_input_schema: {})
       steps    = []
       actions  = Orchestration::Action.none
+      index    = Orchestration::UpstreamSchemaIndex.new({})
 
       render(Orchestration::StepsListComponent.new(
         pipeline: pipeline,
         steps:    steps,
-        actions:  actions
+        actions:  actions,
+        index:    index
       ))
     end
   end

--- a/spec/models/orchestration/pipeline_spec.rb
+++ b/spec/models/orchestration/pipeline_spec.rb
@@ -63,10 +63,10 @@ RSpec.describe Orchestration::Pipeline do
     it 'delegates to Pipeline::Validator.call' do
       pipeline = build(:orchestration_pipeline)
       fake_results = []
-      allow(Orchestration::Pipeline::Validator).to receive(:call).with(pipeline).and_return(fake_results)
+      allow(Orchestration::Pipeline::Validator).to receive(:call).with(pipeline, index: nil).and_return(fake_results)
 
       expect(pipeline.validate_steps).to eq(fake_results)
-      expect(Orchestration::Pipeline::Validator).to have_received(:call).with(pipeline)
+      expect(Orchestration::Pipeline::Validator).to have_received(:call).with(pipeline, index: nil)
     end
 
     it 'returns an array of StepResult objects for a pipeline with steps' do

--- a/spec/services/orchestration/pipeline/validator_spec.rb
+++ b/spec/services/orchestration/pipeline/validator_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Orchestration::Pipeline::Validator do
-  subject(:validator) { described_class.new(pipeline) }
-
   let(:pipeline) { create(:orchestration_pipeline) }
   let(:step)     { create(:orchestration_step, pipeline: pipeline, position: 1) }
+  let(:index)    { Orchestration::UpstreamSchemaIndex.build(pipeline) }
+
+  subject(:validator) { described_class.new(pipeline, index) }
 
   describe '.call' do
     it 'delegates to an instance and returns results' do

--- a/spec/services/orchestration/pipeline/validator_spec.rb
+++ b/spec/services/orchestration/pipeline/validator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Orchestration::Pipeline::Validator do
+  subject(:validator) { described_class.new(pipeline, index) }
+
   let(:pipeline) { create(:orchestration_pipeline) }
   let(:step)     { create(:orchestration_step, pipeline: pipeline, position: 1) }
   let(:index)    { Orchestration::UpstreamSchemaIndex.build(pipeline) }
-
-  subject(:validator) { described_class.new(pipeline, index) }
 
   describe '.call' do
     it 'delegates to an instance and returns results' do

--- a/spec/services/orchestration/upstream_schema_index_spec.rb
+++ b/spec/services/orchestration/upstream_schema_index_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe Orchestration::UpstreamSchemaIndex do
       expect(schemas["fetch"]).to eq(agent1.output_schema)
     end
 
-    it "returns a fallback for an unknown step action" do
+    it "returns an empty hash for an unknown step action" do
       unknown_sa = build_stubbed(:orchestration_step_action, id: 9999)
       schemas = index.schemas_before(unknown_sa)
-      expect(schemas).to eq({ "_initial" => nil })
+      expect(schemas).to eq({})
     end
 
     context "with multiple step actions in the same step" do

--- a/spec/services/orchestration/upstream_schema_index_spec.rb
+++ b/spec/services/orchestration/upstream_schema_index_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Orchestration::UpstreamSchemaIndex do
+  let(:pipeline) { create(:orchestration_pipeline, initial_input_schema: { "type" => "object", "properties" => { "date" => { "type" => "string" } } }) }
+  let(:step1)    { create(:orchestration_step, pipeline: pipeline, position: 1) }
+  let(:step2)    { create(:orchestration_step, pipeline: pipeline, position: 2) }
+
+  let(:agent1) { create(:orchestration_agent, output_schema: { "type" => "object", "properties" => { "result" => { "type" => "string" } } }) }
+  let(:action1) { create(:orchestration_action, agent: agent1) }
+  let(:sa1) { create(:orchestration_step_action, step: step1, position: 1, output_key: "fetch", action: action1) }
+
+  let(:agent2) { create(:orchestration_agent, output_schema: { "type" => "object", "properties" => { "label" => { "type" => "string" } } }) }
+  let(:action2) { create(:orchestration_action, agent: agent2) }
+  let(:sa2) { create(:orchestration_step_action, step: step2, position: 1, output_key: "classify", action: action2) }
+
+  describe ".build" do
+    before { sa1; sa2 }
+
+    it "returns an UpstreamSchemaIndex instance" do
+      expect(described_class.build(pipeline)).to be_a(described_class)
+    end
+  end
+
+  describe "#schemas_before" do
+    subject(:index) { described_class.build(pipeline) }
+
+    before { sa1; sa2 }
+
+    it "returns only _initial for the first step action" do
+      schemas = index.schemas_before(sa1)
+      expect(schemas.keys).to eq(["_initial"])
+      expect(schemas["_initial"]).to eq(pipeline.initial_input_schema)
+    end
+
+    it "returns _initial and the first step action output for the second step action" do
+      schemas = index.schemas_before(sa2)
+      expect(schemas.keys).to contain_exactly("_initial", "fetch")
+      expect(schemas["fetch"]).to eq(agent1.output_schema)
+    end
+
+    it "returns a fallback for an unknown step action" do
+      unknown_sa = build_stubbed(:orchestration_step_action, id: 9999)
+      schemas = index.schemas_before(unknown_sa)
+      expect(schemas).to eq({ "_initial" => nil })
+    end
+
+    context "with multiple step actions in the same step" do
+      let(:sa1b) { create(:orchestration_step_action, step: step1, position: 2, output_key: "enrich") }
+
+      before { sa1b }
+
+      it "sa1b sees only _initial and fetch before it" do
+        schemas = index.schemas_before(sa1b)
+        expect(schemas.keys).to contain_exactly("_initial", "fetch")
+      end
+
+      it "sa2 sees _initial, fetch, and enrich before it" do
+        schemas = index.schemas_before(sa2)
+        expect(schemas.keys).to contain_exactly("_initial", "fetch", "enrich")
+      end
+    end
+  end
+end

--- a/spec/services/orchestration/upstream_schema_index_spec.rb
+++ b/spec/services/orchestration/upstream_schema_index_spec.rb
@@ -2,19 +2,21 @@ require "rails_helper"
 
 RSpec.describe Orchestration::UpstreamSchemaIndex do
   let(:pipeline) { create(:orchestration_pipeline, initial_input_schema: { "type" => "object", "properties" => { "date" => { "type" => "string" } } }) }
-  let(:step1)    { create(:orchestration_step, pipeline: pipeline, position: 1) }
-  let(:step2)    { create(:orchestration_step, pipeline: pipeline, position: 2) }
-
-  let(:agent1) { create(:orchestration_agent, output_schema: { "type" => "object", "properties" => { "result" => { "type" => "string" } } }) }
-  let(:action1) { create(:orchestration_action, agent: agent1) }
-  let(:sa1) { create(:orchestration_step_action, step: step1, position: 1, output_key: "fetch", action: action1) }
-
-  let(:agent2) { create(:orchestration_agent, output_schema: { "type" => "object", "properties" => { "label" => { "type" => "string" } } }) }
-  let(:action2) { create(:orchestration_action, agent: agent2) }
-  let(:sa2) { create(:orchestration_step_action, step: step2, position: 1, output_key: "classify", action: action2) }
+  let(:first_step) { create(:orchestration_step, pipeline: pipeline, position: 1) }
+  let(:fetch_agent) { create(:orchestration_agent, output_schema: { "type" => "object", "properties" => { "result" => { "type" => "string" } } }) }
+  let(:fetch_step_action) { create(:orchestration_step_action, step: first_step, position: 1, output_key: "fetch", action: create(:orchestration_action, agent: fetch_agent)) }
+  let(:classify_step_action) do
+    create(:orchestration_step_action,
+           step: create(:orchestration_step, pipeline: pipeline, position: 2),
+           position: 1,
+           output_key: "classify",
+           action: create(:orchestration_action,
+                          agent: create(:orchestration_agent,
+                                        output_schema: { "type" => "object", "properties" => { "label" => { "type" => "string" } } })))
+  end
 
   describe ".build" do
-    before { sa1; sa2 }
+    before { fetch_step_action; classify_step_action }
 
     it "returns an UpstreamSchemaIndex instance" do
       expect(described_class.build(pipeline)).to be_a(described_class)
@@ -24,18 +26,18 @@ RSpec.describe Orchestration::UpstreamSchemaIndex do
   describe "#schemas_before" do
     subject(:index) { described_class.build(pipeline) }
 
-    before { sa1; sa2 }
+    before { fetch_step_action; classify_step_action }
 
     it "returns only _initial for the first step action" do
-      schemas = index.schemas_before(sa1)
-      expect(schemas.keys).to eq(["_initial"])
+      schemas = index.schemas_before(fetch_step_action)
+      expect(schemas.keys).to eq([ "_initial" ])
       expect(schemas["_initial"]).to eq(pipeline.initial_input_schema)
     end
 
     it "returns _initial and the first step action output for the second step action" do
-      schemas = index.schemas_before(sa2)
+      schemas = index.schemas_before(classify_step_action)
       expect(schemas.keys).to contain_exactly("_initial", "fetch")
-      expect(schemas["fetch"]).to eq(agent1.output_schema)
+      expect(schemas["fetch"]).to eq(fetch_agent.output_schema)
     end
 
     it "returns an empty hash for an unknown step action" do
@@ -45,17 +47,17 @@ RSpec.describe Orchestration::UpstreamSchemaIndex do
     end
 
     context "with multiple step actions in the same step" do
-      let(:sa1b) { create(:orchestration_step_action, step: step1, position: 2, output_key: "enrich") }
+      let(:enrich_step_action) { create(:orchestration_step_action, step: first_step, position: 2, output_key: "enrich") }
 
-      before { sa1b }
+      before { enrich_step_action }
 
-      it "sa1b sees only _initial and fetch before it" do
-        schemas = index.schemas_before(sa1b)
+      it "enrich_step_action sees only _initial and fetch before it" do
+        schemas = index.schemas_before(enrich_step_action)
         expect(schemas.keys).to contain_exactly("_initial", "fetch")
       end
 
-      it "sa2 sees _initial, fetch, and enrich before it" do
-        schemas = index.schemas_before(sa2)
+      it "classify_step_action sees _initial, fetch, and enrich before it" do
+        schemas = index.schemas_before(classify_step_action)
         expect(schemas.keys).to contain_exactly("_initial", "fetch", "enrich")
       end
     end


### PR DESCRIPTION
## Summary
- Introduces `Orchestration::UpstreamSchemaIndex` as a named read-model built once per pipeline-detail request
- `Pipeline::Validator` now accepts `index:` and delegates schema lookup to the index instead of accumulating its own `known_schemas` hash
- `StepsListComponent` drops `compute_upstream_schemas_per_step` and derives per-step schemas via `index.schemas_before`; `validate_steps` is called with the same index so no second walk occurs

Closes #120

## Test plan
- [x] New `UpstreamSchemaIndexSpec` covers `.build` and `#schemas_before` across single/multi-step pipelines
- [x] Updated `ValidatorSpec` shares a single index fixture — no duplicated pipeline setup
- [x] Updated `Pipeline` model spec asserts new keyword signature
- [x] Full suite: 1911 examples, 0 failures, 96.64% line coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=55, output=22557, cache_read=2864818, cache_write=62092