### PR TITLE
feat: experiment history tools for PromptImprover agent

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,8 +58,11 @@ _Avoid_: evaluator LLM, scoring model
 **Justification**: The judge's written reasoning for the score it assigned on one metric for one sample.
 _Avoid_: explanation, rationale
 
-**Improvement**: An LLM-generated revision of a prompt version, produced by `PromptImprover` from the scores and justifications of a completed experiment.
+**Improvement**: An LLM-generated revision of a prompt version, produced by `PromptImprover` from the scores and justifications of a completed experiment. The improver agent can call tools to inspect the full experiment history for the same agent — enabling it to understand direction before generating its revision.
 _Avoid_: refinement, update, optimization
+
+**Experiment history**: The set of all completed experiments for a given agent, excluding the experiment currently being improved. Exposed to `PromptImprover`'s agent via three tools: `list_experiments` (score trajectory), `get_experiment_justifications` (full per-sample reasoning), and `get_experiment_prompt` (exact prompt text used). Failed experiments are excluded — failures are infrastructure issues, not prompt signal.
+_Avoid_: past runs, previous evals
 
 **Auto-eval**: An experiment automatically triggered when a new prompt version is created, using the same dataset as the previous experiment. Provides immediate feedback on whether the improvement helped.
 _Avoid_: automated experiment, post-improvement eval
@@ -78,6 +81,7 @@ _Avoid_: response format, output format, JSON shape
 - **Metrics** must exist for an agent before an experiment can be created
 - A **Prompt version** has a fixed **Output schema** that the **Judge** must not contradict when evaluating format compliance
 - Each **Improvement** creates a new **Prompt version** and triggers an **Auto-eval**
+- `PromptImprover` passes the current experiment's scores and justifications in the initial message; **experiment history** is accessible on-demand via tools scoped to the same agent
 
 ## Example dialogue
 

--- a/lib/evaluation/improvement/agent.rb
+++ b/lib/evaluation/improvement/agent.rb
@@ -3,7 +3,7 @@ module Evaluation
     class Agent < ::RubyLLM::Agent
       chat_model Chat
       model LlmModels.evaluation
-      tools LoadSamplesTool
+      tools LoadSamplesTool, ListExperimentsTool, GetExperimentJustificationsTool, GetExperimentPromptTool
 
       schema do
         string :system_prompt, required: true, description: "The improved system prompt text. Must be non-empty."
@@ -24,6 +24,18 @@ module Evaluation
 
       Your task: improve the system prompt to address weak areas (low scores) while preserving
       behaviors that already score well.
+
+      Before writing the improved prompt, use the available tools to understand the direction of
+      past improvement attempts for this agent:
+      - Call `list_experiments` with the prompt_name and current experiment_id to see the score
+        trajectory across all previous experiments (per-metric averages and overall average).
+      - Call `get_experiment_justifications` on any past experiment to read the judge's full
+        reasoning for that run — useful for understanding what went wrong or right.
+      - Call `get_experiment_prompt` on any past experiment to see the exact prompt text that
+        produced those scores — useful for understanding what changes have already been tried.
+
+      Use this history to avoid repeating directions that have already been tried without success,
+      and to build on directions that showed improvement.
 
       IMPORTANT constraints:
       - Do NOT add output format descriptions, JSON schema examples, or structured output

--- a/lib/evaluation/improvement/get_experiment_justifications_tool.rb
+++ b/lib/evaluation/improvement/get_experiment_justifications_tool.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Evaluation
+  module Improvement
+    class GetExperimentJustificationsTool < ::RubyLLM::Tool
+      description "Fetch all justifications for a specific experiment. Returns the judge's reasoning for every metric on every sample — use this to understand why an experiment scored the way it did."
+
+      param :experiment_id, type: :integer, desc: "ID of the experiment to fetch justifications from.", required: true
+
+      def name = "get_experiment_justifications"
+
+      def execute(experiment_id:)
+        Justification
+          .eager_load(:evaluation_result)
+          .where(evaluation_evaluation_results: { experiment_id: experiment_id })
+          .map do |j|
+            {
+              metric_name: j.metric_name,
+              score: j.evaluation_result.score,
+              justification: j.justification
+            }
+          end
+      end
+    end
+  end
+end

