### PR TITLE
refactor: replace constantize executor dispatch with explicit registry

### DIFF
--- a/app/concerns/orchestration/executable.rb
+++ b/app/concerns/orchestration/executable.rb
@@ -1,7 +1,0 @@
-module Orchestration
-  module Executable
-    # Implementors must define: .call(input, params = {}) -> Hash
-    # input  - the resolved Hash from InputMappingResolver
-    # params - the action's params Hash (may be empty)
-  end
-end

--- a/app/models/orchestration/action.rb
+++ b/app/models/orchestration/action.rb
@@ -30,11 +30,8 @@ module Orchestration
         return
       end
 
-      klass = agent_class.safe_constantize
-      return errors.add(:agent_class, "must be an existing constant") if klass.nil?
-
-      unless klass.ancestors.include?(Orchestration::Executable)
-        errors.add(:agent_class, "must include Orchestration::Executable")
+      unless PipelineRunner::EXECUTORS.key?(agent_class)
+        errors.add(:agent_class, "must be a registered executor")
       end
     end
   end

--- a/app/services/emails/fetch_executor.rb
+++ b/app/services/emails/fetch_executor.rb
@@ -1,7 +1,5 @@
 module Emails
   class FetchExecutor
-    include Orchestration::Executable
-
     DEFAULT_DATE = Date.today.to_s
     DEFAULT_PROVIDERS = %w[gmail yahoo].freeze
     DEFAULT_MAX_RESULTS = 10

--- a/app/services/interviews/gist_export_executor.rb
+++ b/app/services/interviews/gist_export_executor.rb
@@ -1,7 +1,5 @@
 module Interviews
   class GistExportExecutor
-    include Orchestration::Executable
-
     def self.call(input, _params = {})
       gist_id = input.fetch("gist_id") { ENV.fetch("GIST_ID", nil) }
       return { "skipped" => true, "reason" => "GIST_ID not configured" } if gist_id.nil?

--- a/app/services/orchestration/ingestion_executor.rb
+++ b/app/services/orchestration/ingestion_executor.rb
@@ -1,7 +1,5 @@
 module Orchestration
   class IngestionExecutor
-    include Orchestration::Executable
-
     SUPPORTED_OPERATIONS = %w[filter_by_ids rename pick merge_by_index].freeze
 
     def self.call(input, params = {})

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -1,5 +1,12 @@
 module Orchestration
   class PipelineRunner
+    EXECUTORS = {
+      "Emails::FetchExecutor"              => Emails::FetchExecutor,
+      "Orchestration::QueryExecutor"       => Orchestration::QueryExecutor,
+      "Orchestration::IngestionExecutor"   => Orchestration::IngestionExecutor,
+      "Interviews::GistExportExecutor"     => Interviews::GistExportExecutor
+    }.freeze
+
     def initialize(pipeline_run)
       @pipeline_run = pipeline_run
     end
@@ -103,8 +110,9 @@ module Orchestration
         normalized_output = policy.output_schema.present? ? output : { "result" => output }
         { output: normalized_output, raw_content: result.content }
       else
-        klass = action.agent_class&.constantize
-        raise ArgumentError, "Service class not found: #{action.agent_class}" unless klass
+        klass = EXECUTORS.fetch(action.agent_class.to_s) do
+          raise ArgumentError, "Unregistered executor: #{action.agent_class}"
+        end
 
         params = (action.params || {}).merge(action_run.step_action.params || {})
         { output: klass.call(input, params), raw_content: nil }

--- a/app/services/orchestration/query_executor.rb
+++ b/app/services/orchestration/query_executor.rb
@@ -1,6 +1,5 @@
 module Orchestration
   class QueryExecutor
-    include Orchestration::Executable
     extend Records::ModelResolver
 
     def self.call(input, params = {})

--- a/sig/app/concerns/orchestration/executable.rbs
+++ b/sig/app/concerns/orchestration/executable.rbs
@@ -1,6 +1,0 @@
-module Orchestration
-  module Executable
-    # Marker module. Includers must define:
-    #   .call(Hash[String, untyped], ?Hash[String, untyped]) -> Hash[String, untyped]
-  end
-end

--- a/sig/app/services/emails/fetch_executor.rbs
+++ b/sig/app/services/emails/fetch_executor.rbs
@@ -7,7 +7,6 @@ module Emails
     DEFAULT_PROVIDERS: Array[String]
     DEFAULT_MAX_RESULTS: Integer
 
-    include Orchestration::Executable
     def self.call: (Hash[String, untyped] input, ?Hash[String, untyped] params) -> fetch_result
   end
 end

