### PR TITLE
Replace params with input_schema contract on Agent/Action/StepAction

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,10 +67,21 @@ _Avoid_: automated experiment, post-improvement eval
 **Output schema**: The fixed structured-output contract enforced at the API level for an agent (e.g. `{"results": [{"id": ..., "tags": [...]}]}`). Prompt instructions cannot override it.
 _Avoid_: response format, output format, JSON shape
 
+**Input schema**: A JSON Schema object that declares what keys and types a step action must supply when invoking an action. For agent-kind actions it is stored on the `Agent` record; for service-kind actions it is derived at load time from the service class's `input_schema` DSL declaration and its `call` keyword arguments. The schema drives both static pipeline validation (missing required inputs) and runtime validation before execution.
+_Avoid_: params, input contract, required fields
+
+**Input mapping**: A per-step-action hash that maps each input key the action expects to a source spec. Each spec is one of: `{from:, path:}` (resolve from a prior step's output), `{from: "_initial", path:}` (resolve from the pipeline's initial input), or `{value:}` (inline literal value). Required keys from the action's input schema must be covered by the mapping.
+_Avoid_: params, step params, action params
+
+**Executable**: A concern included by service classes that participate in the orchestration pipeline. Provides the `input_schema(types)` DSL to declare parameter types; the schema is derived at first access by cross-referencing the declared types against the `call` method's keyword arguments, raising at load time if they diverge.
+_Avoid_: service interface, callable
+
 ## Relationships
 
 - A **Pipeline** has one or more **Steps**; each **Step** is bound to one **Action**
-- An **Action** may reference an **Agent** (agent-kind) or invoke a service directly
+- An **Action** may reference an **Agent** (agent-kind) or invoke a service directly (service-kind)
+- An **Action** exposes an **Input schema** — sourced from the agent record or derived from the service class
+- A **Step action** has an **Input mapping** that satisfies the action's **Input schema** required keys
 - An **Experiment** uses one **Dataset** and one **Prompt version**
 - A **Dataset** contains one or more **Dataset samples**; each holds an input and optional expected tool call trace
 - The **Sampler** produces one **Sample** per **Dataset sample** during the sampling phase

--- a/app/components/orchestration/step_component.html.erb
+++ b/app/components/orchestration/step_component.html.erb
@@ -16,9 +16,6 @@
             <% @step.step_actions.zip(detach_buttons).each do |sa, btn| %>
               <div class="flex items-center gap-1 bg-gray-100 rounded-lg px-2 py-1 text-xs">
                 <span class="font-medium text-gray-700"><%= sa.action.name %></span>
-                <% if sa.params.present? %>
-                  <span class="text-gray-500 font-mono"><%= sa.params.to_json %></span>
-                <% end %>
                 <%= btn %>
               </div>
             <% end %>
@@ -65,9 +62,6 @@
             { include_blank: "— attach action —" },
             name: "orchestration_step_action[action_id]",
             class: "flex-1 border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
-      <%= f.text_field :params_override, placeholder: '{"key":"val"} optional',
-            name: "orchestration_step_action[params]",
-            class: "w-40 border border-gray-300 rounded-lg px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
       <%= f.submit "Attach", class: "px-3 py-1.5 bg-indigo-600 text-white text-xs font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
     <% end %>
   </div>

--- a/app/concerns/orchestration/executable.rb
+++ b/app/concerns/orchestration/executable.rb
@@ -1,7 +1,50 @@
 module Orchestration
   module Executable
-    # Implementors must define: .call(input, params = {}) -> Hash
-    # input  - the resolved Hash from InputMappingResolver
-    # params - the action's params Hash (may be empty)
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def input_schema(declared_types = nil)
+        if declared_types
+          @_input_schema_types = declared_types.transform_keys(&:to_s)
+        else
+          return nil unless @_input_schema_types
+
+          @_input_schema ||= build_input_schema!
+        end
+      end
+
+      private
+
+      def build_input_schema!
+        declared = @_input_schema_types
+        params   = method(:call).parameters
+        keywords = params.select { |type, _| type == :keyreq || type == :key }
+                         .map { |_, name| name.to_s }
+
+        extra_declared = declared.keys - keywords
+        missing_types  = keywords - declared.keys
+
+        if extra_declared.any?
+          raise ArgumentError,
+            "#{name}: input_schema declares types for undeclared keyword args: #{extra_declared.join(', ')}"
+        end
+
+        if missing_types.any?
+          raise ArgumentError,
+            "#{name}: keyword args missing from input_schema declaration: #{missing_types.join(', ')}"
+        end
+
+        required = params.select { |type, _| type == :keyreq }.map { |_, name| name.to_s }
+
+        schema = {
+          "type"       => "object",
+          "properties" => declared.transform_values { |v| v.transform_keys(&:to_s) }
+        }
+        schema["required"] = required if required.any?
+        schema
+      end
+    end
   end
 end

--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -2,8 +2,6 @@
 
 module Orchestration
   class ActionsController < ApplicationController
-    include JsonParamsParsing
-
     before_action :set_action, only: [ :edit, :update, :destroy ]
     before_action :load_agents, only: [ :new, :create, :edit, :update ]
 
@@ -66,13 +64,9 @@ module Orchestration
     end
 
     def action_params
-      permitted = params.require(:orchestration_action).permit(
-        :name, :description, :kind, :agent_id, :agent_class, :params
+      params.require(:orchestration_action).permit(
+        :name, :description, :kind, :agent_id, :agent_class
       )
-      parse_json_field(permitted, :params)
-      permitted
-    rescue JSON::ParserError
-      permitted
     end
   end
 end

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -64,16 +64,10 @@ module Orchestration
 
     def agent_params
       permitted = params.require(:orchestration_agent).permit(
-        :name, :description, :model, :prompt, :params, :output_schema, tools: []
+        :name, :description, :model, :prompt, :output_schema, tools: []
       )
 
       permitted[:tools] = Array(permitted[:tools]).reject(&:blank?) if permitted.key?(:tools)
-
-      begin
-        parse_json_field(permitted, :params)
-      rescue JSON::ParserError
-        permitted[:params] = {}
-      end
 
       begin
         parse_json_field(permitted, :output_schema)

--- a/app/controllers/orchestration/step_actions_controller.rb
+++ b/app/controllers/orchestration/step_actions_controller.rb
@@ -6,11 +6,9 @@ module Orchestration
     before_action :set_step
 
     def create
-      raw = params.dig(:orchestration_step_action, :params)
       form = Orchestration::StepActionCreateForm.new(
         step: @step,
-        action_id: params.dig(:orchestration_step_action, :action_id),
-        params_json: raw
+        action_id: params.dig(:orchestration_step_action, :action_id)
       )
 
       if form.save

--- a/app/forms/orchestration/step_action_create_form.rb
+++ b/app/forms/orchestration/step_action_create_form.rb
@@ -6,7 +6,7 @@ module Orchestration
 
     validate :action_exists
 
-    def initialize(step:, action_id:, params_json: nil)
+    def initialize(step:, action_id:)
       @step = step
       @action_id = action_id.to_i
     end

--- a/app/forms/orchestration/step_action_create_form.rb
+++ b/app/forms/orchestration/step_action_create_form.rb
@@ -5,19 +5,10 @@ module Orchestration
     attr_reader :step_action
 
     validate :action_exists
-    validate :params_json_valid
 
     def initialize(step:, action_id:, params_json: nil)
       @step = step
       @action_id = action_id.to_i
-      raw = params_json.presence
-      if raw
-        begin
-          @parsed_params = JSON.parse(raw)
-        rescue JSON::ParserError
-          @params_parse_error = true
-        end
-      end
     end
 
     def save
@@ -27,7 +18,6 @@ module Orchestration
       key = Orchestration::OutputKeyDeriver.call(action_name: action.name, step: @step)
       @step_action = @step.step_actions.build(
         action_id: action.id,
-        params: @parsed_params,
         position: next_position,
         output_key: key
       )
@@ -46,10 +36,6 @@ module Orchestration
 
     def action_exists
       errors.add(:base, "Invalid action.") unless action
-    end
-
-    def params_json_valid
-      errors.add(:base, "Params must be valid JSON.") if @params_parse_error
     end
 
     def action

--- a/app/models/orchestration/action.rb
+++ b/app/models/orchestration/action.rb
@@ -12,6 +12,10 @@ module Orchestration
     validates :name, presence: true
     validate :kind_specific_fields_valid
 
+    def input_schema
+      agent? ? agent&.input_schema : agent_class&.safe_constantize&.input_schema
+    end
+
     private
 
     def kind_specific_fields_valid

--- a/app/services/emails/fetch_executor.rb
+++ b/app/services/emails/fetch_executor.rb
@@ -2,21 +2,27 @@ module Emails
   class FetchExecutor
     include Orchestration::Executable
 
-    DEFAULT_DATE = Date.today.to_s
-    DEFAULT_PROVIDERS = %w[gmail yahoo].freeze
+    DEFAULT_DATE        = Date.today.to_s
+    DEFAULT_PROVIDERS   = %w[gmail yahoo].freeze
     DEFAULT_MAX_RESULTS = 10
 
-    def self.call(input, params = {})
-      date        = Date.parse(input["date"] || DEFAULT_DATE)
-      after       = date - 1
-      providers   = input["providers"] || DEFAULT_PROVIDERS
-      max_results = params.fetch("max_results", DEFAULT_MAX_RESULTS).to_i
+    input_schema(
+      date:        { "type" => "string" },
+      providers:   { "type" => "array", "items" => { "type" => "string" } },
+      max_results: { "type" => "integer" }
+    )
+
+    def self.call(date: nil, providers: DEFAULT_PROVIDERS, max_results: DEFAULT_MAX_RESULTS, **)
+      parsed_date = Date.parse(date || DEFAULT_DATE)
+      after       = parsed_date - 1
+      providers   = DEFAULT_PROVIDERS if providers.nil?
+      max_results = DEFAULT_MAX_RESULTS if max_results.nil?
 
       emails = Sync do
         semaphore = Async::Semaphore.new(5)
         providers.map do |provider|
           semaphore.async do
-            Emails.list_messages(provider, max_results:, after_date: after, before_date: date)
+            Emails.list_messages(provider, max_results:, after_date: after, before_date: parsed_date)
           end
         end.flat_map(&:wait)
       end

--- a/app/services/emails/fetch_executor.rb
+++ b/app/services/emails/fetch_executor.rb
@@ -16,7 +16,7 @@ module Emails
       parsed_date = Date.parse(date || DEFAULT_DATE)
       after       = parsed_date - 1
       providers   = DEFAULT_PROVIDERS if providers.nil?
-      max_results = DEFAULT_MAX_RESULTS if max_results.nil?
+      max_results = (max_results || DEFAULT_MAX_RESULTS).to_i
 
       emails = Sync do
         semaphore = Async::Semaphore.new(5)

--- a/app/services/interviews/gist_export_executor.rb
+++ b/app/services/interviews/gist_export_executor.rb
@@ -2,11 +2,15 @@ module Interviews
   class GistExportExecutor
     include Orchestration::Executable
 
-    def self.call(input, _params = {})
-      gist_id = input.fetch("gist_id") { ENV.fetch("GIST_ID", nil) }
-      return { "skipped" => true, "reason" => "GIST_ID not configured" } if gist_id.nil?
+    input_schema(
+      gist_id: { "type" => "string" }
+    )
 
-      result = GistExportService.new(ids: nil, gist_id: gist_id).call
+    def self.call(gist_id: nil, **)
+      resolved_id = gist_id || ENV.fetch("GIST_ID", nil)
+      return { "skipped" => true, "reason" => "GIST_ID not configured" } if resolved_id.nil?
+
+      result = GistExportService.new(ids: nil, gist_id: resolved_id).call
       { "ok" => result.ok, "message" => result.message }
     end
   end

--- a/app/services/orchestration/agent_resolution_policy.rb
+++ b/app/services/orchestration/agent_resolution_policy.rb
@@ -1,16 +1,15 @@
 module Orchestration
   class AgentResolutionPolicy
-    Result = Data.define(:model, :prompt, :tools, :params, :output_schema)
+    Result = Data.define(:model, :prompt, :tools, :output_schema)
 
-    def self.call(action:, pipeline_model: nil, prompt_override: nil, step_params: nil, tool_classes: nil)
-      new(action:, pipeline_model:, prompt_override:, step_params:, tool_classes:).call
+    def self.call(action:, pipeline_model: nil, prompt_override: nil, tool_classes: nil)
+      new(action:, pipeline_model:, prompt_override:, tool_classes:).call
     end
 
-    def initialize(action:, pipeline_model: nil, prompt_override: nil, step_params: nil, tool_classes: nil)
+    def initialize(action:, pipeline_model: nil, prompt_override: nil, tool_classes: nil)
       @action = action
       @pipeline_model = pipeline_model
       @prompt_override = prompt_override
-      @step_params = step_params || {}
       @tool_classes = tool_classes
     end
 
@@ -19,7 +18,6 @@ module Orchestration
         model: resolved_model,
         prompt: resolved_prompt,
         tools: resolved_tools,
-        params: resolved_params,
         output_schema: resolved_output_schema
       )
     end
@@ -56,35 +54,8 @@ module Orchestration
       end
     end
 
-    def resolved_params
-      normalized_hash(agent_record.params, field_name: "agent params")
-        .merge(normalized_hash(@step_params, field_name: "step params"))
-    end
-
     def resolved_output_schema
       agent_record.output_schema.presence
-    end
-
-    def normalized_hash(value, field_name:)
-      return {} if value.nil?
-
-      parsed =
-        case value
-        when Hash
-          value
-        when String
-          return {} if value.blank?
-
-          JSON.parse(value)
-        else
-          raise ArgumentError, "#{field_name} must be a Hash or JSON object string, got #{value.class}"
-        end
-
-      return parsed.transform_keys(&:to_s) if parsed.is_a?(Hash)
-
-      raise ArgumentError, "#{field_name} must be a JSON object, got #{parsed.class}"
-    rescue JSON::ParserError => e
-      raise ArgumentError, "#{field_name} must be valid JSON: #{e.message}"
     end
   end
 end

--- a/app/services/orchestration/ingestion_executor.rb
+++ b/app/services/orchestration/ingestion_executor.rb
@@ -4,9 +4,12 @@ module Orchestration
 
     SUPPORTED_OPERATIONS = %w[filter_by_ids rename pick merge_by_index].freeze
 
-    def self.call(input, params = {})
-      operations = params.fetch("operations", [])
-      output = input.dup
+    input_schema(
+      operations: { "type" => "array" }
+    )
+
+    def self.call(operations: [], **data)
+      output = data.transform_keys(&:to_s)
 
       operations.each_with_object(output) do |op, acc|
         type = op.fetch("type")
@@ -22,22 +25,22 @@ module Orchestration
 
       def execute_operation(output, op)
         case op.fetch("type")
-        when "filter_by_ids" then apply_filter_by_ids(output, op)
-        when "rename"        then apply_rename(output, op)
-        when "pick"          then apply_pick(output, op)
+        when "filter_by_ids"  then apply_filter_by_ids(output, op)
+        when "rename"         then apply_rename(output, op)
+        when "pick"           then apply_pick(output, op)
         when "merge_by_index" then apply_merge_by_index(output, op)
         end
       end
 
       def apply_filter_by_ids(output, op)