--- a/lib/evaluation/improvement/get_experiment_prompt_tool.rb
+++ b/lib/evaluation/improvement/get_experiment_prompt_tool.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Evaluation
+  module Improvement
+    class GetExperimentPromptTool < ::RubyLLM::Tool
+      description "Fetch the prompt text used in a specific experiment. Use this to understand what instructions produced a given set of scores."
+
+      param :experiment_id, type: :integer, desc: "ID of the experiment to fetch the prompt from.", required: true
+
+      def name = "get_experiment_prompt"
+
+      def execute(experiment_id:)
+        experiment = Experiment.includes(:prompt).find_by(id: experiment_id)
+        return nil unless experiment&.prompt
+
+        {
+          system_prompt: experiment.prompt.system_prompt,
+          user_prompt: experiment.prompt.user_prompt
+        }
+      end
+    end
+  end
+end

--- a/lib/evaluation/improvement/get_experiment_prompt_tool.rb
+++ b/lib/evaluation/improvement/get_experiment_prompt_tool.rb
@@ -14,8 +14,9 @@ module Evaluation
         return nil unless experiment&.prompt
 
         {
-          system_prompt: experiment.prompt.system_prompt,
-          user_prompt: experiment.prompt.user_prompt
+          system_prompt: experiment.prompt.system_prompt.to_s,
+          user_prompt: experiment.prompt.user_prompt,
+          output_schema: experiment.prompt.output_schema
         }
       end
     end

--- a/lib/evaluation/improvement/list_experiments_tool.rb
+++ b/lib/evaluation/improvement/list_experiments_tool.rb
@@ -11,10 +11,13 @@ module Evaluation
       def name = "list_experiments"
 
       def execute(prompt_name:, current_experiment_id:)
-        experiments = load_experiments(prompt_name, current_experiment_id)
-        metrics = load_metrics(prompt_name)
+        experiments = load_experiments(prompt_name, current_experiment_id).to_a
+        return [] if experiments.empty?
 
-        experiments.map { |exp| format_experiment(exp, metrics) }
+        metrics = load_metrics(prompt_name)
+        averages_by_experiment = bulk_per_metric_averages(experiments)
+
+        experiments.map { |exp| format_experiment(exp, metrics, averages_by_experiment[exp.id] || {}) }
       end
 
       private
@@ -32,8 +35,27 @@ module Evaluation
         Metric.where(agent_name: prompt_name, active: true).to_a
       end
 