--- a/sig/app/services/interviews/gist_export_executor.rbs
+++ b/sig/app/services/interviews/gist_export_executor.rbs
@@ -1,6 +1,5 @@
 module Interviews
   class GistExportExecutor
-    include Orchestration::Executable
     def self.call: (Hash[String, untyped] input, ?Hash[String, untyped] params) -> Hash[String, untyped]
   end
 end

--- a/sig/app/services/orchestration/ingestion_executor.rbs
+++ b/sig/app/services/orchestration/ingestion_executor.rbs
@@ -2,8 +2,6 @@ module Orchestration
   class IngestionExecutor
     SUPPORTED_OPERATIONS: Array[String]
 
-    include Executable
-
     def self.call: (json_object input, ?Hash[String, untyped] params) -> Hash[String, untyped]
 
     def self.execute_operation: (json_object output, Hash[String, untyped] op) -> untyped

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -1,5 +1,12 @@
 module Orchestration
   class PipelineRunner
+    type executor_class = singleton(Emails::FetchExecutor)
+                        | singleton(Orchestration::QueryExecutor)
+                        | singleton(Orchestration::IngestionExecutor)
+                        | singleton(Interviews::GistExportExecutor)
+
+    EXECUTORS: Hash[String, executor_class]
+
     def initialize: (PipelineRun pipeline_run) -> void
     def call: () -> void
 

--- a/sig/app/services/orchestration/query_executor.rbs
+++ b/sig/app/services/orchestration/query_executor.rbs
@@ -1,6 +1,5 @@
 module Orchestration
   class QueryExecutor
-    include Executable
     extend Records::ModelResolver
 
     def self.call: (Hash[String, untyped] input, ?Hash[String, untyped] params) -> Hash[String, Array[Hash[String, untyped]]]

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -24,9 +24,8 @@ RSpec.describe Orchestration::Action do
     end
 
     context "with kind: :service" do
-      it "is valid with a name and a valid executable class" do
-        stub_const("MyExecutable", Class.new { include Orchestration::Executable })
-        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "MyExecutable")
+      it "is valid with a name and a registered executor class" do
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "Emails::FetchExecutor")
         expect(action).to be_valid
       end
 
@@ -36,22 +35,14 @@ RSpec.describe Orchestration::Action do
         expect(action.errors[:agent_class]).to include(/can't be blank/)
       end
 
-      it "rejects non-existent class" do
-        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "NonExistent::Klass")
+      it "rejects an unregistered class name" do
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "NotInRegistry")
         expect(action).not_to be_valid
-        expect(action.errors[:agent_class]).to include(/must be an existing constant/)
-      end
-
-      it "rejects a class that does not include Orchestration::Executable" do
-        stub_const("RegularClass", Class.new)
-        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "RegularClass")
-        expect(action).not_to be_valid
-        expect(action.errors[:agent_class]).to include(/must include Orchestration::Executable/)
+        expect(action.errors[:agent_class]).to include(/must be a registered executor/)
       end
 
       it "is invalid when agent_id is present" do
-        stub_const("MyExecutable", Class.new { include Orchestration::Executable })
-        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "MyExecutable")
+        action = build(:orchestration_action, kind: :service, agent: nil, agent_class: "Emails::FetchExecutor")
         action.agent_id = 999
         expect(action).not_to be_valid
         expect(action.errors[:agent_id]).to include(/must be blank/)

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -1047,6 +1047,23 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
+    context 'when the action references an unregistered executor class' do
+      let(:fetch_action) { create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor") }
+
+      before do
+        fetch_action
+        create(:orchestration_step_action, step: step1, action: fetch_action, position: 1)
+        stub_const("Orchestration::PipelineRunner::EXECUTORS", {})
+      end
+
+      it 'marks the action_run as failed with ArgumentError' do
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+        expect(action_run.status).to eq("failed")
+        expect(action_run.error).to match(/Unregistered executor: Emails::FetchExecutor/)
+      end
+    end
+
     context 'when input_mapping references a missing path' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       before do
         fetch_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")


### PR DESCRIPTION
## Summary
- Add a frozen `EXECUTORS` constant in `PipelineRunner` mapping class name strings to the four executor classes
- Replace `constantize` dispatch in `run_agent` with `EXECUTORS.fetch`, raising `ArgumentError` for unknown keys
- Delete the `Orchestration::Executable` marker concern and all four `include` sites; update `Action` model validation to check the registry instead

Closes #121

## Test plan
- [x] New test: action with unregistered executor class marks action_run failed with `Unregistered executor:` message
- [x] All 1905 existing tests pass
- [x] RuboCop: no offenses
- [x] Steep: no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
   Tokens used: input=383, output=17067, cache_read=2943111, cache_write=66768