-        source   = op.fetch("source")
-        ids_from = op.fetch("ids_from")
-        dest     = op.fetch("output")
+        source   = op.fetch("source").to_s
+        ids_from = op.fetch("ids_from").to_s
+        dest     = op.fetch("output").to_s
 
         id_items    = Array(dig_path(output, ids_from))
         allowed_ids = id_items.filter_map { |item| item_id(item) }.to_set
 
-        source_items = Array(dig_path(output, source))
+        source_items = Array(output[source])
         filtered     = source_items.select { |item| (id = item_id(item)) && allowed_ids.include?(id) }
 
         output.merge(dest => filtered)

--- a/app/services/orchestration/input_mapping_resolver.rb
+++ b/app/services/orchestration/input_mapping_resolver.rb
@@ -10,6 +10,8 @@ module Orchestration
 
     def resolve
       @input_mapping.transform_values do |spec|
+        next spec["value"] if spec.key?("value")
+
         from     = spec["from"]
         path     = spec["path"]
         optional = spec["optional"]

--- a/app/services/orchestration/input_mapping_resolver.rb
+++ b/app/services/orchestration/input_mapping_resolver.rb
@@ -10,6 +10,7 @@ module Orchestration
 
     def resolve
       @input_mapping.transform_values do |spec|
+        next spec unless spec.is_a?(Hash)
         next spec["value"] if spec.key?("value")
 
         from     = spec["from"]

--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -19,6 +19,7 @@ module Orchestration
           warnings = [] # : Array[Issue]
 
           validate_input_mapping(sa, known_schemas, errors, warnings)
+          validate_input_schema_coverage(sa, errors)
 
           results << StepResult.new(
             step_action_id: sa.id,
@@ -46,6 +47,7 @@ module Orchestration
 
         mapping.each do |mapping_key, spec|
           next unless spec.is_a?(Hash)
+          next if spec.key?("value")
 
           from = spec["from"]
           path = spec["path"]
@@ -61,16 +63,26 @@ module Orchestration
               path: nil
             )
           end
+        end
+      end
 
-          if merge_params(step_action).key?(mapping_key)
-            warnings << Issue.new(
-              code: :param_collision,
-              message: "key #{mapping_key.inspect} appears in both input_mapping and params; input_mapping wins at runtime",
-              mapping_key: mapping_key,
-              from: from,
-              path: nil
-            )
-          end
+      def validate_input_schema_coverage(step_action, errors)
+        schema = step_action.action.input_schema
+        return unless schema
+
+        required_keys = Array(schema["required"])
+        covered_keys  = (step_action.input_mapping || {}).keys
+
+        required_keys.each do |key|
+          next if covered_keys.include?(key)
+
+          errors << Issue.new(
+            code: :missing_required_input,
+            message: "input_schema requires #{key.inspect} but input_mapping has no entry for it",
+            mapping_key: key,
+            from: nil,
+            path: nil
+          )
         end
       end
 
@@ -110,10 +122,6 @@ module Orchestration
         end
 
         true
-      end
-
-      def merge_params(step_action)
-        (step_action.action.params || {}).merge(step_action.params || {})
       end
     end
   end

--- a/app/services/orchestration/pipeline/validator.rb
+++ b/app/services/orchestration/pipeline/validator.rb
@@ -70,7 +70,7 @@ module Orchestration
         schema = step_action.action.input_schema
         return unless schema
 
-        required_keys = Array(schema["required"])
+        required_keys = Array(schema["required"]) # : Array[String]
         covered_keys  = (step_action.input_mapping || {}).keys
 
         required_keys.each do |key|

--- a/app/services/orchestration/pipeline_runner.rb
+++ b/app/services/orchestration/pipeline_runner.rb
@@ -71,6 +71,9 @@ module Orchestration
       action_run.update!(status: "running", started_at: Time.current)
       action = action_run.step_action.action
       policy = action.agent? ? resolve_policy(action_run) : nil
+
+      validate_input_schema!(action_run)
+
       execution = run_agent(action_run, policy: policy)
       if action.agent?
         raise ArgumentError, "policy missing for agent action" unless policy
@@ -79,6 +82,13 @@ module Orchestration
       action_run.update!(status: "completed", output: execution[:output], error: nil, error_details: nil, finished_at: Time.current)
     rescue StandardError => error
       handle_action_failure(action_run, error, raw_content: execution&.dig(:raw_content))
+    end
+
+    def validate_input_schema!(action_run)
+      schema = action_run.step_action.action.input_schema
+      return unless schema
+
+      SchemaValidator.new(schema).validate!(action_run.input || {})
     end
 
     def run_agent(action_run, policy: nil)
@@ -94,11 +104,10 @@ module Orchestration
           model: policy.model,
           prompt: policy.prompt,
           tools: policy.tools&.map(&:to_s) || [],
-          params: policy.params,
           output_schema: policy.output_schema
         }
         action_run.update_columns(chat_id: chat_id, agent_snapshot: snapshot)
-        result = agent.ask(policy.params.merge(input).to_json)
+        result = agent.ask(input.to_json)
         output = parse_content(result.content, policy.output_schema.present?)
         normalized_output = policy.output_schema.present? ? output : { "result" => output }
         { output: normalized_output, raw_content: result.content }
@@ -106,8 +115,7 @@ module Orchestration
         klass = action.agent_class&.constantize
         raise ArgumentError, "Service class not found: #{action.agent_class}" unless klass
 
-        params = (action.params || {}).merge(action_run.step_action.params || {})
-        { output: klass.call(input, params), raw_content: nil }
+        { output: klass.call(**input.transform_keys(&:to_sym)), raw_content: nil }
       end
     end
 
@@ -116,8 +124,7 @@ module Orchestration
       AgentResolutionPolicy.call(
         action: action,
         pipeline_model: @pipeline_run.pipeline.model,
-        prompt_override: prompt_for(action.agent&.name),
-        step_params: action_run.step_action.params
+        prompt_override: prompt_for(action.agent&.name)
       )
     end
 

--- a/app/services/orchestration/query_executor.rb
+++ b/app/services/orchestration/query_executor.rb
@@ -3,16 +3,14 @@ module Orchestration
     include Orchestration::Executable
     extend Records::ModelResolver
 
-    def self.call(input, params = {})
-      table         = params.fetch("table")
-      column_name   = params.fetch("column_name")
-      column_values = if (path = params["column_values_from"])
-        Array(dig_path(input, path))
-      else
-        Array(params.fetch("column_values"))
-      end
-      columns = params["columns"]
+    input_schema(
+      table:         { "type" => "string" },
+      column_name:   { "type" => "string" },
+      column_values: { "type" => "array" },
+      columns:       { "type" => "array" }
+    )
 
+    def self.call(table:, column_name:, column_values:, columns: nil, **)
       model   = resolve_model(table)
       records = model.where(column_name => column_values)
       rows    = records.map do |record|
@@ -25,17 +23,6 @@ module Orchestration
       # steep:ignore:end
     rescue Records::ModelNotFound => error
       raise ArgumentError, error.message
-    end
-
-    class << self
-      private
-
-      def dig_path(hash, path)
-        path.split(".").reduce(hash) do |node, key|
-          break unless node.is_a?(Hash)
-          node[key]
-        end
-      end
     end
   end
 end

--- a/app/views/orchestration/actions/_form.html.erb
+++ b/app/views/orchestration/actions/_form.html.erb
@@ -41,11 +41,6 @@
     <% end %>
   </div>
 
-  <div>
-    <%= f.label :params, "Params (JSON)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_area :params, value: action.params ? action.params.to_json : "", rows: 3, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: '{"key": "value"}' %>
-  </div>
-
   <div class="flex items-center gap-3 pt-2">
     <%= f.submit class: "px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
     <%= link_to "Cancel", orchestration_actions_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -104,11 +104,6 @@
       <%= f.text_area :prompt, rows: 4, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
     </div>
 
-    <div>
-      <%= f.label :params, "Params (JSON object)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_area :params, value: agent.params.present? ? agent.params.to_json : "", rows: 3, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: '{"key":"value"}' %>
-    </div>
-
     <%# Hidden field — Stimulus (schema-builder controller) keeps this in sync with the builder %>
     <%= f.hidden_field :output_schema,
           value: agent.output_schema.present? ? agent.output_schema.to_json : "{}",

--- a/app/views/orchestration/agents/show.html.erb
+++ b/app/views/orchestration/agents/show.html.erb
@@ -16,7 +16,6 @@
         { label: "Model",         attribute: :model },
         { label: "Tools",         attribute: :tools,         type: :json },
         { label: "Prompt",        attribute: :prompt,        type: :multiline },
-        { label: "Params",        attribute: :params,        type: :json },
         { label: "Output Schema", attribute: :output_schema, type: :json }
       ]
     ) %>

--- a/db/migrate/20260506000001_seed_agents_from_app_agents_dir.rb
+++ b/db/migrate/20260506000001_seed_agents_from_app_agents_dir.rb
@@ -181,14 +181,13 @@ class SeedAgentsFromAppAgentsDir < ActiveRecord::Migration[8.1]
     AGENTS.each do |agent|
       execute(<<~SQL)
         INSERT OR IGNORE INTO orchestration_agents
-          (name, model, tools, prompt, enabled, params, created_at, updated_at)
+          (name, model, tools, prompt, enabled, created_at, updated_at)
         VALUES (
           #{quote(agent[:name])},
           #{quote(agent[:model])},
           #{quote(agent[:tools].to_json)},
           #{quote(agent[:prompt])},
           1,
-          '{}',
           #{quote(now)},
           #{quote(now)}
         )

--- a/db/migrate/20260526115644_add_input_schema_to_agents_and_remove_params.rb
+++ b/db/migrate/20260526115644_add_input_schema_to_agents_and_remove_params.rb
@@ -2,8 +2,8 @@ class AddInputSchemaToAgentsAndRemoveParams < ActiveRecord::Migration[8.1]
   def change
     add_column :orchestration_agents, :input_schema, :json
 
-    remove_column :orchestration_agents,      :params, :text
-    remove_column :orchestration_actions,     :params, :text
-    remove_column :orchestration_step_actions, :params, :text
+    remove_column :orchestration_agents,      :params, :json
+    remove_column :orchestration_actions,     :params, :json
+    remove_column :orchestration_step_actions, :params, :json
   end
 end

--- a/db/migrate/20260526115644_add_input_schema_to_agents_and_remove_params.rb
+++ b/db/migrate/20260526115644_add_input_schema_to_agents_and_remove_params.rb
@@ -1,0 +1,9 @@
+class AddInputSchemaToAgentsAndRemoveParams < ActiveRecord::Migration[8.1]
+  def change
+    add_column :orchestration_agents, :input_schema, :json
+
+    remove_column :orchestration_agents,      :params, :text
+    remove_column :orchestration_actions,     :params, :text
+    remove_column :orchestration_step_actions, :params, :text
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,30 +72,18 @@ CLASSIFY_EMAILS_INPUT_MAPPING = {
   "emails" => { "from" => "fetch_emails", "path" => "emails" }
 }.freeze
 
