### PR TITLE
feat: split pipeline and agent edit views into General / Schema Builder tabs

### DIFF
--- a/app/components/orchestration/agent_tools_component.html.erb
+++ b/app/components/orchestration/agent_tools_component.html.erb
@@ -1,0 +1,19 @@
+<input type="hidden" name="orchestration_agent[tools][]" value="">
+<% grouped_tools.each do |namespace, tools| %>
+  <div class="mb-3">
+    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2"><%= namespace %></p>
+    <div class="flex flex-wrap gap-x-4 gap-y-2">
+      <% tools.each do |tool| %>
+        <label class="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
+          <input type="checkbox" name="orchestration_agent[tools][]" value="<%= tool %>"
+            <%= "checked" if selected?(tool) %>
+            class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+          <%= tool %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+<% if @errors.any? %>
+  <p class="mt-1 text-xs text-red-600"><%= @errors.first %></p>
+<% end %>

--- a/app/components/orchestration/agent_tools_component.rb
+++ b/app/components/orchestration/agent_tools_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class AgentToolsComponent < ViewComponent::Base
+    def initialize(available_tools:, selected:, errors: [])
+      @available_tools = available_tools
+      @selected        = Array(selected)
+      @errors          = errors
+    end
+
+    def grouped_tools
+      @available_tools.group_by { |t| t.split("::").first }
+    end
+
+    def selected?(tool)
+      @selected.include?(tool)
+    end
+  end
+end

--- a/app/components/ui/tabs_component.html.erb
+++ b/app/components/ui/tabs_component.html.erb
@@ -1,0 +1,12 @@
+<div data-controller="<%= controller_value %>">
+  <div class="border-b border-gray-200 mb-6">
+    <nav class="-mb-px flex gap-6" aria-label="Tabs" role="tablist">
+      <% tabs.each do |tab| %>
+        <%= tab %>
+      <% end %>
+    </nav>
+  </div>
+  <% panels.each do |panel| %>
+    <%= panel %>
+  <% end %>
+</div>

--- a/app/components/ui/tabs_component.rb
+++ b/app/components/ui/tabs_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module UI
+  class TabsComponent < ViewComponent::Base
+    renders_many :tabs, "UI::TabsComponent::TabComponent"
+    renders_many :panels, "UI::TabsComponent::PanelComponent"
+
+    def initialize(extra_controllers: [])
+      @extra_controllers = Array(extra_controllers)
+    end
+
+    def controller_value
+      ([ "tabs" ] + @extra_controllers).join(" ")
+    end
+  end
+end

--- a/app/components/ui/tabs_component/panel_component.rb
+++ b/app/components/ui/tabs_component/panel_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module UI
+  class TabsComponent
+    class PanelComponent < ViewComponent::Base
+      def initialize(id:, tab_id:, active: false)
+        @id     = id
+        @tab_id = tab_id
+        @active = active
+      end
+
+      def call
+        attrs = {
+          id:   @id,
+          role: "tabpanel",
+          aria: { labelledby: @tab_id },
+          data: { tabs_target: "panel" }
+        }
+        attrs[:hidden] = true unless @active
+        content_tag(:div, content, **attrs)
+      end
+    end
+  end
+end

--- a/app/components/ui/tabs_component/tab_component.rb
+++ b/app/components/ui/tabs_component/tab_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module UI
+  class TabsComponent
+    class TabComponent < ViewComponent::Base
+      def initialize(id:, label:, controls:, active: false)
+        @id       = id
+        @label    = label
+        @controls = controls
+        @active   = active
+      end
+
+      def call
+        content_tag(
+          :button,
+          @label,
+          type: "button",
+          id: @id,
+          role: "tab",
+          aria: { selected: @active.to_s, controls: @controls },
+          tabindex: @active ? "0" : "-1",
+          data: { tabs_target: "tab", action: "click->tabs#show keydown->tabs#keydown" },
+          class: tab_classes
+        )
+      end
+
+      private
+
+      def tab_classes
+        base = "py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
+        state = @active ? "border-indigo-600 text-indigo-600" : "border-transparent text-gray-500"
+        "#{base} #{state}"
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -9,6 +9,7 @@ import PromptCompareController from "./prompt_compare_controller"
 import ResyncController from "./resync_controller"
 import SchemaBuilderController from "./schema_builder_controller"
 import SelectSearchController from "./select_search_controller"
+import TabsController from "./tabs_controller"
 
 application.register("accordion", AccordionController)
 application.register("agent-select", AgentSelectController)