-      def format_experiment(experiment, metrics)
-        averages = experiment.per_metric_averages
+      def bulk_per_metric_averages(experiments)
+        results_table        = EvaluationResult.arel_table
+        justifications_table = Justification.arel_table
+
+        EvaluationResult
+          .joins(
+            results_table.join(justifications_table)
+              .on(justifications_table[:evaluation_result_id].eq(results_table[:id]))
+              .join_sources
+          )
+          .where(experiment: experiments)
+          .group(results_table[:experiment_id], justifications_table[:metric_name])
+          .average(results_table[:score])
+          .each_with_object({} #: Hash[Integer, Hash[String, untyped]]
+                            ) do |((exp_id, metric_name), avg), memo|
+            memo[exp_id.to_i] ||= {} #: Hash[String, untyped]
+            memo[exp_id.to_i][metric_name.to_s] = avg
+          end
+      end
+
+      def format_experiment(experiment, metrics, averages)
         {
           experiment_id: experiment.id,
           date: experiment.created_at.to_date.to_s,

--- a/lib/evaluation/improvement/list_experiments_tool.rb
+++ b/lib/evaluation/improvement/list_experiments_tool.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Evaluation
+  module Improvement
+    class ListExperimentsTool < ::RubyLLM::Tool
+      description "List all completed experiments for an agent ordered by date. Use this to understand the direction of past improvement attempts before generating a revision."
+
+      param :prompt_name, type: :string, desc: "Name of the agent whose experiment history to list.", required: true
+      param :current_experiment_id, type: :integer, desc: "ID of the current experiment to exclude from results.", required: true
+
+      def name = "list_experiments"
+
+      def execute(prompt_name:, current_experiment_id:)
+        experiments = load_experiments(prompt_name, current_experiment_id)
+        metrics = load_metrics(prompt_name)
+
+        experiments.map { |exp| format_experiment(exp, metrics) }
+      end
+
+      private
+
+      def load_experiments(prompt_name, current_experiment_id)
+        Experiment
+          .joins(:prompt)
+          .where(status: :completed, evaluation_prompts: { name: prompt_name })
+          .where.not(id: current_experiment_id)
+          .includes(:prompt)
+          .order(:created_at)
+      end
+
+      def load_metrics(prompt_name)
+        Metric.where(agent_name: prompt_name, active: true).to_a
+      end
+
+      def format_experiment(experiment, metrics)
+        averages = experiment.per_metric_averages
+        {
+          experiment_id: experiment.id,
+          date: experiment.created_at.to_date.to_s,
+          prompt_version: experiment.prompt&.version || 0,
+          per_metric_averages: averages,
+          overall_average: weighted_average(averages, metrics)
+        }
+      end
+
+      def weighted_average(averages, metrics)
+        return 0.0 if metrics.empty? || averages.empty?
+
+        weighted_sum = 0.0
+        total_weight = 0.0
+
+        metrics.each do |metric|
+          score = averages[metric.name.to_s]
+          next if score.nil?
+
+          weighted_sum += score.to_f * metric.weight.to_f
+          total_weight += metric.weight.to_f
+        end
+
+        return 0.0 if total_weight.zero?
+
+        (weighted_sum / total_weight).round(2).to_f
+      end
+    end
+  end
+end

--- a/sig/lib/evaluation/improvement/get_experiment_justifications_tool.rbs
+++ b/sig/lib/evaluation/improvement/get_experiment_justifications_tool.rbs
@@ -2,7 +2,7 @@ module Evaluation
   module Improvement
     class GetExperimentJustificationsTool < ::RubyLLM::Tool
       def name: () -> String
-      def execute: (experiment_id: Integer) -> Array[{ metric_name: String, score: Float, justification: String }]
+      def execute: (experiment_id: Integer) -> Array[{ metric_name: String, score: Float?, justification: String }]
     end
   end
 end

--- a/sig/lib/evaluation/improvement/get_experiment_justifications_tool.rbs
+++ b/sig/lib/evaluation/improvement/get_experiment_justifications_tool.rbs
@@ -1,0 +1,8 @@
+module Evaluation
+  module Improvement
+    class GetExperimentJustificationsTool < ::RubyLLM::Tool
+      def name: () -> String
+      def execute: (experiment_id: Integer) -> Array[{ metric_name: String, score: Float, justification: String }]
+    end
+  end
+end

--- a/sig/lib/evaluation/improvement/get_experiment_prompt_tool.rbs
+++ b/sig/lib/evaluation/improvement/get_experiment_prompt_tool.rbs
@@ -1,0 +1,8 @@
+module Evaluation
+  module Improvement
+    class GetExperimentPromptTool < ::RubyLLM::Tool
+      def name: () -> String
+      def execute: (experiment_id: Integer) -> { system_prompt: String, user_prompt: String }?
+    end
+  end
+end

--- a/sig/lib/evaluation/improvement/get_experiment_prompt_tool.rbs
+++ b/sig/lib/evaluation/improvement/get_experiment_prompt_tool.rbs
@@ -2,7 +2,7 @@ module Evaluation
   module Improvement
     class GetExperimentPromptTool < ::RubyLLM::Tool
       def name: () -> String
-      def execute: (experiment_id: Integer) -> { system_prompt: String, user_prompt: String }?
+      def execute: (experiment_id: Integer) -> { system_prompt: String, user_prompt: String, output_schema: untyped }?
     end
   end
 end

--- a/sig/lib/evaluation/improvement/list_experiments_tool.rbs
+++ b/sig/lib/evaluation/improvement/list_experiments_tool.rbs
@@ -2,14 +2,15 @@ module Evaluation
   module Improvement
     class ListExperimentsTool < ::RubyLLM::Tool
       def name: () -> String
-      def execute: (prompt_name: String, current_experiment_id: Integer) -> Array[{ experiment_id: Integer, date: String, prompt_version: Integer, per_metric_averages: Hash[String, Float], overall_average: Float }]
+      def execute: (prompt_name: String, current_experiment_id: Integer) -> Array[{ experiment_id: Integer, date: String, prompt_version: Integer, per_metric_averages: Hash[String, untyped], overall_average: Float }]
 
       private
 
       def load_experiments: (String prompt_name, Integer current_experiment_id) -> ActiveRecord::Relation
-      def load_metrics: (String prompt_name) -> Array[Metric]
-      def format_experiment: (Experiment experiment, Array[Metric] metrics) -> { experiment_id: Integer, date: String, prompt_version: Integer, per_metric_averages: Hash[String, Float], overall_average: Float }
-      def weighted_average: (Hash[String, untyped] averages, Array[Metric] metrics) -> Float
+      def load_metrics: (String prompt_name) -> Array[::Evaluation::Metric]
+      def bulk_per_metric_averages: (Array[::Evaluation::Experiment] experiments) -> Hash[Integer, Hash[String, untyped]]
+      def format_experiment: (::Evaluation::Experiment experiment, Array[::Evaluation::Metric] metrics, Hash[String, untyped] averages) -> { experiment_id: Integer, date: String, prompt_version: Integer, per_metric_averages: Hash[String, untyped], overall_average: Float }
+      def weighted_average: (Hash[String, untyped] averages, Array[::Evaluation::Metric] metrics) -> Float
     end
   end
 end

--- a/sig/lib/evaluation/improvement/list_experiments_tool.rbs
+++ b/sig/lib/evaluation/improvement/list_experiments_tool.rbs
@@ -1,0 +1,15 @@
+module Evaluation
+  module Improvement
+    class ListExperimentsTool < ::RubyLLM::Tool
+      def name: () -> String
+      def execute: (prompt_name: String, current_experiment_id: Integer) -> Array[{ experiment_id: Integer, date: String, prompt_version: Integer, per_metric_averages: Hash[String, Float], overall_average: Float }]
+
+      private
+
+      def load_experiments: (String prompt_name, Integer current_experiment_id) -> ActiveRecord::Relation
+      def load_metrics: (String prompt_name) -> Array[Metric]
+      def format_experiment: (Experiment experiment, Array[Metric] metrics) -> { experiment_id: Integer, date: String, prompt_version: Integer, per_metric_averages: Hash[String, Float], overall_average: Float }
+      def weighted_average: (Hash[String, untyped] averages, Array[Metric] metrics) -> Float
+    end
+  end
+end

--- a/spec/lib/evaluation/improvement/get_experiment_justifications_tool_spec.rb
+++ b/spec/lib/evaluation/improvement/get_experiment_justifications_tool_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::Improvement::GetExperimentJustificationsTool do
+  subject(:tool) { described_class.new }
+
+  let(:experiment) { create(:evaluation_experiment, status: :completed) }
+
+  describe "#execute" do
+    it "returns an empty array when the experiment has no justifications" do
+      expect(tool.execute(experiment_id: experiment.id)).to eq([])
+    end
+
+    it "returns justification tuples with metric_name, score, and justification" do # rubocop:disable RSpec/ExampleLength
+      result = create(:evaluation_evaluation_result, experiment: experiment, score: 4.0)
+      create(:evaluation_justification,
+             evaluation_result: result,
+             metric_name: "accuracy",
+             justification: "Correct tool called")
+
+      output = tool.execute(experiment_id: experiment.id)
+
+      expect(output.size).to eq(1)
+      expect(output.first).to eq(
+        metric_name: "accuracy",
+        score: 4.0,
+        justification: "Correct tool called"
+      )
+    end
+
+    it "returns all justifications across multiple results and metrics" do
+      result1 = create(:evaluation_evaluation_result, experiment: experiment, score: 3.0)
+      result2 = create(:evaluation_evaluation_result, experiment: experiment, score: 5.0)
+      create(:evaluation_justification, evaluation_result: result1, metric_name: "accuracy", justification: "ok")
+      create(:evaluation_justification, evaluation_result: result2, metric_name: "clarity", justification: "clear")
+
+      output = tool.execute(experiment_id: experiment.id)
+
+      expect(output.size).to eq(2)
+      metric_names = output.map { |r| r[:metric_name] }
+      expect(metric_names).to contain_exactly("accuracy", "clarity")
+    end
+
+    it "does not include justifications from other experiments" do
+      other_experiment = create(:evaluation_experiment, status: :completed)
+      other_result = create(:evaluation_evaluation_result, experiment: other_experiment, score: 5.0)
+      create(:evaluation_justification, evaluation_result: other_result, metric_name: "accuracy", justification: "irrelevant")
+
+      expect(tool.execute(experiment_id: experiment.id)).to be_empty
+    end
+  end
+end

--- a/spec/lib/evaluation/improvement/get_experiment_prompt_tool_spec.rb
+++ b/spec/lib/evaluation/improvement/get_experiment_prompt_tool_spec.rb
@@ -6,18 +6,30 @@ RSpec.describe Evaluation::Improvement::GetExperimentPromptTool do
   subject(:tool) { described_class.new }
 
   describe "#execute" do
-    it "returns system_prompt and user_prompt for the experiment" do
+    it "returns system_prompt, user_prompt, and output_schema for the experiment" do # rubocop:disable RSpec/ExampleLength
+      schema = { "type" => "object" }
       prompt = create(:orchestration_prompt,
                       system_prompt: "You are a classifier.",
-                      user_prompt: "Classify this email: {{input}}")
+                      user_prompt: "Classify this email: {{input}}",
+                      output_schema: schema)
       experiment = create(:evaluation_experiment, prompt: prompt)
 
       result = tool.execute(experiment_id: experiment.id)
 
       expect(result).to eq(
         system_prompt: "You are a classifier.",
-        user_prompt: "Classify this email: {{input}}"
+        user_prompt: "Classify this email: {{input}}",
+        output_schema: schema
       )