-FILTER_EMAILS_STEP_PARAMS = {
-  "topic" => "job applications"
-}.freeze
-
 FILTER_EMAILS_INPUT_MAPPING = {
+  "topic"  => { "value" => "job applications" },
   "emails" => { "from" => "classify_emails", "path" => "results" }
 }.freeze
 
 INGEST_EMAILS_INPUT_MAPPING = {
-  "emails"  => { "from" => "fetch_emails",  "path" => "emails" },
-  "results" => { "from" => "filter_emails", "path" => "results" }
-}.freeze
-
-INGEST_EMAILS_PARAMS = {
-  "operations" => [
+  "emails"     => { "from" => "fetch_emails",  "path" => "emails" },
+  "results"    => { "from" => "filter_emails", "path" => "results" },
+  "operations" => { "value" => [
     { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "results", "output" => "emails" },
     { "type" => "pick", "keys" => [ "emails" ] }
-  ]
-}.freeze
-
-QUERY_EMAIL_RECORDS_PARAMS = {
-  "table"              => "application_mails",
-  "column_name"        => "id",
-  "column_values_from" => "stored_ids"
+  ] }
 }.freeze
 
 MAP_EMAILS_INPUT_MAPPING = {
@@ -103,36 +91,29 @@ MAP_EMAILS_INPUT_MAPPING = {
 }.freeze
 
 STORE_EMAILS_INPUT_MAPPING = {
+  "label"  => { "value" => "applications" },
+  "table"  => { "value" => "application_mails" },
   "emails" => { "from" => "map_emails", "path" => "result.emails" }
 }.freeze
 
-STORE_EMAILS_STEP_PARAMS = {
-  "label" => "applications",
-  "table" => "application_mails"
-}.freeze
-
 QUERY_EMAIL_RECORDS_INPUT_MAPPING = {
-  "stored_ids" => { "from" => "store_emails", "path" => "result.ids" }
-}.freeze
-
-NORMALIZE_EMAILS_STEP_PARAMS = {
-  "destination_table"    => "application_mails",
-  "columns_to_normalize" => [ "company", "job_title" ]
+  "table"         => { "value" => "application_mails" },
+  "column_name"   => { "value" => "id" },
+  "column_values" => { "from" => "store_emails", "path" => "result.ids" }
 }.freeze
 
 NORMALIZE_EMAILS_INPUT_MAPPING = {
+  "destination_table"    => { "value" => "application_mails" },
+  "columns_to_normalize" => { "value" => [ "company", "job_title" ] },
   "records_to_normalize" => { "from" => "query_email_records", "path" => "application_mails" }
 }.freeze
 
-RECONCILE_EMAILS_STEP_PARAMS = {
-  "destination_table"  => "interviews",
-  "matching_columns"   => [ "company", "job_title" ],
-  "statuses"           => [ "pending_reply", "having_interviews", "rejected", "offer_received" ],
-  "initial_status"     => "pending_reply"
-}.freeze
-
 RECONCILE_EMAILS_INPUT_MAPPING = {
-  "emails_to_reconcile" => { "from" => "query_email_records", "path" => "application_mails" }
+  "destination_table"    => { "value" => "interviews" },
+  "matching_columns"     => { "value" => [ "company", "job_title" ] },
+  "statuses"             => { "value" => [ "pending_reply", "having_interviews", "rejected", "offer_received" ] },
+  "initial_status"       => { "value" => "pending_reply" },
+  "emails_to_reconcile"  => { "from" => "query_email_records", "path" => "application_mails" }
 }.freeze
 
 # Agent runtime configs — model, tools, and prompt.
@@ -317,16 +298,16 @@ AGENT_DEFINITIONS = {
 }.freeze
 
 steps = [
-  { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor",                                          sa_input_mapping: FETCH_EMAILS_INPUT_MAPPING     },
-  { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent",                                           sa_input_mapping: CLASSIFY_EMAILS_INPUT_MAPPING  },
-  { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent",  sa_params: FILTER_EMAILS_STEP_PARAMS,      sa_input_mapping: FILTER_EMAILS_INPUT_MAPPING    },
-  { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor",  params: INGEST_EMAILS_PARAMS, sa_input_mapping: INGEST_EMAILS_INPUT_MAPPING   },
-  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",                                            sa_input_mapping: MAP_EMAILS_INPUT_MAPPING       },
-  { name: "Store Emails",                   kind: :agent,   agent_name: "Records::StoreAgent",   sa_params: STORE_EMAILS_STEP_PARAMS,      sa_input_mapping: STORE_EMAILS_INPUT_MAPPING     },
-  { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",  params: QUERY_EMAIL_RECORDS_PARAMS, sa_input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING },
-  { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",  sa_params: NORMALIZE_EMAILS_STEP_PARAMS, sa_input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING },
-  { name: "Reconcile Emails to Interviews", kind: :agent,   agent_name: "Records::ReconcileAgent",  sa_params: RECONCILE_EMAILS_STEP_PARAMS, sa_input_mapping: RECONCILE_EMAILS_INPUT_MAPPING },
-  { name: "Export to Gist",                 kind: :service, agent_class: "Interviews::GistExportExecutor",                                 sa_input_mapping: {}                             }
+  { name: "Fetch Emails",                   kind: :service, agent_class: "Emails::FetchExecutor",              sa_input_mapping: FETCH_EMAILS_INPUT_MAPPING    },
+  { name: "Classify Emails",                kind: :agent,   agent_name: "Emails::ClassifyAgent",               sa_input_mapping: CLASSIFY_EMAILS_INPUT_MAPPING },
+  { name: "Filter Emails",                  kind: :agent,   agent_name: "Emails::FilterAgent",                 sa_input_mapping: FILTER_EMAILS_INPUT_MAPPING   },
+  { name: "Ingest Emails",                  kind: :service, agent_class: "Orchestration::IngestionExecutor",   sa_input_mapping: INGEST_EMAILS_INPUT_MAPPING   },
+  { name: "Map Emails",                     kind: :agent,   agent_name: "Emails::MappingAgent",                sa_input_mapping: MAP_EMAILS_INPUT_MAPPING      },
+  { name: "Store Emails",                   kind: :agent,   agent_name: "Records::StoreAgent",                 sa_input_mapping: STORE_EMAILS_INPUT_MAPPING    },
+  { name: "Query Email Records",            kind: :service, agent_class: "Orchestration::QueryExecutor",       sa_input_mapping: QUERY_EMAIL_RECORDS_INPUT_MAPPING },
+  { name: "Normalize Emails",               kind: :agent,   agent_name: "Records::NormalizeAgent",             sa_input_mapping: NORMALIZE_EMAILS_INPUT_MAPPING },
+  { name: "Reconcile Emails to Interviews", kind: :agent,   agent_name: "Records::ReconcileAgent",             sa_input_mapping: RECONCILE_EMAILS_INPUT_MAPPING },
+  { name: "Export to Gist",                 kind: :service, agent_class: "Interviews::GistExportExecutor",     sa_input_mapping: {}                             }
 ]
 
 Orchestration::Action.where(name: "Merge Email Records").destroy_all
@@ -347,7 +328,6 @@ action_records = steps.map do |attrs|
     a.kind        = attrs[:kind]
     a.agent       = agent_record
     a.agent_class = attrs[:agent_class]
-    a.params      = attrs[:params]
     a.save!
   end
 end
@@ -391,7 +371,6 @@ steps.each_with_index do |step_attrs, index|
     action:        action,
     position:      1,
     output_key:    action.name.parameterize(separator: "_"),
-    params:        step_attrs[:sa_params],
     input_mapping: step_attrs[:sa_input_mapping]
   )
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,10 @@ CREATE UNIQUE INDEX "index_application_mails_on_email_id" ON "application_mails"
 CREATE INDEX "index_application_mails_on_date" ON "application_mails" ("date") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "interviews" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "company" varchar NOT NULL, "job_title" varchar NOT NULL, "status" varchar DEFAULT 'pending_reply', "applied_at" date, "rejected_at" date, "first_interview_at" date, "second_interview_at" date, "third_interview_at" date, "fourth_interview_at" date, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_interviews_on_company_and_job_title" ON "interviews" ("company", "job_title") /*application='ApplicationPipeline'*/;
+CREATE VIRTUAL TABLE email_vectors USING vec0(
+  email_id TEXT PRIMARY KEY,
+  embedding FLOAT[1536]
+);
 CREATE TABLE IF NOT EXISTS "email_vectors_info" (key text primary key, value any);
 CREATE TABLE IF NOT EXISTS "email_vectors_chunks"(chunk_id INTEGER PRIMARY KEY AUTOINCREMENT,size INTEGER NOT NULL,validity BLOB NOT NULL,rowids BLOB NOT NULL);
 CREATE TABLE IF NOT EXISTS "email_vectors_rowids"(rowid INTEGER PRIMARY KEY AUTOINCREMENT,id TEXT UNIQUE NOT NULL,chunk_id INTEGER,chunk_offset INTEGER);
@@ -64,16 +68,7 @@ FOREIGN KEY ("evaluation_result_id")
   REFERENCES "evaluation_evaluation_results" ("id")
 );
 CREATE INDEX "index_evaluation_justifications_on_evaluation_result_id" ON "evaluation_justifications" ("evaluation_result_id") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "prompt" text /*application='ApplicationPipeline'*/, "params" json DEFAULT '{}' NOT NULL /*application='ApplicationPipeline'*/, "output_schema" json /*application='ApplicationPipeline'*/);
-CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name") /*application='ApplicationPipeline'*/;
 CREATE TABLE IF NOT EXISTS "email_connectors" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "provider" varchar NOT NULL, "configuration" text, "enabled" boolean DEFAULT TRUE NOT NULL, "last_connected_at" datetime(6), "status" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE TABLE IF NOT EXISTS "orchestration_step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "input_mapping" json, "output_key" varchar NOT NULL, CONSTRAINT "fk_rails_0b2a35e398"
-FOREIGN KEY ("action_id")
-  REFERENCES "orchestration_actions" ("id")
-, CONSTRAINT "fk_rails_d9cf618a2f"
-FOREIGN KEY ("step_id")
-  REFERENCES "orchestration_steps" ("id")
-);
 CREATE TABLE IF NOT EXISTS "orchestration_steps" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "pipeline_id" integer NOT NULL, "name" varchar NOT NULL, "position" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "enabled" boolean DEFAULT TRUE NOT NULL, CONSTRAINT "fk_rails_bbcf3ea2ee"
 FOREIGN KEY ("pipeline_id")
   REFERENCES "orchestration_pipelines" ("id")
@@ -81,22 +76,12 @@ FOREIGN KEY ("pipeline_id")
 CREATE TABLE IF NOT EXISTS "evaluation_wizard_drafts" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_token" varchar NOT NULL, "step" integer DEFAULT 1 NOT NULL, "payload" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE UNIQUE INDEX "index_evaluation_wizard_drafts_on_session_token" ON "evaluation_wizard_drafts" ("session_token") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_evaluation_prompts_on_name" ON "evaluation_prompts" ("name") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "orchestration_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "params" json, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, CONSTRAINT "fk_rails_951418a714"
-FOREIGN KEY ("agent_id")
-  REFERENCES "orchestration_agents" ("id")
-);
 CREATE INDEX "index_orchestration_pipelines_on_enabled_and_cron_expression" ON "orchestration_pipelines" ("enabled", "cron_expression") /*application='ApplicationPipeline'*/;
 CREATE INDEX "idx_on_pipeline_id_created_at_7642cfe1dd" ON "orchestration_pipeline_runs" ("pipeline_id", "created_at") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_orchestration_pipeline_runs_on_status" ON "orchestration_pipeline_runs" ("status") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_orchestration_pipeline_runs_on_pipeline_id" ON "orchestration_pipeline_runs" ("pipeline_id") /*application='ApplicationPipeline'*/;
 CREATE UNIQUE INDEX "index_orchestration_steps_on_pipeline_id_and_position" ON "orchestration_steps" ("pipeline_id", "position") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_orchestration_steps_on_pipeline_id" ON "orchestration_steps" ("pipeline_id") /*application='ApplicationPipeline'*/;
-CREATE INDEX "index_orchestration_actions_on_agent_id" ON "orchestration_actions" ("agent_id") /*application='ApplicationPipeline'*/;
-CREATE INDEX "index_orchestration_actions_on_agent_class" ON "orchestration_actions" ("agent_class") /*application='ApplicationPipeline'*/;
-CREATE UNIQUE INDEX "index_orchestration_step_actions_on_step_id_and_output_key" ON "orchestration_step_actions" ("step_id", "output_key") /*application='ApplicationPipeline'*/;
-CREATE UNIQUE INDEX "index_orchestration_step_actions_on_step_id_and_position" ON "orchestration_step_actions" ("step_id", "position") /*application='ApplicationPipeline'*/;
-CREATE INDEX "index_orchestration_step_actions_on_action_id" ON "orchestration_step_actions" ("action_id") /*application='ApplicationPipeline'*/;
-CREATE INDEX "index_orchestration_step_actions_on_step_id" ON "orchestration_step_actions" ("step_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_orchestration_action_runs_on_chat_id" ON "orchestration_action_runs" ("chat_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_orchestration_action_runs_on_status" ON "orchestration_action_runs" ("status") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_orchestration_action_runs_on_step_action_id" ON "orchestration_action_runs" ("step_action_id") /*application='ApplicationPipeline'*/;
@@ -144,7 +129,27 @@ FOREIGN KEY ("prompt_id")
 );
 CREATE INDEX "index_evaluation_experiments_on_prompt_id" ON "evaluation_experiments" ("prompt_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_evaluation_experiments_on_dataset_id" ON "evaluation_experiments" ("dataset_id") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "orchestration_agents" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "description" text, "model" varchar, "tools" json DEFAULT '[]', "enabled" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "prompt" text, "output_schema" json, "input_schema" json);
+CREATE UNIQUE INDEX "index_orchestration_agents_on_name" ON "orchestration_agents" ("name") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "orchestration_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "agent_class" varchar, "description" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "kind" varchar DEFAULT 'service' NOT NULL, "agent_id" integer, CONSTRAINT "fk_rails_e75e7d130e"
+FOREIGN KEY ("agent_id")
+  REFERENCES "orchestration_agents" ("id")
+);
+CREATE INDEX "index_orchestration_actions_on_agent_id" ON "orchestration_actions" ("agent_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_orchestration_actions_on_agent_class" ON "orchestration_actions" ("agent_class") /*application='ApplicationPipeline'*/;
+CREATE TABLE IF NOT EXISTS "orchestration_step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "input_mapping" json, "output_key" varchar NOT NULL, CONSTRAINT "fk_rails_5ad029fcf8"
+FOREIGN KEY ("action_id")
+  REFERENCES "orchestration_actions" ("id")
+, CONSTRAINT "fk_rails_f260603cab"
+FOREIGN KEY ("step_id")
+  REFERENCES "orchestration_steps" ("id")
+);
+CREATE UNIQUE INDEX "index_orchestration_step_actions_on_step_id_and_output_key" ON "orchestration_step_actions" ("step_id", "output_key") /*application='ApplicationPipeline'*/;
+CREATE UNIQUE INDEX "index_orchestration_step_actions_on_step_id_and_position" ON "orchestration_step_actions" ("step_id", "position") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_orchestration_step_actions_on_action_id" ON "orchestration_step_actions" ("action_id") /*application='ApplicationPipeline'*/;
+CREATE INDEX "index_orchestration_step_actions_on_step_id" ON "orchestration_step_actions" ("step_id") /*application='ApplicationPipeline'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260526115644'),
 ('20260525134853'),
 ('20260525133519'),
 ('20260523080923'),

--- a/sig/app/concerns/orchestration/executable.rbs
+++ b/sig/app/concerns/orchestration/executable.rbs
@@ -1,6 +1,7 @@
 module Orchestration
   module Executable
-    # Marker module. Includers must define:
-    #   .call(Hash[String, untyped], ?Hash[String, untyped]) -> Hash[String, untyped]
+    module ClassMethods
+      def input_schema: (?Hash[Symbol, Hash[String, untyped]] declared_types) -> Hash[String, untyped]?
+    end
   end
 end

--- a/sig/app/models/orchestration/action.rbs
+++ b/sig/app/models/orchestration/action.rbs
@@ -14,8 +14,7 @@ module Orchestration
     def agent_class=: (String?) -> String?
     def description: () -> String?
     def description=: (String?) -> String?
-    def params: () -> Hash[String, untyped]?
-    def params=: (Hash[String, untyped]?) -> Hash[String, untyped]?
+    def input_schema: () -> Hash[String, untyped]?
 
     def step_actions: () -> ActiveRecord::Associations::CollectionProxy
     def agent: () -> Orchestration::Agent?

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -17,8 +17,8 @@ module Orchestration
     def tools=: (Array[String]) -> Array[String]
     def prompt: () -> String?
     def prompt=: (String?) -> String?
-    def params: () -> Hash[String, untyped]
-    def params=: (Hash[String, untyped]) -> Hash[String, untyped]
+    def input_schema: () -> Hash[String, untyped]?
+    def input_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def output_schema: () -> Hash[String, untyped]?
     def output_schema=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def enabled: () -> bool

--- a/sig/app/models/orchestration/step_action.rbs
+++ b/sig/app/models/orchestration/step_action.rbs
@@ -8,9 +8,6 @@ module Orchestration
     def input_mapping=: (Hash[String, untyped]?) -> Hash[String, untyped]?
     def position: () -> Integer?
     def position=: (Integer?) -> Integer?
-    def params: () -> Hash[String, untyped]?
-    def params=: (Hash[String, untyped]?) -> Hash[String, untyped]?
-
     def step: () -> Orchestration::Step
     def step=: (Orchestration::Step) -> Orchestration::Step
     def action: () -> Orchestration::Action

--- a/sig/app/services/emails/fetch_executor.rbs
+++ b/sig/app/services/emails/fetch_executor.rbs
@@ -8,6 +8,7 @@ module Emails
     DEFAULT_MAX_RESULTS: Integer
 
     include Orchestration::Executable
-    def self.call: (Hash[String, untyped] input, ?Hash[String, untyped] params) -> fetch_result
+    extend Orchestration::Executable::ClassMethods
+    def self.call: (?date: String?, ?providers: Array[String], ?max_results: Integer) -> fetch_result
   end
 end

--- a/sig/app/services/interviews/gist_export_executor.rbs
+++ b/sig/app/services/interviews/gist_export_executor.rbs
@@ -1,6 +1,7 @@
 module Interviews
   class GistExportExecutor
     include Orchestration::Executable
-    def self.call: (Hash[String, untyped] input, ?Hash[String, untyped] params) -> Hash[String, untyped]
+    extend Orchestration::Executable::ClassMethods
+    def self.call: (?gist_id: String?) -> Hash[String, untyped]
   end
 end

--- a/sig/app/services/orchestration/agent_resolution_policy.rbs
+++ b/sig/app/services/orchestration/agent_resolution_policy.rbs
@@ -4,14 +4,12 @@ module Orchestration
       attr_reader model: String?
       attr_reader prompt: String?
       attr_reader tools: Array[untyped]?
-      attr_reader params: Hash[String, untyped]
       attr_reader output_schema: Hash[String, untyped]?
 
       def initialize: (
         model: String?,
         prompt: String?,
         tools: Array[untyped]?,
-        params: Hash[String, untyped],
         output_schema: Hash[String, untyped]?
       ) -> void
     end
@@ -20,7 +18,6 @@ module Orchestration
       action: Action,
       ?pipeline_model: String?,
       ?prompt_override: String?,
-      ?step_params: Hash[String, untyped]?,
       ?tool_classes: Array[untyped]?
     ) -> Result
 
@@ -28,7 +25,6 @@ module Orchestration
       action: Action,
       ?pipeline_model: String?,
       ?prompt_override: String?,
-      ?step_params: Hash[String, untyped]?,
       ?tool_classes: Array[untyped]?
     ) -> void
 
@@ -40,7 +36,6 @@ module Orchestration
     def resolved_model: () -> String?
     def resolved_prompt: () -> String?
     def resolved_tools: () -> Array[untyped]?
-    def resolved_params: () -> Hash[String, untyped]
     def resolved_output_schema: () -> Hash[String, untyped]?
     def resolved_generation_schema: () -> Hash[String, untyped]?
     def normalized_hash: (Hash[untyped, untyped] | String | nil value, field_name: String) -> Hash[String, untyped]

--- a/sig/app/services/orchestration/ingestion_executor.rbs
+++ b/sig/app/services/orchestration/ingestion_executor.rbs
@@ -3,8 +3,9 @@ module Orchestration
     SUPPORTED_OPERATIONS: Array[String]
 
     include Executable
+    extend Executable::ClassMethods
 
-    def self.call: (json_object input, ?Hash[String, untyped] params) -> Hash[String, untyped]
+    def self.call: (?operations: Array[Hash[String, untyped]]) -> Hash[String, untyped]
 
     def self.execute_operation: (json_object output, Hash[String, untyped] op) -> untyped
     def self.apply_filter_by_ids: (json_object output, Hash[String, untyped] op) -> Hash[String, untyped]

--- a/sig/app/services/orchestration/pipeline/validator.rbs
+++ b/sig/app/services/orchestration/pipeline/validator.rbs
@@ -27,9 +27,9 @@ module Orchestration
 
       def ordered_step_actions: () -> Array[Orchestration::StepAction]
       def validate_input_mapping: (Orchestration::StepAction step_action, Hash[String, untyped] known_schemas, Array[Issue] errors, Array[Issue] warnings) -> void
+      def validate_input_schema_coverage: (Orchestration::StepAction step_action, Array[Issue] errors) -> void
       def validate_path_vs_schema: (String from, String? path, String mapping_key, Hash[String, untyped]? upstream_schema, Array[Issue] errors) -> void
       def path_valid_in_schema?: (String path, Hash[String, untyped] schema) -> bool
-      def merge_params: (Orchestration::StepAction step_action) -> Hash[String, untyped]
     end
   end
 end

--- a/sig/app/services/orchestration/pipeline_runner.rbs
+++ b/sig/app/services/orchestration/pipeline_runner.rbs
@@ -12,6 +12,7 @@ module Orchestration
     def resolve_policy: (ActionRun action_run) -> AgentResolutionPolicy::Result
     def parse_content: (String | untyped content, bool structured_output_expected) -> untyped
     def validate_output!: (untyped output, policy: AgentResolutionPolicy::Result, raw_content: untyped) -> void
+    def validate_input_schema!: (ActionRun action_run) -> void
     def handle_action_failure: (ActionRun action_run, StandardError error, raw_content: untyped) -> void
     def log_action_failure: (ActionRun action_run, NormalizeActionRunFailure::Result failure) -> void
     def prompt_for: (String? agent_name) -> String?

--- a/sig/app/services/orchestration/query_executor.rbs
+++ b/sig/app/services/orchestration/query_executor.rbs
@@ -1,9 +1,10 @@
 module Orchestration
   class QueryExecutor
     include Executable
+    extend Executable::ClassMethods
     extend Records::ModelResolver
 
-    def self.call: (Hash[String, untyped] input, ?Hash[String, untyped] params) -> Hash[String, Array[Hash[String, untyped]]]
+    def self.call: (table: String, column_name: String, column_values: Array[untyped], ?columns: Array[String]?) -> Hash[String, Array[Hash[String, untyped]]]
 
     def self.dig_path: (Hash[String, untyped] hash, String path) -> untyped
   end

--- a/spec/components/orchestration/step_component_spec.rb
+++ b/spec/components/orchestration/step_component_spec.rb
@@ -96,9 +96,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
   context "when the step has step_actions" do
     let(:step) do
       sa = build_stubbed(:orchestration_step_action,
-                         action: build_stubbed(:orchestration_action, name: "Classify Agent")).tap do |s|
-        allow(s).to receive(:params).and_return(nil)
-      end
+                         action: build_stubbed(:orchestration_action, name: "Classify Agent"))
       build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
         allow(s).to receive_messages(step_actions: [ sa ],)
       end
@@ -160,9 +158,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: { "email" => { "from" => "_initial", "path" => nil } },
-                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
-        allow(s).to receive(:params).and_return(nil)
-      end
+                         action: build_stubbed(:orchestration_action, name: "My Action"))
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
         allow(s).to receive_messages(step_actions: [ sa ])
       end
@@ -193,9 +189,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: { "email" => { "from" => "prior_action", "path" => nil } },
-                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
-        allow(s).to receive(:params).and_return(nil)
-      end
+                         action: build_stubbed(:orchestration_action, name: "My Action"))
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
         allow(s).to receive_messages(step_actions: [ sa ])
       end
@@ -221,9 +215,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: { "email" => { "from" => "_initial", "path" => nil } },
-                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
-        allow(s).to receive(:params).and_return(nil)
-      end
+                         action: build_stubbed(:orchestration_action, name: "My Action"))
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
         allow(s).to receive_messages(step_actions: [ sa ])
       end
@@ -249,9 +241,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: {},
-                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
-        allow(s).to receive(:params).and_return(nil)
-      end
+                         action: build_stubbed(:orchestration_action, name: "My Action"))
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
         allow(s).to receive_messages(step_actions: [ sa ])
       end
@@ -284,9 +274,7 @@ RSpec.describe Orchestration::StepComponent, type: :component do
       sa = build_stubbed(:orchestration_step_action,
                          id: 99, output_key: "my_action",
                          input_mapping: {},
-                         action: build_stubbed(:orchestration_action, name: "My Action")).tap do |s|
-        allow(s).to receive(:params).and_return(nil)
-      end
+                         action: build_stubbed(:orchestration_action, name: "My Action"))
       the_step = build_stubbed(:orchestration_step, id: 10, pipeline: pipeline, name: "My Step", position: 2, enabled: true).tap do |s|
         allow(s).to receive_messages(step_actions: [ sa ])
       end

--- a/spec/concerns/orchestration/executable_spec.rb
+++ b/spec/concerns/orchestration/executable_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Orchestration::Executable do
       end
 
       it 'lists only keyreq params as required' do
-        expect(schema["required"]).to eq(["date"])
+        expect(schema["required"]).to eq([ "date" ])
       end
 
       it 'preserves nested type definitions' do

--- a/spec/concerns/orchestration/executable_spec.rb
+++ b/spec/concerns/orchestration/executable_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Orchestration::Executable do
+  def make_executor(&block)
+    Class.new do
+      include Orchestration::Executable
+      class_eval(&block)
+    end
+  end
+
+  describe '.input_schema' do
+    context 'with a valid declaration covering all keyword args' do
+      subject(:schema) do
+        make_executor do
+          input_schema(
+            date:      { "type" => "string" },
+            providers: { "type" => "array", "items" => { "type" => "string" } }
+          )
+          def self.call(date:, providers: [], **); end
+        end.input_schema
+      end
+
+      it 'returns type object at top level' do
+        expect(schema["type"]).to eq("object")
+      end
+
+      it 'includes all declared properties' do
+        expect(schema["properties"].keys).to contain_exactly("date", "providers")
+      end
+
+      it 'lists only keyreq params as required' do
+        expect(schema["required"]).to eq(["date"])
+      end
+
+      it 'preserves nested type definitions' do
+        expect(schema["properties"]["providers"]).to eq(
+          "type" => "array", "items" => { "type" => "string" }
+        )
+      end
+    end
+
+    context 'when a required keyword arg has no declared type' do
+      it 'raises ArgumentError at schema access time' do
+        klass = make_executor do
+          input_schema(date: { "type" => "string" })
+          def self.call(date:, topic:, **); end
+        end
+
+        expect { klass.input_schema }.to raise_error(ArgumentError, /topic/)
+      end
+    end
+
+    context 'when a declared type has no matching keyword arg' do
+      it 'raises ArgumentError at schema access time' do
+        klass = make_executor do
+          input_schema(date: { "type" => "string" }, ghost: { "type" => "string" })
+          def self.call(date:, **); end
+        end
+
+        expect { klass.input_schema }.to raise_error(ArgumentError, /ghost/)
+      end
+    end
+
+    context 'when input_schema is not declared' do
+      it 'returns nil' do
+        klass = make_executor { def self.call(**); end }
+        expect(klass.input_schema).to be_nil
+      end
+    end
+
+    context 'when there are no keyword args (only **)' do
+      it 'raises ArgumentError when types are declared but no keyword args exist' do
+        klass = make_executor do
+          input_schema(date: { "type" => "string" })
+          def self.call(**); end
+        end
+
+        expect { klass.input_schema }.to raise_error(ArgumentError, /date/)
+      end
+    end
+  end
+end

--- a/spec/db/seeds_agent_backfill_spec.rb
+++ b/spec/db/seeds_agent_backfill_spec.rb
@@ -84,10 +84,10 @@ RSpec.describe "Seeds: agent config backfill" do # rubocop:disable RSpec/Describ
   end
 
   describe "Ingest Emails step" do
-    subject(:action) { Orchestration::Action.find_by!(name: "Ingest Emails") }
+    subject(:step_action) { Orchestration::Pipeline.find_by!(name: "Applications Workflow").steps.find_by!(name: "Ingest Emails").step_actions.first! }
 
     it "uses ids_from: 'results' (Filter Emails output is unwrapped since it has output_schema)" do
-      filter_op = action.params["operations"].find { |op| op["type"] == "filter_by_ids" }
+      filter_op = step_action.input_mapping["operations"]["value"].find { |op| op["type"] == "filter_by_ids" }
       expect(filter_op["ids_from"]).to eq("results")
     end
   end

--- a/spec/db/seeds_pipeline_input_mapping_spec.rb
+++ b/spec/db/seeds_pipeline_input_mapping_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe "Seeds: pipeline 2 step input_mapping" do # rubocop:disable RSpec
   describe "Filter Emails (step 3)" do
     subject(:sa) { step_action_for("Filter Emails") }
 
-    it "has topic param set to job applications" do
-      expect(sa.params).to include("topic" => "job applications")
+    it "has topic set as static value in input_mapping" do
+      expect(sa.input_mapping).to include("topic" => { "value" => "job applications" })
     end
 
     it "maps emails from classify_emails results" do

--- a/spec/factories/orchestration_agents.rb
+++ b/spec/factories/orchestration_agents.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Agent::Class#{n}" }
     enabled { true }
     prompt { nil }
-    params { {} }
+    input_schema { nil }
     output_schema { nil }
   end
 end

--- a/spec/forms/orchestration/step_action_create_form_spec.rb
+++ b/spec/forms/orchestration/step_action_create_form_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe Orchestration::StepActionCreateForm do
       end
     end
 
-    context "with valid JSON params" do
-      it "parses and stores them" do
-        build_form(params_json: '{"threshold": 0.8}').save
-        expect(step.step_actions.last.params).to eq("threshold" => 0.8)
-      end
-    end
-
     context "with an invalid action_id" do
       it "returns false" do
         expect(build_form(action_id: 0).save).to be false
@@ -65,22 +58,6 @@ RSpec.describe Orchestration::StepActionCreateForm do
         form = build_form(action_id: 0)
         form.save
         expect(form.errors.full_messages).to include("Invalid action.")
-      end
-    end
-
-    context "with invalid JSON in params" do
-      it "returns false" do
-        expect(build_form(params_json: "{not json}").save).to be false
-      end
-
-      it "does not create a step_action" do
-        expect { build_form(params_json: "{not json}").save }.not_to change(Orchestration::StepAction, :count)
-      end
-
-      it "adds an error message about valid JSON" do
-        form = build_form(params_json: "{not json}")
-        form.save
-        expect(form.errors.full_messages.first).to include("valid JSON")
       end
     end
 

--- a/spec/forms/orchestration/step_action_create_form_spec.rb
+++ b/spec/forms/orchestration/step_action_create_form_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Orchestration::StepActionCreateForm do
   let(:step)     { create(:orchestration_step, pipeline: pipeline) }
   let(:action)   { create(:orchestration_action, name: "Classify Emails") }
 
-  def build_form(action_id: action.id, params_json: nil)
-    described_class.new(step: step, action_id: action_id, params_json: params_json)
+  def build_form(action_id: action.id)
+    described_class.new(step: step, action_id: action_id)
   end
 
   describe "#save" do

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Orchestration::Action do
   end
 
   describe '#input_schema' do
-    context 'for an agent-kind action' do
+    context 'when action is agent-kind' do
       it 'delegates to the associated agent' do
         schema = { "type" => "object", "properties" => { "emails" => { "type" => "array" } } }
         agent  = create(:orchestration_agent, input_schema: schema)
@@ -98,7 +98,7 @@ RSpec.describe Orchestration::Action do
       end
     end
 
-    context 'for a service-kind action' do
+    context 'when action is service-kind' do
       it 'delegates to the service class input_schema' do
         stub_const("MyExecutable", Class.new do
           include Orchestration::Executable

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -72,10 +72,47 @@ RSpec.describe Orchestration::Action do
   end
 
   describe "columns" do
-    it "does not expose the dropped LLM config attributes" do
+    it "does not expose dropped LLM config DB attributes" do
       action = build(:orchestration_action)
-      %i[prompt model tools output_schema input_schema schema_class].each do |attr|
+      %i[prompt model tools output_schema schema_class].each do |attr|
         expect(action).not_to respond_to(attr)
+      end
+    end
+  end
+
+  describe '#input_schema' do
+    context 'for an agent-kind action' do
+      it 'delegates to the associated agent' do
+        schema = { "type" => "object", "properties" => { "emails" => { "type" => "array" } } }
+        agent  = create(:orchestration_agent, input_schema: schema)
+        action = create(:orchestration_action, agent:)
+
+        expect(action.input_schema).to eq(schema)
+      end
+
+      it 'returns nil when the agent has no input_schema' do
+        agent  = create(:orchestration_agent, input_schema: nil)
+        action = create(:orchestration_action, agent:)
+
+        expect(action.input_schema).to be_nil
+      end
+    end
+
+    context 'for a service-kind action' do
+      it 'delegates to the service class input_schema' do
+        stub_const("MyExecutable", Class.new do
+          include Orchestration::Executable
+          input_schema(topic: { "type" => "string" })
+          def self.call(topic:, **); end
+        end)
+        action = create(:orchestration_action, :service_kind, agent_class: "MyExecutable")
+
+        expect(action.input_schema["properties"].keys).to include("topic")
+      end
+
+      it 'returns nil when agent_class is blank' do
+        action = build(:orchestration_action, :service_kind, agent_class: nil)
+        expect(action.input_schema).to be_nil
       end
     end
   end

--- a/spec/requests/orchestration/actions_spec.rb
+++ b/spec/requests/orchestration/actions_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe "Orchestration::Actions" do
             name: "New Action",
             kind: "agent",
             agent_id: orchestration_agent.id,
-            description: "A description",
-            prompt: "Classify this email",
-            params: '{"key":"value"}'
+            description: "A description"
           }
         }
       end

--- a/spec/requests/orchestration/agents_spec.rb
+++ b/spec/requests/orchestration/agents_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe "Orchestration::Agents" do
             model: "mistral-small",
             tools: [],
             prompt: "Classify this payload",
-            params: '{"mode":"strict"}',
             output_schema: '{"type":"object","required":["result"],"properties":{"result":{"type":"array"}}}'
           }
         }
@@ -57,7 +56,6 @@ RSpec.describe "Orchestration::Agents" do
         }.to change(Orchestration::Agent, :count).by(1)
         expect(response).to redirect_to(orchestration_agents_path)
         expect(Orchestration::Agent.last.prompt).to eq("Classify this payload")
-        expect(Orchestration::Agent.last.params).to eq({ "mode" => "strict" })
         expect(Orchestration::Agent.last.output_schema).to eq(
           "type" => "object",
           "required" => [ "result" ],
@@ -72,19 +70,17 @@ RSpec.describe "Orchestration::Agents" do
         expect(response).to have_http_status(:unprocessable_content)
       end
 
-      it "preserves valid JSON fields when one JSON field is invalid" do # rubocop:disable RSpec/ExampleLength
+      it "preserves valid fields when output_schema JSON is invalid" do
         post orchestration_agents_path, params: {
           orchestration_agent: {
             name: "Emails::ClassifyAgent",
             tools: [ "Records::TempFileTool" ],
-            params: '{"mode":"strict"}',
             output_schema: "{invalid"
           }
         }
 
         agent = Orchestration::Agent.last
         expect(agent.tools).to eq([ "Records::TempFileTool" ])
-        expect(agent.params).to eq({ "mode" => "strict" })
         expect(agent.output_schema).to be_nil
       end
     end

--- a/spec/requests/orchestration/pipeline_lifecycle_spec.rb
+++ b/spec/requests/orchestration/pipeline_lifecycle_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
             name: "Query Interviews",
             kind: "service",
             agent_class: "Orchestration::QueryExecutor",
-            description: "Fetches interviews from the database",
-            params: '{"table":"interviews","column_name":"status","column_values":["screening"],"columns":["id","company","job_title"]}'
+            description: "Fetches interviews from the database"
           }
         }
       }.to change(Orchestration::Action, :count).by(1)
@@ -28,7 +27,6 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
       query_action = Orchestration::Action.last
       expect(response).to redirect_to(orchestration_actions_path)
       expect(query_action.agent_class).to eq("Orchestration::QueryExecutor")
-      expect(query_action.params).to include("table" => "interviews")
 
       classify_agent_record = create(:orchestration_agent, name: "Emails::ClassifyAgent")
 
@@ -112,8 +110,7 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
     let!(:query_action) do
       create(:orchestration_action, :service_kind,
         name: "Query Interviews",
-        agent_class: "Orchestration::QueryExecutor",
-        params: { "table" => "interviews", "column_name" => "status", "column_values" => [ "screening" ] })
+        agent_class: "Orchestration::QueryExecutor")
     end
     let!(:classify_agent) do
       create(:orchestration_agent,
@@ -129,7 +126,12 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
     let!(:classify_step) { create(:orchestration_step, pipeline: pipeline, name: "Classify Emails", position: 2) }
 
     before do
-      create(:orchestration_step_action, step: fetch_step, action: query_action, position: 1)
+      create(:orchestration_step_action, step: fetch_step, action: query_action, position: 1,
+        input_mapping: {
+          "table"         => { "value" => "interviews" },
+          "column_name"   => { "value" => "status" },
+          "column_values" => { "value" => [ "screening" ] }
+        })
       create(:orchestration_step_action, step: classify_step, action: classify_action, position: 1)
     end
 
@@ -181,16 +183,14 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
   describe "edit: updating an existing pipeline's metadata, steps, and action attachments" do
     let!(:ingest_action) do
       create(:orchestration_action, :service_kind, name: "Transform Data",
-        agent_class: "Orchestration::IngestionExecutor",
-        params: { "operations" => [ { "type" => "pick", "keys" => [ "interviews" ] } ] })
+        agent_class: "Orchestration::IngestionExecutor")
     end
     let!(:pipeline) { create(:orchestration_pipeline, name: "Job Application Pipeline", enabled: true) }
     let!(:fetch_step) { create(:orchestration_step, pipeline: pipeline, name: "Fetch Interviews", position: 1) }
     let!(:classify_step) { create(:orchestration_step, pipeline: pipeline, name: "Classify Emails", position: 2) }
     let!(:fetch_step_action) do
       query_action = create(:orchestration_action, :service_kind, name: "Query Interviews",
-        agent_class: "Orchestration::QueryExecutor",
-        params: { "table" => "interviews", "column_name" => "status", "column_values" => [ "screening" ] })
+        agent_class: "Orchestration::QueryExecutor")
       create(:orchestration_step_action, step: fetch_step, action: query_action, position: 1)
     end
 
@@ -236,17 +236,13 @@ RSpec.describe "Orchestration::Pipeline lifecycle" do
       expect(transform_step.position).to eq(3)
 
       post orchestration_pipeline_step_step_actions_path(pipeline, transform_step), params: {
-        orchestration_step_action: {
-          action_id: ingest_action.id,
-          params: '{"operations":[{"type":"pick","keys":["interviews"]}]}'
-        }
+        orchestration_step_action: { action_id: ingest_action.id }
       }
 
       transform_step.reload
       expect(transform_step.step_actions.count).to eq(1)
       step_action = transform_step.step_actions.first
       expect(step_action.action).to eq(ingest_action)
-      expect(step_action.params).to eq("operations" => [ { "type" => "pick", "keys" => [ "interviews" ] } ])
     end
     # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength
 

--- a/spec/requests/orchestration/pipelines_spec.rb
+++ b/spec/requests/orchestration/pipelines_spec.rb
@@ -311,19 +311,6 @@ RSpec.describe "Orchestration::Pipelines" do
       expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
       expect(Orchestration::StepAction.last.position).to eq(1)
     end
-
-    it "attaches with optional params override JSON" do
-      pipeline = create(:orchestration_pipeline)
-      step = create(:orchestration_step, pipeline: pipeline, position: 1)
-      action = create(:orchestration_action)
-
-      post orchestration_pipeline_step_step_actions_path(pipeline, step), params: {
-        orchestration_step_action: { action_id: action.id, params: '{"override":"true"}' }
-      }
-
-      expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
-      expect(Orchestration::StepAction.last.params).to eq({ "override" => "true" })
-    end
   end
 
   describe "POST /orchestration/pipelines/:id/run" do

--- a/spec/requests/orchestration/step_actions_spec.rb
+++ b/spec/requests/orchestration/step_actions_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "Orchestration::StepActions" do
       orchestration_pipeline_step_step_actions_path(pipeline, step)
     end
 
-    def post_create(action_id: action.id, params_json: nil)
+    def post_create(action_id: action.id)
       post create_path, params: {
-        orchestration_step_action: { action_id: action_id, params: params_json }.compact
+        orchestration_step_action: { action_id: action_id }
       }
     end
 
@@ -31,11 +31,6 @@ RSpec.describe "Orchestration::StepActions" do
         post_create
         expect(step.step_actions.last.output_key).to eq("classify_emails")
       end
-
-      it "parses valid JSON params and stores them" do
-        post_create(params_json: '{"threshold": 0.8}')
-        expect(step.step_actions.last.params).to eq("threshold" => 0.8)
-      end
     end
 
     context "with an invalid action_id" do
@@ -47,18 +42,6 @@ RSpec.describe "Orchestration::StepActions" do
         expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
         follow_redirect!
         expect(response.body).to include("Invalid action")
-      end
-    end
-
-    context "with invalid JSON in params" do
-      it "redirects with an alert and does not create a step_action" do
-        expect {
-          post_create(params_json: "{not json}")
-        }.not_to change(Orchestration::StepAction, :count)
-
-        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
-        follow_redirect!
-        expect(response.body).to include("valid JSON")
       end
     end
 
@@ -134,20 +117,5 @@ RSpec.describe "Orchestration::StepActions" do
       end
     end
 
-    context "when Pipeline::Validator returns warnings (param collision)" do
-      before do
-        action.update!(params: { "email" => "default@example.com" })
-        step_action.update!(params: { "email" => "override@example.com" })
-      end
-
-      it "saves the mapping and shows advisory warning in notice" do
-        patch_update(input_mapping: { "email" => { "from" => "_initial", "path" => "" } })
-
-        expect(response).to redirect_to(orchestration_pipeline_path(pipeline))
-        follow_redirect!
-        expect(response.body).to include("param_collision").or include("Warning")
-        expect(step_action.reload.input_mapping).to have_key("email")
-      end
-    end
   end
 end

--- a/spec/requests/orchestration/step_actions_spec.rb
+++ b/spec/requests/orchestration/step_actions_spec.rb
@@ -116,6 +116,5 @@ RSpec.describe "Orchestration::StepActions" do
         expect(step_action.reload.input_mapping).to eq(original_mapping)
       end
     end
-
   end
 end

--- a/spec/services/emails/fetch_executor_spec.rb
+++ b/spec/services/emails/fetch_executor_spec.rb
@@ -8,39 +8,50 @@ RSpec.describe Emails::FetchExecutor do
       allow(Emails).to receive(:list_messages).and_return([])
     end
 
-    it 'calls Emails.list_messages for both gmail and yahoo' do
+    it 'calls Emails.list_messages for each provider' do
       allow(Emails).to receive(:list_messages).with('gmail', any_args).and_return([ { id: 1 } ])
       allow(Emails).to receive(:list_messages).with('yahoo', any_args).and_return([ { id: 2 } ])
 
-      result = described_class.call({ "date" => date.to_s })
+      result = described_class.call(date: date.to_s, providers: %w[gmail yahoo])
       expect(result).to eq({ "emails" => [ { id: 1 }, { id: 2 } ] })
     end
 
-    it 'uses today as default date when key is absent' do
-      described_class.call({})
+    it 'uses today as default date when not provided' do
+      described_class.call
 
       expect(Emails).to have_received(:list_messages).with('gmail', hash_including(after_date: date - 1, before_date: date))
       expect(Emails).to have_received(:list_messages).with('yahoo', hash_including(after_date: date - 1, before_date: date))
     end
 
-    it 'falls back to today when date is nil (optional mapping from scheduled run)' do
-      described_class.call({ "date" => nil, "providers" => nil })
+    it 'falls back to today when date is nil' do
+      described_class.call(date: nil)
 
       expect(Emails).to have_received(:list_messages).with('gmail', hash_including(after_date: date - 1, before_date: date))
-      expect(Emails).to have_received(:list_messages).with('yahoo', hash_including(after_date: date - 1, before_date: date))
     end
 
-    it 'passes max_results from params to list_messages' do
-      described_class.call({ "date" => date.to_s }, { "max_results" => 5 })
+    it 'passes max_results to list_messages' do
+      described_class.call(date: date.to_s, max_results: 5)
 
       expect(Emails).to have_received(:list_messages).with('gmail', hash_including(max_results: 5))
       expect(Emails).to have_received(:list_messages).with('yahoo', hash_including(max_results: 5))
     end
 
-    it 'defaults to 10 max_results when not specified' do
-      described_class.call({ "date" => date.to_s })
+    it 'defaults to 10 max_results' do
+      described_class.call(date: date.to_s)
 
       expect(Emails).to have_received(:list_messages).with('gmail', hash_including(max_results: 10))
+    end
+
+    describe '.input_schema' do
+      it 'returns a valid JSON Schema object' do
+        schema = described_class.input_schema
+        expect(schema["type"]).to eq("object")
+        expect(schema["properties"].keys).to include("date", "providers", "max_results")
+      end
+
+      it 'has no required fields (all have defaults)' do
+        expect(described_class.input_schema["required"]).to be_nil
+      end
     end
   end
 end

--- a/spec/services/interviews/gist_export_executor_spec.rb
+++ b/spec/services/interviews/gist_export_executor_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Interviews::GistExportExecutor do
       allow(Interviews::GistExportService).to receive(:new).with(ids: nil, gist_id: gist_id).and_return(service)
       allow(service).to receive(:call).and_return(result)
 
-      output = described_class.call({ "gist_id" => gist_id })
+      output = described_class.call(gist_id: gist_id)
       expect(output).to eq({ "ok" => true, "message" => "Success" })
     end
 
-    it 'calls GistExportService with gist_id from ENV if not in input' do
+    it 'falls back to ENV when gist_id is not provided' do
       allow(ENV).to receive(:fetch).with("GIST_ID", nil).and_return(gist_id)
       service = instance_double(Interviews::GistExportService)
       result = Interviews::GistExportService::Result.new(ok: true, message: 'Success')
@@ -23,15 +23,23 @@ RSpec.describe Interviews::GistExportExecutor do
       allow(Interviews::GistExportService).to receive(:new).with(ids: nil, gist_id: gist_id).and_return(service)
       allow(service).to receive(:call).and_return(result)
 
-      output = described_class.call({})
+      output = described_class.call
       expect(output).to eq({ "ok" => true, "message" => "Success" })
     end
 
-    it 'returns skipped if gist_id is missing' do
+    it 'returns skipped when gist_id is absent and ENV unset' do
       allow(ENV).to receive(:fetch).with("GIST_ID", nil).and_return(nil)
 
-      output = described_class.call({})
+      output = described_class.call
       expect(output).to eq({ "skipped" => true, "reason" => "GIST_ID not configured" })
+    end
+
+    describe '.input_schema' do
+      it 'declares gist_id as an optional string' do
+        schema = described_class.input_schema
+        expect(schema["properties"]["gist_id"]["type"]).to eq("string")
+        expect(schema["required"]).to be_nil
+      end
     end
   end
 end

--- a/spec/services/orchestration/agent_resolution_policy_spec.rb
+++ b/spec/services/orchestration/agent_resolution_policy_spec.rb
@@ -2,11 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Orchestration::AgentResolutionPolicy do
   subject(:policy) do
-    described_class.call(
-      action: action,
-      pipeline_model: "mistral-large",
-      step_params: { "limit" => 5 }
-    )
+    described_class.call(action: action, pipeline_model: "mistral-large")
   end
 
   let(:agent_record) do
@@ -14,7 +10,6 @@ RSpec.describe Orchestration::AgentResolutionPolicy do
            model: "mistral-small",
            tools: [ "Records::TempFileTool" ],
            prompt: "Classify this email",
-           params: { "mode" => "fast" },
            output_schema: { "type" => "object" })
   end
   let(:action) { create(:orchestration_action, agent: agent_record) }
@@ -59,32 +54,6 @@ RSpec.describe Orchestration::AgentResolutionPolicy do
     it 'raises ArgumentError when a tool class cannot be found' do
       allow(agent_record).to receive(:tools).and_return([ "Records::NonExistentTool" ])
       expect { policy }.to raise_error(ArgumentError, /NonExistentTool/)
-    end
-  end
-
-  describe '#params' do
-    it 'merges agent params with step_params (step_params win)' do
-      expect(policy.params).to eq({ "mode" => "fast", "limit" => 5 })
-    end
-
-    it 'treats blank legacy JSON strings as empty params' do
-      allow(agent_record).to receive(:params).and_return("")
-      result = described_class.call(action: action, step_params: { "limit" => 3 })
-
-      expect(result.params).to eq({ "limit" => 3 })
-    end
-
-    it 'returns only step_params when agent has no params' do
-      allow(agent_record).to receive(:params).and_return(nil)
-      result = described_class.call(action: action, step_params: { "limit" => 3 })
-      expect(result.params).to eq({ "limit" => 3 })
-    end
-
-    it 'parses legacy JSON strings before merging step_params' do
-      allow(agent_record).to receive(:params).and_return('{"mode":"fast"}')
-      result = described_class.call(action: action, step_params: { "limit" => 3 })
-
-      expect(result.params).to eq({ "mode" => "fast", "limit" => 3 })
     end
   end
 

--- a/spec/services/orchestration/ingestion_executor_spec.rb
+++ b/spec/services/orchestration/ingestion_executor_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Orchestration::IngestionExecutor do
+  def call(input = {}, operations: [])
+    described_class.call(operations:, **input.transform_keys(&:to_sym))
+  end
+
   describe '.call' do
     let(:emails) do
       [
@@ -14,21 +18,17 @@ RSpec.describe Orchestration::IngestionExecutor do
     let(:input)         { { "emails" => emails, "result" => filter_result } }
 
     context 'when filtering by ids' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" }
-          ]
-        }
+      let(:operations) do
+        [ { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" } ]
       end
 
       it 'keeps only emails whose id appears in ids_from' do
-        result = described_class.call(input, params)
+        result = call(input, operations:)
         expect(result["emails"].map { _1["id"] }).to eq(%w[e1 e3])
       end
 
       it 'retains full email objects, not just ids' do
-        result = described_class.call(input, params)
+        result = call(input, operations:)
         expect(result["emails"].first).to include("subject", "body")
       end
 
@@ -39,13 +39,13 @@ RSpec.describe Orchestration::IngestionExecutor do
           { "id" => "2", "subject" => "B" },
           { "id" => "3", "subject" => "C" }
         ]
-        result = described_class.call({ "emails" => str_emails, "result" => int_filter }, params)
+        result = call({ "emails" => str_emails, "result" => int_filter }, operations:)
         expect(result["emails"].map { _1["id"] }).to eq(%w[1 3])
       end
 
       it 'does not mutate the original input' do
         original = input.dup
-        described_class.call(input, params)
+        call(input, operations:)
         expect(input).to eq(original)
       end
     end
@@ -57,94 +57,65 @@ RSpec.describe Orchestration::IngestionExecutor do
           "result" => { "results" => filter_result }
         }
       end
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result.results", "output" => "emails" }
-          ]
-        }
+      let(:operations) do
+        [ { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result.results", "output" => "emails" } ]
       end
 
       it 'digs into the nested structure to resolve the id list' do
-        result = described_class.call(nested_input, params)
+        result = call(nested_input, operations:)
         expect(result["emails"].map { _1["id"] }).to eq(%w[e1 e3])
       end
     end
 
     context 'when an intermediate node in ids_from path is an Array (regression: Run #60 TypeError)' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result.results", "output" => "emails" }
-          ]
-        }
+      let(:operations) do
+        [ { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result.results", "output" => "emails" } ]
       end
       let(:array_result_input) { { "emails" => emails, "result" => filter_result } }
 
       it 'returns empty emails instead of raising TypeError' do
-        result = described_class.call(array_result_input, params)
+        result = call(array_result_input, operations:)
         expect(result["emails"]).to eq([])
       end
     end
 
     context 'when renaming a key' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "rename", "from" => "emails", "to" => "messages" }
-          ]
-        }
-      end
+      let(:operations) { [ { "type" => "rename", "from" => "emails", "to" => "messages" } ] }
 
       it 'renames the key' do
-        result = described_class.call(input, params)
+        result = call(input, operations:)
         expect(result).to have_key("messages")
         expect(result).not_to have_key("emails")
       end
     end
 
     context 'when picking keys' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "pick", "keys" => [ "emails" ] }
-          ]
-        }
-      end
+      let(:operations) { [ { "type" => "pick", "keys" => [ "emails" ] } ] }
 
       it 'keeps only the specified keys' do
-        result = described_class.call(input, params)
+        result = call(input, operations:)
         expect(result.keys).to eq([ "emails" ])
       end
     end
 
     context 'with sequential operations (filter_by_ids then pick)' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" },
-            { "type" => "pick", "keys" => [ "emails" ] }
-          ]
-        }
+      let(:operations) do
+        [
+          { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" },
+          { "type" => "pick", "keys" => [ "emails" ] }
+        ]
       end
 
       it 'applies operations in order and returns only filtered emails' do
-        result = described_class.call(input, params)
+        result = call(input, operations:)
         expect(result.keys).to eq([ "emails" ])
         expect(result["emails"].map { _1["id"] }).to eq(%w[e1 e3])
       end
     end
 
-    context 'when params has no operations key' do
+    context 'when no operations are provided' do
       it 'returns the input unchanged' do
-        result = described_class.call(input, {})
-        expect(result).to eq(input)
-      end
-    end
-
-    context 'when params is absent (single-arg call)' do
-      it 'returns the input unchanged' do
-        result = described_class.call(input)
+        result = call(input)
         expect(result).to eq(input)
       end
     end
@@ -157,16 +128,12 @@ RSpec.describe Orchestration::IngestionExecutor do
           "stored_ids" => [ 986, 987 ]
         }
       end
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids", "inject" => "id", "output" => "records" }
-          ]
-        }
+      let(:operations) do
+        [ { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids", "inject" => "id", "output" => "records" } ]
       end
 
       it 'zips source objects with ids, injecting the id field into each object' do
-        result = described_class.call(merge_input, params)
+        result = call(merge_input, operations:)
         expect(result["records"]).to eq([
           { "id" => 986, "email_id" => "19d4", "company" => "Bilendo" },
           { "id" => 987, "email_id" => "abcd", "company" => "Foo" }
@@ -175,80 +142,66 @@ RSpec.describe Orchestration::IngestionExecutor do
 
       it 'truncates to the shorter array when source is longer than ids' do
         long_source = merge_input["emails"] + [ { "email_id" => "extra", "company" => "Extra" } ]
-        result = described_class.call({ "emails" => long_source, "stored_ids" => merge_input["stored_ids"] }, params)
+        result = call({ "emails" => long_source, "stored_ids" => merge_input["stored_ids"] }, operations:)
         expect(result["records"].length).to eq(2)
         expect(result["records"].map { _1["id"] }).to eq([ 986, 987 ])
       end
 
       it 'truncates to the shorter array when ids is longer than source' do
         long_ids = merge_input["stored_ids"] + [ 999 ]
-        result = described_class.call({ "emails" => merge_input["emails"], "stored_ids" => long_ids }, params)
+        result = call({ "emails" => merge_input["emails"], "stored_ids" => long_ids }, operations:)
         expect(result["records"].length).to eq(2)
         expect(result["records"].map { _1["id"] }).to eq([ 986, 987 ])
       end
 
       it 'returns empty records when source is nil' do
-        result = described_class.call({ "emails" => nil, "stored_ids" => merge_input["stored_ids"] }, params)
+        result = call({ "emails" => nil, "stored_ids" => merge_input["stored_ids"] }, operations:)
         expect(result["records"]).to eq([])
       end
 
       it 'returns empty records when ids is nil' do
-        result = described_class.call({ "emails" => merge_input["emails"], "stored_ids" => nil }, params)
+        result = call({ "emails" => merge_input["emails"], "stored_ids" => nil }, operations:)
         expect(result["records"]).to eq([])
       end
     end
 
     context 'when an unknown operation type is given' do
-      let(:params) { { "operations" => [ { "type" => "explode" } ] } }
-
       it 'raises ArgumentError with the unknown type' do
-        expect { described_class.call(input, params) }
+        expect { call(input, operations: [ { "type" => "explode" } ]) }
           .to raise_error(ArgumentError, /unknown operation type: explode/)
       end
     end
 
     context 'when filter_by_ids yields no matches' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" }
-          ]
-        }
+      let(:operations) do
+        [ { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" } ]
       end
 
       it 'returns an empty array for the output key' do
-        result = described_class.call({ "emails" => emails, "result" => [] }, params)
+        result = call({ "emails" => emails, "result" => [] }, operations:)
         expect(result["emails"]).to eq([])
       end
     end
 
-    context 'when source items have no id key (item_id returns empty string)' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" }
-          ]
-        }
+    context 'when source items have no id key' do
+      let(:operations) do
+        [ { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" } ]
       end
       let(:emails_without_id) { [ { "subject" => "A" }, { "subject" => "B" } ] }
 
       it 'excludes items with no id from the filtered output' do
-        result = described_class.call({ "emails" => emails_without_id, "result" => [] }, params)
+        result = call({ "emails" => emails_without_id, "result" => [] }, operations:)
         expect(result["emails"]).to eq([])
       end
     end
 
     context 'when ids_from contains non-Hash items' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" }
-          ]
-        }
+      let(:operations) do
+        [ { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result", "output" => "emails" } ]
       end
 
       it 'ignores non-Hash items in ids_from when building the allowed set' do
-        result = described_class.call({ "emails" => emails, "result" => [ "e1", "e3" ] }, params)
+        result = call({ "emails" => emails, "result" => [ "e1", "e3" ] }, operations:)
         expect(result["emails"]).to eq([])
       end
     end
@@ -262,36 +215,30 @@ RSpec.describe Orchestration::IngestionExecutor do
       end
 
       it 'coerces Symbol source key to string for lookup' do
-        params = {
-          "operations" => [
-            { "type" => "merge_by_index", "source" => :emails, "ids" => "stored_ids",
-              "inject" => "id", "output" => "records" }
-          ]
-        }
-        result = described_class.call(merge_input, params)
+        operations = [
+          { "type" => "merge_by_index", "source" => :emails, "ids" => "stored_ids",
+            "inject" => "id", "output" => "records" }
+        ]
+        result = call(merge_input, operations:)
         expect(result["records"]).to eq([ { "id" => 99, "email_id" => "abc", "company" => "Acme" } ])
       end
 
       it 'coerces Symbol inject key to string in the merged hash' do
-        params = {
-          "operations" => [
-            { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids",
-              "inject" => :id, "output" => "records" }
-          ]
-        }
-        result = described_class.call(merge_input, params)
+        operations = [
+          { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids",
+            "inject" => :id, "output" => "records" }
+        ]
+        result = call(merge_input, operations:)
         expect(result["records"].first).to have_key("id")
         expect(result["records"].first).not_to have_key(:id)
       end
 
       it 'coerces Symbol dest key to string' do
-        params = {
-          "operations" => [
-            { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids",
-              "inject" => "id", "output" => :records }
-          ]
-        }
-        result = described_class.call(merge_input, params)
+        operations = [
+          { "type" => "merge_by_index", "source" => "emails", "ids" => "stored_ids",
+            "inject" => "id", "output" => :records }
+        ]
+        result = call(merge_input, operations:)
         expect(result).to have_key("records")
         expect(result).not_to have_key(:records)
       end
@@ -299,32 +246,37 @@ RSpec.describe Orchestration::IngestionExecutor do
 
     context 'when rename op keys are non-string (Symbol)' do
       it 'coerces Symbol from key to string before comparing' do
-        params = { "operations" => [ { "type" => "rename", "from" => :emails, "to" => "messages" } ] }
-        result = described_class.call(input, params)
+        operations = [ { "type" => "rename", "from" => :emails, "to" => "messages" } ]
+        result = call(input, operations:)
         expect(result).to have_key("messages")
         expect(result).not_to have_key("emails")
       end
 
       it 'coerces Symbol to key to string in the output' do
-        params = { "operations" => [ { "type" => "rename", "from" => "emails", "to" => :messages } ] }
-        result = described_class.call(input, params)
+        operations = [ { "type" => "rename", "from" => "emails", "to" => :messages } ]
+        result = call(input, operations:)
         expect(result).to have_key("messages")
         expect(result).not_to have_key(:messages)
       end
     end
 
     context 'when dig_path has a nil intermediate node' do
-      let(:params) do
-        {
-          "operations" => [
-            { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result.ids", "output" => "emails" }
-          ]
-        }
+      let(:operations) do
+        [ { "type" => "filter_by_ids", "source" => "emails", "ids_from" => "result.ids", "output" => "emails" } ]
       end
 
       it 'returns empty when an intermediate path segment is nil' do
-        result = described_class.call({ "emails" => emails, "result" => nil }, params)
+        result = call({ "emails" => emails, "result" => nil }, operations:)
         expect(result["emails"]).to eq([])
+      end
+    end
+
+    describe '.input_schema' do
+      it 'declares operations as an optional array' do
+        schema = described_class.input_schema
+        expect(schema["type"]).to eq("object")
+        expect(schema["properties"]["operations"]["type"]).to eq("array")
+        expect(schema["required"]).to be_nil
       end
     end
   end

--- a/spec/services/orchestration/input_mapping_updater_spec.rb
+++ b/spec/services/orchestration/input_mapping_updater_spec.rb
@@ -70,41 +70,6 @@ RSpec.describe Orchestration::InputMappingUpdater do
       end
     end
 
-    context "when the mapping triggers a validator warning (param collision)" do
-      before do
-        action.update!(params: { "email" => "default@example.com" })
-        step_action.update!(params: { "email" => "override@example.com" })
-      end
-
-      it "returns a saved result" do
-        result = described_class.call(
-          step_action: step_action,
-          input_mapping: { "email" => { "from" => "_initial" } }
-        )
-
-        expect(result.saved).to be true
-      end
-
-      it "populates warnings on the result" do
-        result = described_class.call(
-          step_action: step_action,
-          input_mapping: { "email" => { "from" => "_initial" } }
-        )
-
-        expect(result.warnings).not_to be_empty
-        expect(result.warnings.first.code).to eq(:param_collision)
-      end
-
-      it "persists the mapping to the database" do
-        described_class.call(
-          step_action: step_action,
-          input_mapping: { "email" => { "from" => "_initial" } }
-        )
-
-        expect(step_action.reload.input_mapping).to have_key("email")
-      end
-    end
-
     context "when the input_mapping is empty" do
       it "saves and returns empty errors and warnings" do
         result = described_class.call(step_action: step_action, input_mapping: {})

--- a/spec/services/orchestration/pipeline/validator_spec.rb
+++ b/spec/services/orchestration/pipeline/validator_spec.rb
@@ -120,27 +120,94 @@ RSpec.describe Orchestration::Pipeline::Validator do
       end
     end
 
-    context 'with a key collision between input_mapping and params' do
-      let(:action) do
-        create(:orchestration_action, params: { "key1" => "default_value" })
+    context 'when the action has an input_schema with required keys all covered by input_mapping' do
+      let(:agent_with_schema) do
+        create(:orchestration_agent,
+               input_schema: {
+                 "type" => "object",
+                 "properties" => { "emails" => { "type" => "array" }, "topic" => { "type" => "string" } },
+                 "required" => [ "emails", "topic" ]
+               })
       end
+      let(:action_with_schema) { create(:orchestration_action, agent: agent_with_schema) }
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "classify",
+               action: action_with_schema,
+               input_mapping: {
+                 "emails" => { "from" => "_initial", "path" => "emails" },
+                 "topic"  => { "from" => "_initial", "path" => "topic" }
+               })
+      end
+
+      it 'produces no missing_required_input errors' do
+        expect(validator.call.first.errors).to be_empty
+      end
+    end
+
+    context 'when the action has an input_schema and a required key is absent from input_mapping' do
+      let(:agent_with_schema) do
+        create(:orchestration_agent,
+               input_schema: {
+                 "type" => "object",
+                 "properties" => { "emails" => { "type" => "array" }, "topic" => { "type" => "string" } },
+                 "required" => [ "emails", "topic" ]
+               })
+      end
+      let(:action_with_schema) { create(:orchestration_action, agent: agent_with_schema) }
+
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "classify",
+               action: action_with_schema,
+               input_mapping: { "emails" => { "from" => "_initial", "path" => "emails" } })
+      end
+
+      it 'emits a missing_required_input error' do
+        error = validator.call.first.errors.find { |e| e.code == :missing_required_input }
+        expect(error).not_to be_nil
+        expect(error.message).to include("topic")
+        expect(error.mapping_key).to eq("topic")
+      end
+
+      it 'produces no errors for the covered required key' do
+        errors = validator.call.first.errors
+        expect(errors.none? { |e| e.mapping_key == "emails" }).to be true
+      end
+    end
+
+    context 'when the action has an input_schema but no required keys' do
+      let(:agent_with_schema) do
+        create(:orchestration_agent,
+               input_schema: {
+                 "type" => "object",
+                 "properties" => { "limit" => { "type" => "integer" } }
+               })
+      end
+      let(:action_with_schema) { create(:orchestration_action, agent: agent_with_schema) }
 
       before do
         create(:orchestration_step_action,
                step: step, position: 1, output_key: "fetch",
-               action: action,
-               input_mapping: { "key1" => { "from" => "_initial" } })
+               action: action_with_schema,
+               input_mapping: nil)
       end
 
-      it 'produces no errors' do
+      it 'produces no missing_required_input errors' do
         expect(validator.call.first.errors).to be_empty
       end
+    end
 
-      it 'produces a param_collision warning naming the colliding key' do
-        warning = validator.call.first.warnings.first
-        expect(warning.code).to eq(:param_collision)
-        expect(warning.message).to include("key1")
-        expect(warning.mapping_key).to eq("key1")
+    context 'when the action has no input_schema' do
+      before do
+        create(:orchestration_step_action,
+               step: step, position: 1, output_key: "fetch",
+               input_mapping: nil)
+      end
+
+      it 'produces no missing_required_input errors' do
+        expect(validator.call.first.errors).to be_empty
       end
     end
 

--- a/spec/services/orchestration/pipeline_runner_spec.rb
+++ b/spec/services/orchestration/pipeline_runner_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Orchestration::PipelineRunner do
     context 'with a serialized orchestration agent configuration' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:serialized_chat) { create(:chat) }
       let(:serialized_agent) do
-        instance_double(RubyLLM::Agent, chat: serialized_chat, params: {})
+        instance_double(RubyLLM::Agent, chat: serialized_chat)
       end
 
       before do
@@ -96,7 +96,6 @@ RSpec.describe Orchestration::PipelineRunner do
           model: "mistral-small",
           tools: [ "Records::TempFileTool" ],
           prompt: "Classify incoming emails",
-          params: { "mode" => "default", "limit" => 1 },
           output_schema: {
             "type" => "object",
             "required" => [ "result" ],
@@ -114,10 +113,15 @@ RSpec.describe Orchestration::PipelineRunner do
             }
           }
         )
-        create(:orchestration_step_action, step: step1, action: action, position: 1, params: { "limit" => 2 })
+        create(:orchestration_step_action, step: step1, action: action, position: 1)
         allow(RubyLLM::Agent).to receive(:new).and_return(serialized_agent)
         allow(serialized_chat).to receive(:with_instructions)
-        allow(serialized_agent).to receive_messages(with_model: serialized_agent, with_tools: serialized_agent, with_schema: serialized_agent, ask: instance_double(RubyLLM::Message, content: { "result" => [ { "id" => "mail-1" } ] }))
+        allow(serialized_agent).to receive_messages(
+          with_model: serialized_agent,
+          with_tools: serialized_agent,
+          with_schema: serialized_agent,
+          ask: instance_double(RubyLLM::Message, content: { "result" => [ { "id" => "mail-1" } ] })
+        )
       end
 
       it 'executes without relying on a Ruby agent subclass' do
@@ -129,11 +133,11 @@ RSpec.describe Orchestration::PipelineRunner do
         expect(action_run.output).to eq({ "result" => [ { "id" => "mail-1" } ] })
       end
 
-      it 'passes merged agent-default and step params into the ask call' do
+      it 'calls the agent with the resolved input as JSON' do
         described_class.new(pipeline_run).call
 
         expect(serialized_agent).to have_received(:ask)
-          .with(satisfy { |json| JSON.parse(json) == { "mode" => "default", "limit" => 2 } })
+          .with(satisfy { |json| JSON.parse(json) == {} })
       end
 
       it 'uses the database output schema for structured output requests' do # rubocop:disable RSpec/ExampleLength
@@ -165,35 +169,42 @@ RSpec.describe Orchestration::PipelineRunner do
             name: "Reusable email classifier",
             model: "mistral-small",
             tools: [ "Records::TempFileTool" ],
-            prompt: "Classify incoming emails",
-            params: { "mode" => "default" }
+            prompt: "Classify incoming emails"
           )
         end
       end
-      let(:snapshot_agent) { instance_double(RubyLLM::Agent, chat: create(:chat), params: {}) }
+      let(:snapshot_chat) { create(:chat) }
+      let(:snapshot_agent) { instance_double(RubyLLM::Agent, chat: snapshot_chat) }
 
       before do
         agent_record
-        create(:orchestration_step_action, step: step1, action: action, position: 1, params: { "limit" => 2 })
+        create(:orchestration_step_action, step: step1, action: action, position: 1)
         allow(RubyLLM::Agent).to receive(:new).and_return(snapshot_agent)
         allow(snapshot_agent).to receive_messages(
           with_model: snapshot_agent, with_tools: snapshot_agent,
           with_schema: snapshot_agent,
           ask: instance_double(RubyLLM::Message, content: "result")
         )
-        allow(snapshot_agent.chat).to receive(:with_instructions)
+        allow(snapshot_chat).to receive(:with_instructions)
       end
 
-      it 'persists a resolved agent_snapshot on the action_run' do
+      it 'persists a resolved agent_snapshot on the action_run without params' do
         described_class.new(pipeline_run).call
         action_run = Orchestration::ActionRun.last
 
         expect(action_run.agent_snapshot).to include(
           "model" => "mistral-small",
           "prompt" => "Classify incoming emails",
-          "tools" => [ "Records::TempFileTool" ],
-          "params" => { "mode" => "default", "limit" => 2 }
+          "tools" => [ "Records::TempFileTool" ]
         )
+        expect(action_run.agent_snapshot).not_to have_key("params")
+      end
+
+      it 'persists model, prompt, tools, and output_schema in the snapshot' do
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+
+        expect(action_run.agent_snapshot.keys).to contain_exactly("model", "prompt", "tools", "output_schema")
       end
 
       it 'does not mutate historical snapshots when the agent is later edited' do
@@ -279,12 +290,13 @@ RSpec.describe Orchestration::PipelineRunner do
 
     context 'with an executable action' do
       before do
+        Emails::FetchExecutor.input_schema # warm cache before stub is set up
         executable_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         create(:orchestration_step_action, step: step1, action: executable_action, position: 1)
+        allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
       end
 
       it 'calls the executable and stores its Hash output' do
-        allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
         described_class.new(pipeline_run).call
         action_run = Orchestration::ActionRun.last
         expect(action_run.status).to eq("completed")
@@ -292,27 +304,9 @@ RSpec.describe Orchestration::PipelineRunner do
       end
 
       it 'does not persist an agent_snapshot for service-backed runs' do
-        allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [] })
         described_class.new(pipeline_run).call
         action_run = Orchestration::ActionRun.last
         expect(action_run.agent_snapshot).to be_nil
-      end
-    end
-
-    context 'with an executable action that has params' do
-      before do
-        ops = { "operations" => [ { "type" => "pick", "keys" => [ "emails" ] } ] }
-        ingest_action = create(:orchestration_action, :service_kind,
-                                agent_class: "Orchestration::IngestionExecutor",
-                                params: ops)
-        create(:orchestration_step_action, step: step1, action: ingest_action, position: 1)
-        allow(Orchestration::IngestionExecutor).to receive(:call).and_return({ "emails" => [] })
-      end
-
-      it 'forwards merged params to the executable' do
-        described_class.new(pipeline_run).call
-        expect(Orchestration::IngestionExecutor).to have_received(:call)
-          .with(anything, { "operations" => [ { "type" => "pick", "keys" => [ "emails" ] } ] })
       end
     end
 
@@ -336,6 +330,30 @@ RSpec.describe Orchestration::PipelineRunner do
         expect(action_run.status).to eq("failed")
         expect(action_run.error).to eq("agent exploded")
         expect(action_run.error_details).to be_nil
+      end
+    end
+
+    context 'when the action has an input_schema and resolved input is missing a required field' do
+      before do
+        input_schema = {
+          "type" => "object",
+          "properties" => { "emails" => { "type" => "array" } },
+          "required" => [ "emails" ]
+        }
+        action.agent.update!(input_schema: input_schema)
+        create(:orchestration_step_action, step: step1, action: action, position: 1)
+      end
+
+      it 'marks the action_run as failed with a schema validation error' do
+        described_class.new(pipeline_run).call
+        action_run = Orchestration::ActionRun.last
+        expect(action_run.status).to eq("failed")
+        expect(action_run.error).to match(/emails/)
+      end
+
+      it 'marks the pipeline_run as failed' do
+        described_class.new(pipeline_run).call
+        expect(pipeline_run.reload.status).to eq("failed")
       end
     end
 
@@ -487,7 +505,7 @@ RSpec.describe Orchestration::PipelineRunner do
                              output_schema: { "type" => "object", "required" => [ "result" ],
                                               "properties" => { "result" => { "type" => "array" } } })
         create(:orchestration_step_action, step: step1, action: action, position: 1)
-        generic_agent = instance_double(RubyLLM::Agent, chat: create(:chat), params: {})
+        generic_agent = instance_double(RubyLLM::Agent, chat: create(:chat))
         allow(RubyLLM::Agent).to receive(:new).and_return(generic_agent)
         allow(generic_agent).to receive_messages(with_schema: generic_agent, ask: instance_double(RubyLLM::Message, content: { "result" => "not an array" }))
       end
@@ -562,6 +580,7 @@ RSpec.describe Orchestration::PipelineRunner do
 
     context 'when pipeline_run has initial_input' do
       before do
+        Emails::FetchExecutor.input_schema # warm cache before stub is set up
         pipeline_run.update!(initial_input: { "date" => "2026-04-03", "providers" => [ "gmail" ] })
         executable_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         create(:orchestration_step_action, step: step1, action: executable_action, position: 1)
@@ -577,6 +596,7 @@ RSpec.describe Orchestration::PipelineRunner do
 
     context 'when pipeline_run has an empty initial_input and a step maps from _initial' do
       before do
+        Emails::FetchExecutor.input_schema # warm cache before stub is set up
         pipeline_run.update!(initial_input: {})
         executable_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         create(:orchestration_step_action,
@@ -587,13 +607,16 @@ RSpec.describe Orchestration::PipelineRunner do
 
       it 'seeds _initial even for an empty hash so explicit mappings resolve without UnknownOutputKey' do
         described_class.new(pipeline_run).call
-        expect(Emails::FetchExecutor).to have_received(:call).with({ "data" => {} }, anything)
+        expect(Emails::FetchExecutor).to have_received(:call).with(data: {})
         expect(pipeline_run.reload.status).to eq("completed")
       end
     end
 
     context 'with three steps where step 3 needs step 1 output (accumulation)' do
       before do
+        Emails::FetchExecutor.input_schema         # warm cache before stub is set up
+        Orchestration::IngestionExecutor.input_schema # warm cache before stub is set up
+
         step2 = create(:orchestration_step, pipeline: pipeline, name: "filter",  position: 2)
         step3 = create(:orchestration_step, pipeline: pipeline, name: "ingest",  position: 3)
 
@@ -602,20 +625,14 @@ RSpec.describe Orchestration::PipelineRunner do
         fetch_action  = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         filter_action = create(:orchestration_action, agent: filter_agent_record)
         ingest_action = create(:orchestration_action, :service_kind,
-                                agent_class: "Orchestration::IngestionExecutor",
-                                params: {
-                                  "operations" => [
-                                    { "type" => "filter_by_ids", "source" => "emails",
-                                      "ids_from" => "result.results", "output" => "emails" },
-                                    { "type" => "pick", "keys" => [ "emails" ] }
-                                  ]
-                                })
+                                agent_class: "Orchestration::IngestionExecutor")
 
         create(:orchestration_step_action, step: step1, action: fetch_action,  position: 1)
         create(:orchestration_step_action, step: step2, action: filter_action, position: 1)
         create(:orchestration_step_action, step: step3, action: ingest_action, position: 1)
 
         allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [ { "id" => "e1" } ] })
+        allow(Orchestration::IngestionExecutor).to receive(:call).and_return({ "emails" => [] })
         allow(stub_agent).to receive(:ask)
           .and_return(instance_double(RubyLLM::Message, content: { "results" => [ { "id" => "e1" } ] }))
       end
@@ -908,66 +925,10 @@ RSpec.describe Orchestration::PipelineRunner do
       end
     end
 
-    context 'when an agent action has step params alongside a resolved input' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:classify_agent) { instance_double(RubyLLM::Agent, chat: create(:chat), params: {}) }
-
-      before do
-        fetch_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
-        classify_action = create(:orchestration_action, agent: create(:orchestration_agent, name: "Emails::ClassifyAgent"))
-        step2 = create(:orchestration_step, pipeline: pipeline, name: "classify", position: 2)
-
-        create(:orchestration_step_action, step: step1, action: fetch_action, position: 1, output_key: "fetch")
-        create(:orchestration_step_action,
-               step: step2, action: classify_action, position: 1,
-               input_mapping: { "emails" => { "from" => "fetch", "path" => "emails" } },
-               params: { "mode" => "strict", "limit" => 10 })
-
-        allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [ { "id" => "e1" } ] })
-        allow(RubyLLM::Agent).to receive(:new).and_return(classify_agent)
-        allow(classify_agent).to receive_messages(
-          with_model: classify_agent,
-          ask: instance_double(RubyLLM::Message, content: "done")
-        )
-      end
-
-      it 'passes step params merged with the resolved input to the agent ask call' do
-        described_class.new(pipeline_run).call
-        expect(classify_agent).to have_received(:ask)
-          .with(satisfy { |json| JSON.parse(json) == { "mode" => "strict", "limit" => 10, "emails" => [ { "id" => "e1" } ] } })
-      end
-    end
-
-    context 'when step params and input_mapping share a key' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:classify_agent) { instance_double(RubyLLM::Agent, chat: create(:chat), params: {}) }
-
-      before do
-        fetch_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
-        classify_action = create(:orchestration_action, agent: create(:orchestration_agent, name: "Emails::ClassifyAgent"))
-        step2 = create(:orchestration_step, pipeline: pipeline, name: "classify", position: 2)
-
-        create(:orchestration_step_action, step: step1, action: fetch_action, position: 1, output_key: "fetch")
-        create(:orchestration_step_action,
-               step: step2, action: classify_action, position: 1,
-               input_mapping: { "emails" => { "from" => "fetch", "path" => "emails" } },
-               params: { "emails" => "PARAM_OVERRIDE", "limit" => 5 })
-
-        allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [ { "id" => "e1" } ] })
-        allow(RubyLLM::Agent).to receive(:new).and_return(classify_agent)
-        allow(classify_agent).to receive_messages(
-          with_model: classify_agent,
-          ask: instance_double(RubyLLM::Message, content: "done")
-        )
-      end
-
-      it 'input_mapping value wins over the param value on collision' do
-        described_class.new(pipeline_run).call
-        expect(classify_agent).to have_received(:ask)
-          .with(satisfy { |json| JSON.parse(json).fetch("emails") == [ { "id" => "e1" } ] })
-      end
-    end
-
     context 'when a step has two parallel actions with distinct output keys' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       before do
+        Emails::FetchExecutor.input_schema # warm cache before stub is set up
+
         step2 = create(:orchestration_step, pipeline: pipeline, name: "consume", position: 2)
         fetch_a = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         fetch_b = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
@@ -996,6 +957,8 @@ RSpec.describe Orchestration::PipelineRunner do
 
     context 'when an input_mapping references a sibling action in the same step' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       before do
+        Emails::FetchExecutor.input_schema # warm cache before stub is set up
+
         step2 = create(:orchestration_step, pipeline: pipeline, name: "process", position: 2)
         sibling_a = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         sibling_b = create(:orchestration_action, agent: action.agent)
@@ -1049,6 +1012,8 @@ RSpec.describe Orchestration::PipelineRunner do
 
     context 'when input_mapping references a missing path' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       before do
+        Emails::FetchExecutor.input_schema # warm cache before stub is set up
+
         fetch_action = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         classify_action = create(:orchestration_action, agent: action.agent)
         step2 = create(:orchestration_step, pipeline: pipeline, name: "classify", position: 2)
@@ -1073,6 +1038,9 @@ RSpec.describe Orchestration::PipelineRunner do
 
     context 'when filter agent returns a bare array (regression: Run #58 TypeError)' do
       before do
+        Emails::FetchExecutor.input_schema         # warm cache before stub is set up
+        Orchestration::IngestionExecutor.input_schema # warm cache before stub is set up
+
         step2 = create(:orchestration_step, pipeline: pipeline, name: "filter",  position: 2)
         step3 = create(:orchestration_step, pipeline: pipeline, name: "ingest",  position: 3)
 
@@ -1081,18 +1049,18 @@ RSpec.describe Orchestration::PipelineRunner do
         fetch_action  = create(:orchestration_action, :service_kind, agent_class: "Emails::FetchExecutor")
         filter_action = create(:orchestration_action, agent: filter_agent_record)
         ingest_action = create(:orchestration_action, :service_kind,
-                                agent_class: "Orchestration::IngestionExecutor",
-                                params: {
-                                  "operations" => [
-                                    { "type" => "filter_by_ids", "source" => "emails",
-                                      "ids_from" => "result.results", "output" => "emails" },
-                                    { "type" => "pick", "keys" => [ "emails" ] }
-                                  ]
-                                })
+                                agent_class: "Orchestration::IngestionExecutor")
+
+        pipeline_run.update!(initial_input: { "operations" => [
+          { "type" => "filter_by_ids", "source" => "emails",
+            "ids_from" => "result.results", "output" => "emails" },
+          { "type" => "pick", "keys" => [ "emails" ] }
+        ] })
 
         create(:orchestration_step_action, step: step1, action: fetch_action,  position: 1)
         create(:orchestration_step_action, step: step2, action: filter_action, position: 1)
-        create(:orchestration_step_action, step: step3, action: ingest_action, position: 1)
+        create(:orchestration_step_action, step: step3, action: ingest_action, position: 1,
+               input_mapping: { "operations" => { "from" => "_initial", "path" => "operations" } })
 
         allow(Emails::FetchExecutor).to receive(:call).and_return({ "emails" => [ { "id" => "e1" } ] })
         allow(stub_agent).to receive(:ask)

--- a/spec/services/orchestration/query_executor_spec.rb
+++ b/spec/services/orchestration/query_executor_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Orchestration::QueryExecutor do
   describe '.call' do
-    let!(:acme)    { create(:application_mail, company: 'Acme',   provider: 'gmail') }
-    let!(:globex)  { create(:application_mail, company: 'Globex', provider: 'yahoo') }
-    let!(:initech) { create(:application_mail, company: 'Initech', provider: 'gmail') }
+    before do
+      create(:application_mail, company: 'Acme',    provider: 'gmail')
+      create(:application_mail, company: 'Globex',  provider: 'yahoo')
+      create(:application_mail, company: 'Initech', provider: 'gmail')
+    end
 
     context 'when filtering by a single value' do
       it 'returns only matching records under the table key' do

--- a/spec/services/orchestration/query_executor_spec.rb
+++ b/spec/services/orchestration/query_executor_spec.rb
@@ -2,137 +2,84 @@ require 'rails_helper'
 
 RSpec.describe Orchestration::QueryExecutor do
   describe '.call' do
-    let!(:acme)   { create(:application_mail, company: 'Acme',   provider: 'gmail') }
-    let!(:globex) { create(:application_mail, company: 'Globex', provider: 'yahoo') }
+    let!(:acme)    { create(:application_mail, company: 'Acme',   provider: 'gmail') }
+    let!(:globex)  { create(:application_mail, company: 'Globex', provider: 'yahoo') }
     let!(:initech) { create(:application_mail, company: 'Initech', provider: 'gmail') }
 
-    let(:input) { {} }
-
     context 'when filtering by a single value' do
-      let(:params) do
-        { "table" => "application_mails", "column_name" => "provider", "column_values" => [ "gmail" ] }
-      end
-
       it 'returns only matching records under the table key' do
-        result = described_class.call(input, params)
+        result = described_class.call(
+          table: "application_mails", column_name: "provider", column_values: [ "gmail" ]
+        )
         expect(result.keys).to eq([ "application_mails" ])
         expect(result["application_mails"].map { _1["company"] }).to contain_exactly('Acme', 'Initech')
       end
 
       it 'returns records as hashes with string keys' do
-        result = described_class.call(input, params)
+        result = described_class.call(
+          table: "application_mails", column_name: "provider", column_values: [ "gmail" ]
+        )
         expect(result["application_mails"].first).to be_a(Hash)
         expect(result["application_mails"].first.keys).to all(be_a(String))
       end
     end
 
     context 'when filtering by multiple values' do
-      let(:params) do
-        { "table" => "application_mails", "column_name" => "company", "column_values" => [ "Acme", "Globex" ] }
-      end
-
       it 'returns all records matching any of the values' do
-        result = described_class.call(input, params)
+        result = described_class.call(
+          table: "application_mails", column_name: "company", column_values: [ "Acme", "Globex" ]
+        )
         expect(result["application_mails"].map { _1["company"] }).to contain_exactly('Acme', 'Globex')
       end
     end
 
-    context 'when columns param is specified' do
-      let(:params) do
-        {
-          "table"         => "application_mails",
-          "column_name"   => "provider",
-          "column_values" => [ "yahoo" ],
-          "columns"       => [ "company", "provider" ]
-        }
-      end
-
+    context 'when columns is specified' do
       it 'returns only the specified columns' do
-        result = described_class.call(input, params)
+        result = described_class.call(
+          table: "application_mails", column_name: "provider",
+          column_values: [ "yahoo" ], columns: [ "company", "provider" ]
+        )
         expect(result["application_mails"].first.keys).to contain_exactly("company", "provider")
       end
     end
 
-    context 'when columns param is absent' do
-      let(:params) do
-        { "table" => "application_mails", "column_name" => "provider", "column_values" => [ "yahoo" ] }
-      end
-
+    context 'when columns is absent' do
       it 'returns all columns' do
-        result = described_class.call(input, params)
+        result = described_class.call(
+          table: "application_mails", column_name: "provider", column_values: [ "yahoo" ]
+        )
         expect(result["application_mails"].first.keys).to include("id", "company", "provider", "action")
       end
     end
 
     context 'when no records match' do
-      let(:params) do
-        { "table" => "application_mails", "column_name" => "company", "column_values" => [ "Unknown" ] }
-      end
-
       it 'returns an empty array under the table key' do
-        result = described_class.call(input, params)
-        expect(result["application_mails"]).to eq([])
-      end
-    end
-
-    context 'when column_values_from is used instead of column_values' do
-      let(:params) do
-        { "table" => "application_mails", "column_name" => "id", "column_values_from" => "stored_ids" }
-      end
-
-      it 'reads ids from the input and returns matching records' do
-        result = described_class.call({ "stored_ids" => [ acme.id, initech.id ] }, params)
-        expect(result["application_mails"].map { _1["company"] }).to contain_exactly('Acme', 'Initech')
-      end
-
-      it 'supports a dotted path in column_values_from' do
-        result = described_class.call({ "result" => { "ids" => [ globex.id ] } },
-                                      params.merge("column_values_from" => "result.ids"))
-        expect(result["application_mails"].map { _1["company"] }).to eq([ 'Globex' ])
-      end
-
-      it 'returns empty array when the path resolves to nil' do
-        result = described_class.call({}, params)
+        result = described_class.call(
+          table: "application_mails", column_name: "company", column_values: [ "Unknown" ]
+        )
         expect(result["application_mails"]).to eq([])
       end
     end
 
     context 'when the table is unknown' do
-      let(:params) do
-        { "table" => "nonexistent_table", "column_name" => "id", "column_values" => [ 1 ] }
-      end
-
       it 'raises ArgumentError' do
-        expect { described_class.call(input, params) }
-          .to raise_error(ArgumentError, /Unknown table/)
+        expect {
+          described_class.call(table: "nonexistent_table", column_name: "id", column_values: [ 1 ])
+        }.to raise_error(ArgumentError, /Unknown table/)
       end
     end
 
-    context 'when a required param is missing' do
-      it 'raises KeyError for missing table' do
-        expect { described_class.call(input, { "column_name" => "id", "column_values" => [ 1 ] }) }
-          .to raise_error(KeyError)
+    describe '.input_schema' do
+      it 'returns a JSON Schema with required fields' do
+        schema = described_class.input_schema
+        expect(schema["type"]).to eq("object")
+        expect(schema["required"]).to include("table", "column_name", "column_values")
       end
 
-      it 'raises KeyError for missing column_name' do
-        expect { described_class.call(input, { "table" => "application_mails", "column_values" => [ 1 ] }) }
-          .to raise_error(KeyError)
-      end
-
-      it 'raises KeyError for missing column_values' do
-        expect { described_class.call(input, { "table" => "application_mails", "column_name" => "id" }) }
-          .to raise_error(KeyError)
-      end
-    end
-
-    context 'when an intermediate node in column_values_from path is nil' do
-      let(:params) do
-        { "table" => "application_mails", "column_name" => "id", "column_values_from" => "result.ids" }
-      end
-
-      it 'returns an empty array rather than raising' do
-        result = described_class.call({ "result" => nil }, params)
-        expect(result["application_mails"]).to eq([])
+      it 'declares columns as optional' do
+        schema = described_class.input_schema
+        expect(schema["required"]).not_to include("columns")
+        expect(schema["properties"].keys).to include("columns")
       end
     end
   end

--- a/spec/services/orchestration/runtime_agent_builder_spec.rb
+++ b/spec/services/orchestration/runtime_agent_builder_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
       model: "mistral-large-latest",
       prompt: "Classify this email",
       tools: [ Records::TempFileTool ],
-      params: { "mode" => "fast" },
       output_schema: { "type" => "object" }
     )
   end
@@ -53,7 +52,7 @@ RSpec.describe Orchestration::RuntimeAgentBuilder do
     context 'when all policy fields are blank' do
       let(:policy) do
         Orchestration::AgentResolutionPolicy::Result.new(
-          model: nil, prompt: nil, tools: [], params: {}, output_schema: nil
+          model: nil, prompt: nil, tools: [], output_schema: nil
         )
       end
 


### PR DESCRIPTION
## Summary

- Removes `params` from `orchestration_agents`, `orchestration_actions`, and `orchestration_step_actions`
- Adds `input_schema` (JSON Schema) column to `orchestration_agents`; service-kind actions derive their schema from the `Executable` DSL + `call` keyword arguments at load time, raising if they diverge
- `InputMappingResolver` gains `{value:}` literal spec so seeds and configs can inline static values without a prior step
- `Pipeline::Validator` adds `:missing_required_input` check; `PipelineRunner` validates resolved input against the schema before execution
- `CONTEXT.md` updated with Input schema, Input mapping, and Executable terms

## Test plan

- [ ] `bundle exec rspec spec/concerns/orchestration/executable_spec.rb` — Executable DSL
- [ ] `bundle exec rspec spec/services/orchestration/pipeline/validator_spec.rb` — static missing_required_input check
- [ ] `bundle exec rspec spec/services/orchestration/pipeline_runner_spec.rb` — runtime schema validation
- [ ] `bundle exec rspec spec/models/orchestration/action_spec.rb` — Action#input_schema delegation
- [ ] `bundle exec rspec spec/services/orchestration/agent_resolution_policy_spec.rb` — params removed from Result
- [ ] `bundle exec rspec spec/services/orchestration/query_executor_spec.rb spec/services/orchestration/ingestion_executor_spec.rb` — executor keyword-arg interfaces

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)