@@ -20,4 +21,5 @@ application.register("prompt-compare", PromptCompareController)
 application.register("resync", ResyncController)
 application.register("schema-builder", SchemaBuilderController)
 application.register("select-search", SelectSearchController)
+application.register("tabs", TabsController)
 

--- a/app/javascript/controllers/tabs_controller.ts
+++ b/app/javascript/controllers/tabs_controller.ts
@@ -26,7 +26,7 @@ export default class TabsController extends Controller {
     else return
     event.preventDefault()
     this.indexValue = i
-    ;(tabs[i] as HTMLElement).focus()
+    tabs[i].focus()
   }
 
   indexValueChanged() {

--- a/app/javascript/controllers/tabs_controller.ts
+++ b/app/javascript/controllers/tabs_controller.ts
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class TabsController extends Controller {
+  static targets = ["tab", "panel"]
+  static values = { index: { type: Number, default: 0 } }
+
+  declare tabTargets: HTMLElement[]
+  declare panelTargets: HTMLElement[]
+  declare indexValue: number
+
+  connect() {
+    this.showTab()
+  }
+
+  show(event: Event) {
+    this.indexValue = this.tabTargets.indexOf(event.currentTarget as HTMLElement)
+  }
+
+  indexValueChanged() {
+    this.showTab()
+  }
+
+  private showTab() {
+    this.panelTargets.forEach((panel, i) => {
+      panel.hidden = i !== this.indexValue
+    })
+    this.tabTargets.forEach((tab, i) => {
+      const active = i === this.indexValue
+      tab.setAttribute("aria-selected", String(active))
+      tab.classList.toggle("border-indigo-600", active)
+      tab.classList.toggle("text-indigo-600", active)
+      tab.classList.toggle("border-transparent", !active)
+      tab.classList.toggle("text-gray-500", !active)
+    })
+  }
+}

--- a/app/javascript/controllers/tabs_controller.ts
+++ b/app/javascript/controllers/tabs_controller.ts
@@ -16,6 +16,19 @@ export default class TabsController extends Controller {
     this.indexValue = this.tabTargets.indexOf(event.currentTarget as HTMLElement)
   }
 
+  keydown(event: KeyboardEvent) {
+    const tabs = this.tabTargets
+    let i = this.indexValue
+    if (event.key === "ArrowRight") i = (i + 1) % tabs.length
+    else if (event.key === "ArrowLeft") i = (i - 1 + tabs.length) % tabs.length
+    else if (event.key === "Home") i = 0
+    else if (event.key === "End") i = tabs.length - 1
+    else return
+    event.preventDefault()
+    this.indexValue = i
+    ;(tabs[i] as HTMLElement).focus()
+  }
+
   indexValueChanged() {
     this.showTab()
   }
@@ -27,6 +40,7 @@ export default class TabsController extends Controller {
     this.tabTargets.forEach((tab, i) => {
       const active = i === this.indexValue
       tab.setAttribute("aria-selected", String(active))
+      tab.setAttribute("tabindex", active ? "0" : "-1")
       tab.classList.toggle("border-indigo-600", active)
       tab.classList.toggle("text-indigo-600", active)
       tab.classList.toggle("border-transparent", !active)

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -1,7 +1,95 @@
 <%# schema-builder controller wraps the Turbo Frame AND the agent form so Stimulus can bridge them %>
-<div data-controller="schema-builder">
-  <%# Output schema section - builder view and raw view are separate Stimulus targets %>
-  <div class="mb-6">
+<div data-controller="schema-builder tabs">
+  <%# Tab navigation %>
+  <div class="border-b border-gray-200 mb-6">
+    <nav class="-mb-px flex gap-6" aria-label="Tabs">
+      <button type="button"
+              data-tabs-target="tab"
+              data-action="click->tabs#show"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
+              aria-selected="true">
+        General
+      </button>
+      <button type="button"
+              data-tabs-target="tab"
+              data-action="click->tabs#show"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
+              aria-selected="false">
+        Schema Builder
+      </button>
+    </nav>
+  </div>
+
+  <%# Tab 1: General Info %>
+  <div data-tabs-target="panel">
+    <%# Agent form (contains the hidden field Stimulus keeps in sync) %>
+    <%= form_with model: agent,
+          url: agent.new_record? ? orchestration_agents_path : orchestration_agent_path(agent),
+          id: "agent-form",
+          class: "space-y-6" do |f| %>
+      <%= render UI::ErrorMessagesComponent.new(errors: agent.errors) %>
+
+      <div>
+        <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_field :name, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if agent.errors[:name].any?}", placeholder: "e.g. Emails::ClassifyAgent" %>
+        <% if agent.errors[:name].any? %>
+          <p class="mt-1 text-xs text-red-600"><%= agent.errors[:name].first %></p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_area :description, rows: 2, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+      </div>
+
+      <div>
+        <%= f.label :model, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.select :model,
+              grouped_options_for_select(
+                Orchestration::Agent.available_models,
+                agent.model
+              ),
+              { include_blank: "— select a model —" },
+              { data: { controller: "select-search" }, class: "w-full" } %>
+      </div>
+
+      <div>
+        <%= f.label :tools, "Tools", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <input type="hidden" name="orchestration_agent[tools][]" value="">
+        <% Orchestration::Agent.available_tools.group_by { |t| t.split("::").first }.each do |namespace, tools| %>
+          <div class="mb-3">
+            <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2"><%= namespace %></p>
+            <div class="flex flex-wrap gap-x-4 gap-y-2">
+              <% tools.each do |tool| %>
+                <label class="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
+                  <input type="checkbox" name="orchestration_agent[tools][]" value="<%= tool %>"
+                    <%= "checked" if Array(agent.tools).include?(tool) %>
+                    class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                  <%= tool %>
+                </label>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+        <% if agent.errors[:tools].any? %>
+          <p class="mt-1 text-xs text-red-600"><%= agent.errors[:tools].first %></p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :prompt, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_area :prompt, rows: 4, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+      </div>
+
+      <%# Hidden field — Stimulus (schema-builder controller) keeps this in sync with the builder %>
+      <%= f.hidden_field :output_schema,
+            value: agent.output_schema.present? ? agent.output_schema.to_json : "{}",
+            data: { schema_builder_target: "json" } %>
+    <% end %>
+  </div>
+
+  <%# Tab 2: Schema Builder %>
+  <div data-tabs-target="panel">
     <div class="flex items-center justify-between mb-2">
       <label class="block text-sm font-medium text-gray-700">Output schema builder</label>
       <button type="button"
@@ -48,70 +136,13 @@
     </div>
   </div>
 
-  <%# Agent form (contains the hidden field Stimulus keeps in sync) %>
-  <%= form_with model: agent, url: agent.new_record? ? orchestration_agents_path : orchestration_agent_path(agent), class: "space-y-6" do |f| %>
-    <%= render UI::ErrorMessagesComponent.new(errors: agent.errors) %>
-
-    <div>
-      <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :name, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if agent.errors[:name].any?}", placeholder: "e.g. Emails::ClassifyAgent" %>
-      <% if agent.errors[:name].any? %>
-        <p class="mt-1 text-xs text-red-600"><%= agent.errors[:name].first %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_area :description, rows: 2, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
-    </div>
-
-    <div>
-      <%= f.label :model, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.select :model,
-            grouped_options_for_select(
-              Orchestration::Agent.available_models,
-              agent.model
-            ),
-            { include_blank: "— select a model —" },
-            { data: { controller: "select-search" }, class: "w-full" } %>
-    </div>
-
-    <div>
-      <%= f.label :tools, "Tools", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <input type="hidden" name="orchestration_agent[tools][]" value="">
-      <% Orchestration::Agent.available_tools.group_by { |t| t.split("::").first }.each do |namespace, tools| %>
-        <div class="mb-3">
-          <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2"><%= namespace %></p>
-          <div class="flex flex-wrap gap-x-4 gap-y-2">
-            <% tools.each do |tool| %>
-              <label class="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
-                <input type="checkbox" name="orchestration_agent[tools][]" value="<%= tool %>"
-                  <%= "checked" if Array(agent.tools).include?(tool) %>
-                  class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-                <%= tool %>
-              </label>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-      <% if agent.errors[:tools].any? %>
-        <p class="mt-1 text-xs text-red-600"><%= agent.errors[:tools].first %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :prompt, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_area :prompt, rows: 4, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
-    </div>
-
-    <%# Hidden field — Stimulus (schema-builder controller) keeps this in sync with the builder %>
-    <%= f.hidden_field :output_schema,
-          value: agent.output_schema.present? ? agent.output_schema.to_json : "{}",
-          data: { schema_builder_target: "json" } %>
-
-    <div class="flex items-center gap-3 pt-2">
-      <%= f.submit class: "px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
-      <%= link_to "Cancel", orchestration_agents_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
-    </div>
-  <% end %>
+  <%# Submit bar — always visible, targets the main form via form= attribute %>
+  <div class="flex items-center gap-3 pt-4 mt-6 border-t border-gray-200">
+    <button type="submit"
+            form="agent-form"
+            class="px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer">
+      <%= agent.new_record? ? "Create Agent" : "Update Agent" %>
+    </button>
+    <%= link_to "Cancel", orchestration_agents_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
+  </div>
 </div>

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -1,38 +1,9 @@
 <%# schema-builder controller wraps the Turbo Frame AND the agent form so Stimulus can bridge them %>
-<div data-controller="schema-builder tabs">
-  <%# Tab navigation %>
-  <div class="border-b border-gray-200 mb-6">
-    <nav class="-mb-px flex gap-6" aria-label="Tabs" role="tablist">
-      <button type="button"
-              id="agent-tab-general"
-              role="tab"
-              aria-selected="true"
-              aria-controls="agent-panel-general"
-              tabindex="0"
-              data-tabs-target="tab"
-              data-action="click->tabs#show keydown->tabs#keydown"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-indigo-600 text-indigo-600">
-        General
-      </button>
-      <button type="button"
-              id="agent-tab-schema"
-              role="tab"
-              aria-selected="false"
-              aria-controls="agent-panel-schema"
-              tabindex="-1"
-              data-tabs-target="tab"
-              data-action="click->tabs#show keydown->tabs#keydown"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-transparent text-gray-500">
-        Schema Builder
-      </button>
-    </nav>
-  </div>
+<%= render UI::TabsComponent.new(extra_controllers: ["schema-builder"]) do |t| %>
+  <% t.with_tab(id: "agent-tab-general", label: "General", controls: "agent-panel-general", active: true) %>
+  <% t.with_tab(id: "agent-tab-schema", label: "Schema Builder", controls: "agent-panel-schema") %>
 
-  <%# Tab 1: General Info %>
-  <div id="agent-panel-general"
-       role="tabpanel"
-       aria-labelledby="agent-tab-general"
-       data-tabs-target="panel">
+  <% t.with_panel(id: "agent-panel-general", tab_id: "agent-tab-general", active: true) do %>
     <%# Agent form (contains the hidden field Stimulus keeps in sync) %>
     <%= form_with model: agent,
           url: agent.new_record? ? orchestration_agents_path : orchestration_agent_path(agent),
@@ -97,14 +68,10 @@
             value: agent.output_schema.present? ? agent.output_schema.to_json : "{}",
             data: { schema_builder_target: "json" } %>
     <% end %>
-  </div>
+  <% end %>
 
   <%# Tab 2: Schema Builder (hidden server-side — no flash on load) %>
-  <div id="agent-panel-schema"
-       role="tabpanel"
-       aria-labelledby="agent-tab-schema"
-       data-tabs-target="panel"
-       hidden>
+  <% t.with_panel(id: "agent-panel-schema", tab_id: "agent-tab-schema") do %>
     <div class="flex items-center justify-between mb-2">
       <label class="block text-sm font-medium text-gray-700">Output schema builder</label>
       <button type="button"
@@ -149,15 +116,15 @@
         </div>
       </form>
     </div>
-  </div>
+  <% end %>
+<% end %>
 
-  <%# Submit bar — always visible, targets the main form via form= attribute %>
-  <div class="flex items-center gap-3 pt-4 mt-6 border-t border-gray-200">
-    <button type="submit"
-            form="agent-form"
-            class="px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer">
-      <%= agent.new_record? ? "Create Agent" : "Update Agent" %>
-    </button>
-    <%= link_to "Cancel", orchestration_agents_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
-  </div>
+<%# Submit bar — always visible, targets the main form via form= attribute %>
+<div class="flex items-center gap-3 pt-4 mt-6 border-t border-gray-200">
+  <button type="submit"
+          form="agent-form"
+          class="px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer">
+    <%= agent.new_record? ? "Create Agent" : "Update Agent" %>
+  </button>
+  <%= link_to "Cancel", orchestration_agents_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
 </div>

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -37,25 +37,11 @@
 
       <div>
         <%= f.label :tools, "Tools", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <input type="hidden" name="orchestration_agent[tools][]" value="">
-        <% Orchestration::Agent.available_tools.group_by { |t| t.split("::").first }.each do |namespace, tools| %>
-          <div class="mb-3">
-            <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2"><%= namespace %></p>
-            <div class="flex flex-wrap gap-x-4 gap-y-2">
-              <% tools.each do |tool| %>
-                <label class="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
-                  <input type="checkbox" name="orchestration_agent[tools][]" value="<%= tool %>"
-                    <%= "checked" if Array(agent.tools).include?(tool) %>
-                    class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-                  <%= tool %>
-                </label>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-        <% if agent.errors[:tools].any? %>
-          <p class="mt-1 text-xs text-red-600"><%= agent.errors[:tools].first %></p>
-        <% end %>
+        <%= render Orchestration::AgentToolsComponent.new(
+              available_tools: Orchestration::Agent.available_tools,
+              selected: agent.tools,
+              errors: agent.errors[:tools]
+            ) %>
       </div>
 
       <div>

--- a/app/views/orchestration/agents/_form.html.erb
+++ b/app/views/orchestration/agents/_form.html.erb
@@ -2,26 +2,37 @@
 <div data-controller="schema-builder tabs">
   <%# Tab navigation %>
   <div class="border-b border-gray-200 mb-6">
-    <nav class="-mb-px flex gap-6" aria-label="Tabs">
+    <nav class="-mb-px flex gap-6" aria-label="Tabs" role="tablist">
       <button type="button"
+              id="agent-tab-general"
+              role="tab"
+              aria-selected="true"
+              aria-controls="agent-panel-general"
+              tabindex="0"
               data-tabs-target="tab"
-              data-action="click->tabs#show"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
-              aria-selected="true">
+              data-action="click->tabs#show keydown->tabs#keydown"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-indigo-600 text-indigo-600">
         General
       </button>
       <button type="button"
+              id="agent-tab-schema"
+              role="tab"
+              aria-selected="false"
+              aria-controls="agent-panel-schema"
+              tabindex="-1"
               data-tabs-target="tab"
-              data-action="click->tabs#show"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
-              aria-selected="false">
+              data-action="click->tabs#show keydown->tabs#keydown"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-transparent text-gray-500">
         Schema Builder
       </button>
     </nav>
   </div>
 
   <%# Tab 1: General Info %>
-  <div data-tabs-target="panel">
+  <div id="agent-panel-general"
+       role="tabpanel"
+       aria-labelledby="agent-tab-general"
+       data-tabs-target="panel">
     <%# Agent form (contains the hidden field Stimulus keeps in sync) %>
     <%= form_with model: agent,
           url: agent.new_record? ? orchestration_agents_path : orchestration_agent_path(agent),
@@ -88,8 +99,12 @@
     <% end %>
   </div>
 
-  <%# Tab 2: Schema Builder %>
-  <div data-tabs-target="panel">
+  <%# Tab 2: Schema Builder (hidden server-side — no flash on load) %>
+  <div id="agent-panel-schema"
+       role="tabpanel"
+       aria-labelledby="agent-tab-schema"
+       data-tabs-target="panel"
+       hidden>
     <div class="flex items-center justify-between mb-2">
       <label class="block text-sm font-medium text-gray-700">Output schema builder</label>
       <button type="button"

--- a/app/views/orchestration/pipelines/_form.html.erb
+++ b/app/views/orchestration/pipelines/_form.html.erb
@@ -1,26 +1,37 @@
 <div data-controller="schema-builder tabs">
   <%# Tab navigation %>
   <div class="border-b border-gray-200 mb-6">
-    <nav class="-mb-px flex gap-6" aria-label="Tabs">
+    <nav class="-mb-px flex gap-6" aria-label="Tabs" role="tablist">
       <button type="button"
+              id="pipeline-tab-general"
+              role="tab"
+              aria-selected="true"
+              aria-controls="pipeline-panel-general"
+              tabindex="0"
               data-tabs-target="tab"
-              data-action="click->tabs#show"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
-              aria-selected="true">
+              data-action="click->tabs#show keydown->tabs#keydown"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-indigo-600 text-indigo-600">
         General
       </button>
       <button type="button"
+              id="pipeline-tab-schema"
+              role="tab"
+              aria-selected="false"
+              aria-controls="pipeline-panel-schema"
+              tabindex="-1"
               data-tabs-target="tab"
-              data-action="click->tabs#show"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
-              aria-selected="false">
+              data-action="click->tabs#show keydown->tabs#keydown"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-transparent text-gray-500">
         Schema Builder
       </button>
     </nav>
   </div>
 
   <%# Tab 1: General Info %>
-  <div data-tabs-target="panel">
+  <div id="pipeline-panel-general"
+       role="tabpanel"
+       aria-labelledby="pipeline-tab-general"
+       data-tabs-target="panel">
     <%= form_with model: pipeline,
           url: pipeline.new_record? ? orchestration_pipelines_path : orchestration_pipeline_path(pipeline),
           id: "pipeline-form",
@@ -63,8 +74,12 @@
     <% end %>
   </div>
 
-  <%# Tab 2: Schema Builder %>
-  <div data-tabs-target="panel">
+  <%# Tab 2: Schema Builder (hidden server-side — no flash on load) %>
+  <div id="pipeline-panel-schema"
+       role="tabpanel"
+       aria-labelledby="pipeline-tab-schema"
+       data-tabs-target="panel"
+       hidden>
     <div class="flex items-center justify-between mb-2">
       <label class="block text-sm font-medium text-gray-700">Initial input schema</label>
       <button type="button"

--- a/app/views/orchestration/pipelines/_form.html.erb
+++ b/app/views/orchestration/pipelines/_form.html.erb
@@ -1,5 +1,70 @@
-<div data-controller="schema-builder">
-  <div class="mb-6">
+<div data-controller="schema-builder tabs">
+  <%# Tab navigation %>
+  <div class="border-b border-gray-200 mb-6">
+    <nav class="-mb-px flex gap-6" aria-label="Tabs">
+      <button type="button"
+              data-tabs-target="tab"
+              data-action="click->tabs#show"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
+              aria-selected="true">
+        General
+      </button>
+      <button type="button"
+              data-tabs-target="tab"
+              data-action="click->tabs#show"
+              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap"
+              aria-selected="false">
+        Schema Builder
+      </button>
+    </nav>
+  </div>
+
+  <%# Tab 1: General Info %>
+  <div data-tabs-target="panel">
+    <%= form_with model: pipeline,
+          url: pipeline.new_record? ? orchestration_pipelines_path : orchestration_pipeline_path(pipeline),
+          id: "pipeline-form",
+          class: "space-y-6" do |f| %>
+      <%= render UI::ErrorMessagesComponent.new(errors: pipeline.errors) %>
+
+      <div>
+        <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_field :name, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if pipeline.errors[:name].any?}" %>
+        <% if pipeline.errors[:name].any? %>
+          <p class="mt-1 text-xs text-red-600"><%= pipeline.errors[:name].first %></p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_area :description, rows: 2, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+      </div>
+
+      <div>
+        <%= f.label :model, "Model Override", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_field :model, placeholder: "e.g. mistral-small-latest (leave blank to use action defaults)", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+        <p class="mt-1 text-xs text-gray-400">When set, overrides the model for all AI actions in this pipeline.</p>
+      </div>
+
+      <div>
+        <%= f.label :cron_expression, "Cron Schedule", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_field :cron_expression, placeholder: "e.g. 0 * * * * (hourly)", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+        <p class="mt-1 text-xs text-gray-400">Standard 5-field cron expression. Leave blank to disable scheduled runs.</p>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <%= f.check_box :enabled, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>
+        <%= f.label :enabled, "Enabled", class: "text-sm font-medium text-gray-700" %>
+      </div>
+
+      <%= f.hidden_field :initial_input_schema,
+            value: pipeline.initial_input_schema.present? ? pipeline.initial_input_schema.to_json : "{}",
+            data: { schema_builder_target: "json" } %>
+    <% end %>
+  </div>
+
+  <%# Tab 2: Schema Builder %>
+  <div data-tabs-target="panel">
     <div class="flex items-center justify-between mb-2">
       <label class="block text-sm font-medium text-gray-700">Initial input schema</label>
       <button type="button"
@@ -45,46 +110,13 @@
     </div>
   </div>
 
-  <%= form_with model: pipeline, url: pipeline.new_record? ? orchestration_pipelines_path : orchestration_pipeline_path(pipeline), class: "space-y-6" do |f| %>
-    <%= render UI::ErrorMessagesComponent.new(errors: pipeline.errors) %>
-
-    <div>
-      <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :name, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 #{"border-red-400" if pipeline.errors[:name].any?}" %>
-      <% if pipeline.errors[:name].any? %>
-        <p class="mt-1 text-xs text-red-600"><%= pipeline.errors[:name].first %></p>
-      <% end %>
-    </div>
-
-    <div>
-      <%= f.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_area :description, rows: 2, class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
-    </div>
-
-    <div>
-      <%= f.label :model, "Model Override", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :model, placeholder: "e.g. mistral-small-latest (leave blank to use action defaults)", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
-      <p class="mt-1 text-xs text-gray-400">When set, overrides the model for all AI actions in this pipeline.</p>
-    </div>
-
-    <div>
-      <%= f.label :cron_expression, "Cron Schedule", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :cron_expression, placeholder: "e.g. 0 * * * * (hourly)", class: "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
-      <p class="mt-1 text-xs text-gray-400">Standard 5-field cron expression. Leave blank to disable scheduled runs.</p>
-    </div>
-
-    <div class="flex items-center gap-2">
-      <%= f.check_box :enabled, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>
-      <%= f.label :enabled, "Enabled", class: "text-sm font-medium text-gray-700" %>
-    </div>
-
-    <%= f.hidden_field :initial_input_schema,
-          value: pipeline.initial_input_schema.present? ? pipeline.initial_input_schema.to_json : "{}",
-          data: { schema_builder_target: "json" } %>
-
-    <div class="flex items-center gap-3 pt-2">
-      <%= f.submit class: "px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer" %>
-      <%= link_to "Cancel", orchestration_pipelines_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
-    </div>
-  <% end %>
+  <%# Submit bar — always visible, targets the main form via form= attribute %>
+  <div class="flex items-center gap-3 pt-4 mt-6 border-t border-gray-200">
+    <button type="submit"
+            form="pipeline-form"
+            class="px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer">
+      <%= pipeline.new_record? ? "Create Pipeline" : "Update Pipeline" %>
+    </button>
+    <%= link_to "Cancel", orchestration_pipelines_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
+  </div>
 </div>

--- a/app/views/orchestration/pipelines/_form.html.erb
+++ b/app/views/orchestration/pipelines/_form.html.erb
@@ -1,37 +1,8 @@
-<div data-controller="schema-builder tabs">
-  <%# Tab navigation %>
-  <div class="border-b border-gray-200 mb-6">
-    <nav class="-mb-px flex gap-6" aria-label="Tabs" role="tablist">
-      <button type="button"
-              id="pipeline-tab-general"
-              role="tab"
-              aria-selected="true"
-              aria-controls="pipeline-panel-general"
-              tabindex="0"
-              data-tabs-target="tab"
-              data-action="click->tabs#show keydown->tabs#keydown"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-indigo-600 text-indigo-600">
-        General
-      </button>
-      <button type="button"
-              id="pipeline-tab-schema"
-              role="tab"
-              aria-selected="false"
-              aria-controls="pipeline-panel-schema"
-              tabindex="-1"
-              data-tabs-target="tab"
-              data-action="click->tabs#show keydown->tabs#keydown"
-              class="py-2 px-1 border-b-2 text-sm font-medium whitespace-nowrap border-transparent text-gray-500">
-        Schema Builder
-      </button>
-    </nav>
-  </div>
+<%= render UI::TabsComponent.new(extra_controllers: ["schema-builder"]) do |t| %>
+  <% t.with_tab(id: "pipeline-tab-general", label: "General", controls: "pipeline-panel-general", active: true) %>
+  <% t.with_tab(id: "pipeline-tab-schema", label: "Schema Builder", controls: "pipeline-panel-schema") %>
 
-  <%# Tab 1: General Info %>
-  <div id="pipeline-panel-general"
-       role="tabpanel"
-       aria-labelledby="pipeline-tab-general"
-       data-tabs-target="panel">
+  <% t.with_panel(id: "pipeline-panel-general", tab_id: "pipeline-tab-general", active: true) do %>
     <%= form_with model: pipeline,
           url: pipeline.new_record? ? orchestration_pipelines_path : orchestration_pipeline_path(pipeline),
           id: "pipeline-form",
@@ -72,14 +43,10 @@
             value: pipeline.initial_input_schema.present? ? pipeline.initial_input_schema.to_json : "{}",
             data: { schema_builder_target: "json" } %>
     <% end %>
-  </div>
+  <% end %>
 
   <%# Tab 2: Schema Builder (hidden server-side — no flash on load) %>
-  <div id="pipeline-panel-schema"
-       role="tabpanel"
-       aria-labelledby="pipeline-tab-schema"
-       data-tabs-target="panel"
-       hidden>
+  <% t.with_panel(id: "pipeline-panel-schema", tab_id: "pipeline-tab-schema") do %>
     <div class="flex items-center justify-between mb-2">
       <label class="block text-sm font-medium text-gray-700">Initial input schema</label>
       <button type="button"
@@ -123,15 +90,15 @@
         </div>
       </form>
     </div>
-  </div>
+  <% end %>
+<% end %>
 
-  <%# Submit bar — always visible, targets the main form via form= attribute %>
-  <div class="flex items-center gap-3 pt-4 mt-6 border-t border-gray-200">
-    <button type="submit"
-            form="pipeline-form"
-            class="px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer">
-      <%= pipeline.new_record? ? "Create Pipeline" : "Update Pipeline" %>
-    </button>
-    <%= link_to "Cancel", orchestration_pipelines_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
-  </div>
+<%# Submit bar — always visible, targets the main form via form= attribute %>
+<div class="flex items-center gap-3 pt-4 mt-6 border-t border-gray-200">
+  <button type="submit"
+          form="pipeline-form"
+          class="px-5 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer">
+    <%= pipeline.new_record? ? "Create Pipeline" : "Update Pipeline" %>
+  </button>
+  <%= link_to "Cancel", orchestration_pipelines_path, class: "px-5 py-2 text-sm text-gray-600 hover:text-gray-800" %>
 </div>

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -137,12 +137,12 @@ FOREIGN KEY ("agent_id")
 );
 CREATE INDEX "index_orchestration_actions_on_agent_id" ON "orchestration_actions" ("agent_id") /*application='ApplicationPipeline'*/;
 CREATE INDEX "index_orchestration_actions_on_agent_class" ON "orchestration_actions" ("agent_class") /*application='ApplicationPipeline'*/;