+    end
+
+    it "coerces nil system_prompt to an empty string" do
+      prompt = create(:orchestration_prompt, system_prompt: nil, user_prompt: "user prompt")
+      experiment = create(:evaluation_experiment, prompt: prompt)
+
+      result = tool.execute(experiment_id: experiment.id)
+
+      expect(result[:system_prompt]).to eq("")
     end
 
     it "returns nil when the experiment does not exist" do

--- a/spec/lib/evaluation/improvement/get_experiment_prompt_tool_spec.rb
+++ b/spec/lib/evaluation/improvement/get_experiment_prompt_tool_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::Improvement::GetExperimentPromptTool do
+  subject(:tool) { described_class.new }
+
+  describe "#execute" do
+    it "returns system_prompt and user_prompt for the experiment" do
+      prompt = create(:orchestration_prompt,
+                      system_prompt: "You are a classifier.",
+                      user_prompt: "Classify this email: {{input}}")
+      experiment = create(:evaluation_experiment, prompt: prompt)
+
+      result = tool.execute(experiment_id: experiment.id)
+
+      expect(result).to eq(
+        system_prompt: "You are a classifier.",
+        user_prompt: "Classify this email: {{input}}"
+      )
+    end
+
+    it "returns nil when the experiment does not exist" do
+      expect(tool.execute(experiment_id: 0)).to be_nil
+    end
+
+    it "returns nil when the experiment has no prompt" do
+      experiment = create(:evaluation_experiment, prompt: nil)
+
+      expect(tool.execute(experiment_id: experiment.id)).to be_nil
+    end
+  end
+end

