### PR TITLE
fix: preserve output_schema when improving prompt

### DIFF
--- a/lib/evaluation/improvement/list_experiments_tool.rb
+++ b/lib/evaluation/improvement/list_experiments_tool.rb
@@ -50,7 +50,8 @@ module Evaluation
           .average(results_table[:score])
           .each_with_object({} #: Hash[Integer, Hash[String, untyped]]
                             ) do |((exp_id, metric_name), avg), memo|
-            memo[exp_id.to_i] ||= ({} #: Hash[String, untyped])
+            empty = {} #: Hash[String, untyped]
+            memo[exp_id.to_i] ||= empty
             memo[exp_id.to_i][metric_name.to_s] = avg
           end
       end

--- a/lib/evaluation/improvement/list_experiments_tool.rb
+++ b/lib/evaluation/improvement/list_experiments_tool.rb
@@ -50,7 +50,7 @@ module Evaluation
           .average(results_table[:score])
           .each_with_object({} #: Hash[Integer, Hash[String, untyped]]
                             ) do |((exp_id, metric_name), avg), memo|
-            memo[exp_id.to_i] ||= {} #: Hash[String, untyped]
+            memo[exp_id.to_i] ||= ({} #: Hash[String, untyped])
             memo[exp_id.to_i][metric_name.to_s] = avg
           end
       end

--- a/lib/evaluation/prompt_improver.rb
+++ b/lib/evaluation/prompt_improver.rb
@@ -23,7 +23,7 @@ module Evaluation
         name: current_prompt.name,
         system_prompt: improved[:system_prompt],
         user_prompt: improved[:user_prompt].presence || current_prompt.user_prompt,
-        output_schema: improved[:output_schema]
+        output_schema: current_prompt.output_schema
       )
     end
 

--- a/spec/lib/evaluation/prompt_improver_spec.rb
+++ b/spec/lib/evaluation/prompt_improver_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Evaluation::PromptImprover do
       expect(Evaluation::Prompt.last.name).to eq(prompt.name)
     end
 
+    it "preserves the output_schema from the current prompt" do
+      schema = { "type" => "object", "properties" => { "label" => { "type" => "string" } } }
+      prompt.update!(output_schema: schema)
+      stub_improvement_agent
+      described_class.call(experiment: experiment)
+      expect(Evaluation::Prompt.last.output_schema).to eq(schema)
+    end
+
     it "falls back to the original user_prompt when the LLM returns an empty user_prompt" do
       stub_improvement_agent(user_prompt: "")
       described_class.call(experiment: experiment)


### PR DESCRIPTION
## Summary

- `PromptImprover` was creating new prompts with `output_schema: nil` on every "improve prompt" action
- Root cause: `parse_response` never extracted `output_schema` from the LLM response, and the `Improvement::Agent` schema doesn't include it as an output field (by design — the agent instructions explicitly forbid altering the output schema)
- Fix: copy `output_schema` directly from the current prompt instead of reading it from `improved[:output_schema]`

## Test plan

- [ ] Added spec: "preserves the output_schema from the current prompt" — was red before fix, green after
- [ ] Full spec suite for `PromptImprover`: 8/8 passing
- [ ] Manual: click "improve prompt" on an experiment whose agent has an output schema and verify the new prompt version retains it

🤖 Generated with [Claude Code](https://claude.com/claude-code)