-CREATE TABLE IF NOT EXISTS "orchestration_step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "input_mapping" json, "output_key" varchar NOT NULL, CONSTRAINT "fk_rails_5ad029fcf8"
-FOREIGN KEY ("action_id")
-  REFERENCES "orchestration_actions" ("id")
-, CONSTRAINT "fk_rails_f260603cab"
+CREATE TABLE IF NOT EXISTS "orchestration_step_actions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "step_id" integer NOT NULL, "action_id" integer NOT NULL, "position" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "input_mapping" json, "output_key" varchar NOT NULL, CONSTRAINT "fk_rails_f260603cab"
 FOREIGN KEY ("step_id")
   REFERENCES "orchestration_steps" ("id")
+, CONSTRAINT "fk_rails_5ad029fcf8"
+FOREIGN KEY ("action_id")
+  REFERENCES "orchestration_actions" ("id")
 );
 CREATE UNIQUE INDEX "index_orchestration_step_actions_on_step_id_and_output_key" ON "orchestration_step_actions" ("step_id", "output_key") /*application='ApplicationPipeline'*/;
 CREATE UNIQUE INDEX "index_orchestration_step_actions_on_step_id_and_position" ON "orchestration_step_actions" ("step_id", "position") /*application='ApplicationPipeline'*/;