--- a/spec/lib/evaluation/improvement/list_experiments_tool_spec.rb
+++ b/spec/lib/evaluation/improvement/list_experiments_tool_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Evaluation::Improvement::ListExperimentsTool do
+  subject(:tool) { described_class.new }
+
+  let(:prompt_name) { "Emails::ClassifyAgent" }
+  let(:prompt) { create(:orchestration_prompt, name: prompt_name) }
+  let(:current_experiment) { create(:evaluation_experiment, status: :completed, prompt: prompt) }
+
+  def result_with_justification(experiment, metric_name:, score:, justification: "good")
+    result = create(:evaluation_evaluation_result, experiment: experiment, score: score)
+    create(:evaluation_justification, evaluation_result: result, metric_name: metric_name, justification: justification)
+  end
+
+  describe "#execute" do
+    it "returns empty array when no other completed experiments exist" do
+      expect(tool.execute(prompt_name: prompt_name, current_experiment_id: current_experiment.id)).to eq([])
+    end
+
+    it "excludes the current experiment" do
+      result_with_justification(current_experiment, metric_name: "accuracy", score: 4.0)
+      expect(tool.execute(prompt_name: prompt_name, current_experiment_id: current_experiment.id)).to be_empty
+    end
+
+    it "excludes failed experiments" do
+      create(:evaluation_experiment, status: :failed, prompt: prompt)
+      expect(tool.execute(prompt_name: prompt_name, current_experiment_id: current_experiment.id)).to be_empty
+    end
+
+    it "excludes experiments for other agents" do
+      other_prompt = create(:orchestration_prompt, name: "OtherAgent")
+      create(:evaluation_experiment, status: :completed, prompt: other_prompt)
+      expect(tool.execute(prompt_name: prompt_name, current_experiment_id: current_experiment.id)).to be_empty
+    end
+
+    context "with a past completed experiment" do
+      let(:metric) { create(:evaluation_metric, agent_name: prompt_name, name: "accuracy", weight: 1.0) }
+      let(:past_experiment) { create(:evaluation_experiment, status: :completed, prompt: prompt) }
+
+      before do
+        metric
+        result_with_justification(past_experiment, metric_name: "accuracy", score: 3.0)
+      end
+
+      it "returns correct structure" do
+        results = tool.execute(prompt_name: prompt_name, current_experiment_id: current_experiment.id)
+
+        expect(results.size).to eq(1)
+        expect(results.first).to include(
+          experiment_id: past_experiment.id,
+          prompt_version: past_experiment.prompt.version,
+          per_metric_averages: { "accuracy" => 3.0 },
+          overall_average: 3.0
+        )
+        expect(results.first[:date]).to be_a(String)
+      end
+
+      it "computes weighted overall average across metrics" do
+        create(:evaluation_metric, agent_name: prompt_name, name: "clarity", weight: 3.0)
+        result_with_justification(past_experiment, metric_name: "clarity", score: 5.0)
+
+        results = tool.execute(prompt_name: prompt_name, current_experiment_id: current_experiment.id)
+        # accuracy: 3.0 * 1.0, clarity: 5.0 * 3.0 → (3+15)/4 = 4.5
+        expect(results.first[:overall_average]).to eq(4.5)
+      end
+
+      it "orders results by created_at ascending" do
+        later_prompt = create(:orchestration_prompt, name: prompt_name)
+        later_experiment = create(:evaluation_experiment, status: :completed, prompt: later_prompt)
+        result_with_justification(later_experiment, metric_name: "accuracy", score: 4.0)
+
+        results = tool.execute(prompt_name: prompt_name, current_experiment_id: current_experiment.id)
+        ids = results.map { |r| r[:experiment_id] }
+        expect(ids).to eq([ past_experiment.id, later_experiment.id ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds three on-demand tools to `Evaluation::Improvement::Agent` so it can query the full experiment history for an agent before generating a prompt revision
- `list_experiments` — score trajectory across all completed past experiments (per-metric averages + weighted overall average)
- `get_experiment_justifications` — full judge reasoning for any past experiment
- `get_experiment_prompt` — exact prompt text used in any past experiment
- Updates agent instructions to direct it to consult history before writing a revision, avoiding directions already tried without success
- Updates `CONTEXT.md` with **Experiment history** as a canonical domain term

## Test plan

- [ ] `bundle exec rspec spec/lib/evaluation/improvement/` — 20 examples, 0 failures
- [ ] Trigger a prompt improvement on an agent with multiple past experiments and confirm the agent calls `list_experiments` before generating its revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)