--- a/sig/app/components/orchestration/agent_tools_component.rbs
+++ b/sig/app/components/orchestration/agent_tools_component.rbs
@@ -1,0 +1,7 @@
+module Orchestration
+  class AgentToolsComponent < ViewComponent::Base
+    def initialize: (available_tools: Array[String], selected: Array[String] | nil, ?errors: Array[String]) -> void
+    def grouped_tools: () -> Hash[String, Array[String]]
+    def selected?: (String tool) -> bool
+  end
+end

--- a/sig/app/components/ui/tabs_component.rbs
+++ b/sig/app/components/ui/tabs_component.rbs
@@ -1,0 +1,16 @@
+module UI
+  class TabsComponent < ViewComponent::Base
+    def initialize: (?extra_controllers: Array[String] | String) -> void
+    def controller_value: () -> String
+  end
+
+  class TabsComponent::TabComponent < ViewComponent::Base
+    def initialize: (id: String, label: String, controls: String, ?active: bool) -> void
+    def call: () -> String
+  end
+
+  class TabsComponent::PanelComponent < ViewComponent::Base
+    def initialize: (id: String, tab_id: String, ?active: bool) -> void
+    def call: () -> String
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a reusable Stimulus `tabs` controller (`tabs_controller.ts`) with `tab` and `panel` targets and index-based active state management
- Restructures the pipeline edit form: **General** tab holds name, description, model override, cron schedule, enabled; **Schema Builder** tab holds the initial input schema builder
- Restructures the agent edit form: **General** tab holds name, description, model, tools, prompt; **Schema Builder** tab holds the output schema builder
- Submit bar is always visible below both tabs using the HTML5 `form=` attribute, so saving works without needing to navigate back to the General tab

## Test plan

- [ ] Navigate to pipeline edit — General tab is active by default with all fields visible
- [ ] Click Schema Builder tab — JSON schema builder loads with existing schema
- [ ] Edit schema, switch back to General, click Update Pipeline — schema change is saved
- [ ] Navigate to agent edit — same tab behaviour
- [ ] Click Update Agent from either tab — saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)