### PR TITLE
Extract ActiveRecord query logic into model scopes/class methods

### DIFF
--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -30,7 +30,7 @@ module Evaluation
     end
 
     def snapshot_agent_prompt
-      agent = Orchestration::Agent.find_by(name: params[:agent_name])
+      agent = Orchestration::Agent.named(params[:agent_name])
 
       if agent.nil? || agent.prompt.blank?
         render json: { error: "Agent not found or has no prompt" }, status: :unprocessable_content

--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -70,10 +70,7 @@ module Evaluation
     end
 
     def prompt_versions
-      prompts = Prompt
-        .where(name: params[:agent_name])
-        .order(version: :desc)
-        .select(:id, :version, :metadata)
+      prompts = Prompt.metadata_versions_for(params[:agent_name])
       render json: prompts.map { |p|
         meta = begin; JSON.parse(p.metadata || "{}"); rescue JSON::ParserError; {}; end
         { id: p.id, version: p.version, active: meta["active"] == true }

--- a/app/controllers/evaluation/experiments_controller.rb
+++ b/app/controllers/evaluation/experiments_controller.rb
@@ -106,9 +106,7 @@ module Evaluation
 
     def compare
       @candidate = Experiment
-        .joins(:prompt)
-        .where(evaluation_prompts: { name: @experiment.prompt&.name })
-        .where.not(id: @experiment.id)
+        .sibling_for_prompt_name(@experiment.prompt&.name, excluding_id: @experiment.id)
         .find_by(id: params[:candidate_id])
 
       unless @candidate

--- a/app/controllers/evaluation/prompt_diffs_controller.rb
+++ b/app/controllers/evaluation/prompt_diffs_controller.rb
@@ -4,7 +4,7 @@ module Evaluation
   class PromptDiffsController < ApplicationController
     def show
       @prompt = Evaluation::Prompt.find(params[:id].to_i)
-      @other_version = Evaluation::Prompt.where(name: @prompt.name).where.not(id: @prompt.id).order(version: :desc, id: :desc).first
+      @other_version = Evaluation::Prompt.other_versions_for(@prompt.name, excluding_id: @prompt.id).first
     end
   end
 end

--- a/app/controllers/orchestration/actions_controller.rb
+++ b/app/controllers/orchestration/actions_controller.rb
@@ -6,12 +6,7 @@ module Orchestration
     before_action :load_agents, only: [ :new, :create, :edit, :update ]
 
     def index
-      @actions = Orchestration::Action
-        .includes(:agent)
-        .left_joins(step_actions: { step: :pipeline })
-        .select("orchestration_actions.*, COUNT(DISTINCT orchestration_pipelines.id) AS pipeline_count")
-        .group("orchestration_actions.id")
-        .order("orchestration_actions.name")
+      @actions = Orchestration::Action.with_pipeline_counts
     end
 
     def new

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -7,11 +7,7 @@ module Orchestration
     before_action :set_agent, only: [ :show, :edit, :update, :destroy, :toggle ]
 
     def index
-      @agents = Orchestration::Agent
-        .left_joins(:actions)
-        .select("orchestration_agents.*, COUNT(DISTINCT orchestration_actions.id) AS action_count")
-        .group("orchestration_agents.id")
-        .order("orchestration_agents.name")
+      @agents = Orchestration::Agent.with_action_counts
     end
 
     def show

--- a/app/controllers/orchestration/agents_controller.rb
+++ b/app/controllers/orchestration/agents_controller.rb
@@ -11,7 +11,7 @@ module Orchestration
     end
 
     def show
-      @using_actions = @agent.actions.includes(step_actions: { step: :pipeline }).order(:name)
+      @using_actions = @agent.actions_with_usage
     end
 
     def new

--- a/app/controllers/orchestration/all_pipeline_runs_controller.rb
+++ b/app/controllers/orchestration/all_pipeline_runs_controller.rb
@@ -3,7 +3,7 @@
 module Orchestration
   class AllPipelineRunsController < ApplicationController
     def index
-      @pagy, @runs = pagy(:offset, Orchestration::PipelineRun.includes(:pipeline).order(created_at: :desc))
+      @pagy, @runs = pagy(:offset, Orchestration::PipelineRun.includes(:pipeline).recent_first)
     end
   end
 end

--- a/app/controllers/orchestration/pipeline_runs_controller.rb
+++ b/app/controllers/orchestration/pipeline_runs_controller.rb
@@ -5,7 +5,7 @@ module Orchestration
     before_action :set_pipeline
 
     def index
-      @pagy, @runs = pagy(:offset, @pipeline.pipeline_runs.order(created_at: :desc))
+      @pagy, @runs = pagy(:offset, @pipeline.pipeline_runs.recent_first)
     end
 
     def show

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -7,11 +7,7 @@ module Orchestration
     before_action :set_pipeline, only: [ :show, :edit, :update, :destroy, :run, :toggle ]
 
     def index
-      @pipelines = Orchestration::Pipeline
-        .left_joins(:steps)
-        .select("orchestration_pipelines.*, COUNT(orchestration_steps.id) AS step_count")
-        .group("orchestration_pipelines.id")
-        .order("orchestration_pipelines.name")
+      @pipelines = Orchestration::Pipeline.with_step_counts
     end
 
     def show

--- a/app/controllers/orchestration/pipelines_controller.rb
+++ b/app/controllers/orchestration/pipelines_controller.rb
@@ -11,9 +11,9 @@ module Orchestration
     end
 
     def show
-      @steps = @pipeline.steps.includes(step_actions: { action: :agent })
+      @steps = @pipeline.steps_with_actions
       @actions = Orchestration::Action.order(:name)
-      @latest_run = @pipeline.pipeline_runs.order(created_at: :desc).first
+      @latest_run = @pipeline.latest_run
     end
     def new
       @pipeline = Orchestration::Pipeline.new

--- a/app/controllers/orchestration/steps_controller.rb
+++ b/app/controllers/orchestration/steps_controller.rb
@@ -30,13 +30,13 @@ module Orchestration
     end
 
     def move_up
-      prev_step = @pipeline.steps.where("position < ?", @step.position).order(position: :desc).first
+      prev_step = @step.previous_sibling
       @step.swap_position_with(prev_step) if prev_step
       redirect_to orchestration_pipeline_path(@pipeline)
     end
 
     def move_down
-      next_step = @pipeline.steps.where("position > ?", @step.position).order(position: :asc).first
+      next_step = @step.next_sibling
       @step.swap_position_with(next_step) if next_step
       redirect_to orchestration_pipeline_path(@pipeline)
     end
@@ -57,7 +57,7 @@ module Orchestration
     end
 
     def render_pipeline_show
-      @steps = @pipeline.steps.includes(step_actions: { action: :agent })
+      @steps = @pipeline.steps_with_actions
       @actions = Orchestration::Action.order(:name)
       render "orchestration/pipelines/show", status: :unprocessable_content
     end

--- a/app/forms/evaluation/wizard/step3_form.rb
+++ b/app/forms/evaluation/wizard/step3_form.rb
@@ -19,10 +19,7 @@ module Evaluation
       def datasets
         Evaluation::Dataset
           .for_agent(agent_name)
-          .left_joins(:dataset_samples)
-          .group("evaluation_datasets.id")
-          .select("evaluation_datasets.*, COUNT(evaluation_dataset_samples.id) AS record_count")
-          .order(:name)
+          .with_record_counts
       end
 
       private

--- a/app/forms/orchestration/pipeline_run_form.rb
+++ b/app/forms/orchestration/pipeline_run_form.rb
@@ -28,7 +28,7 @@ module Orchestration
     private
 
     def no_active_run
-      return unless @pipeline.pipeline_runs.exists?(status: %w[pending running])
+      return unless @pipeline.run_in_progress?
 
       errors.add(:base, "A run is already pending.")
     end

--- a/app/jobs/evaluation/evaluation_job.rb
+++ b/app/jobs/evaluation/evaluation_job.rb
@@ -5,6 +5,7 @@ module Evaluation
     queue_as :default
 
     retry_on RubyLLM::Error, attempts: 3 do |job, _error|
+      # job.arguments[0] is SolidQueue's positional job-callback convention; intentionally not extracted into a named model method to avoid leaking framework coupling into the domain model.
       experiment = Evaluation::Experiment.find_by(id: job.arguments[0])
       next unless experiment
 

--- a/app/jobs/evaluation/prompt_auto_eval_job.rb
+++ b/app/jobs/evaluation/prompt_auto_eval_job.rb
@@ -21,9 +21,7 @@ module Evaluation
 
     def find_previous_experiment(prompt)
       Evaluation::Experiment
-        .joins(:prompt)
-        .where(evaluation_prompts: { name: prompt.name })
-        .where(status: :completed)
+        .completed_for_prompt_name(prompt.name)
         .order(id: :desc)
         .first
     end

--- a/app/jobs/evaluation/sampling_job.rb
+++ b/app/jobs/evaluation/sampling_job.rb
@@ -5,6 +5,7 @@ module Evaluation
     queue_as :default
 
     retry_on RubyLLM::Error, attempts: 3 do |job, _error|
+      # job.arguments[0] is SolidQueue's positional job-callback convention; intentionally not extracted into a named model method to avoid leaking framework coupling into the domain model.
       experiment = Evaluation::Experiment.find_by(id: job.arguments[0])
       next unless experiment
 

--- a/app/jobs/evaluation/synthetic_dataset_job.rb
+++ b/app/jobs/evaluation/synthetic_dataset_job.rb
@@ -39,12 +39,7 @@ module Evaluation
     end
 
     def fetch_system_prompt(agent_name)
-      Evaluation::Prompt
-        .where(name: agent_name)
-        .order(version: :desc, id: :desc)
-        .first
-        &.system_prompt
-        .to_s
+      Evaluation::Prompt.last_for_agent(agent_name)&.system_prompt.to_s
     end
 
     def fetch_few_shot_samples(agent_name)

--- a/app/jobs/records/fill_job.rb
+++ b/app/jobs/records/fill_job.rb
@@ -3,7 +3,7 @@
 module Records
   class FillJob < ApplicationJob
     def perform(ids)
-      mails = ApplicationMail.where(id: ids)
+      mails = ApplicationMail.by_ids(ids)
       input = {
         emails:            mails.map(&:attributes),
         destination_table: "application_mails"

--- a/app/jobs/records/normalize_job.rb
+++ b/app/jobs/records/normalize_job.rb
@@ -3,7 +3,7 @@
 module Records
   class NormalizeJob < ApplicationJob
     def perform(ids)
-      mails = ApplicationMail.where(id: ids)
+      mails = ApplicationMail.by_ids(ids)
       input = {
         records_to_normalize: mails.map(&:attributes),
         destination_table:    "application_mails",

--- a/app/jobs/records/reconcile_job.rb
+++ b/app/jobs/records/reconcile_job.rb
@@ -3,7 +3,7 @@
 module Records
   class ReconcileJob < ApplicationJob
     def perform(ids)
-      mails = ApplicationMail.where(id: ids)
+      mails = ApplicationMail.by_ids(ids)
       input = {
         emailsto_reconcile: mails.map(&:attributes),
         destination_table:  "interviews",

--- a/app/models/application_mail.rb
+++ b/app/models/application_mail.rb
@@ -1,11 +1,14 @@
 class ApplicationMail < ApplicationRecord
   include Searchable
+  include Batchable
   COLUMN_NAMES = %w[id date provider email_id company job_title action].freeze
 
   def self.tool_column_names = COLUMN_NAMES
 
   validates :date, :provider, :email_id, presence: true
   validates :email_id, uniqueness: true
+
+  scope :by_ids, ->(ids) { where(id: ids) }
 
   # rubocop:disable Metrics/BlockLength
   scope :groupped, -> {

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,4 +1,6 @@
 class Chat < ApplicationRecord
+  include Batchable
+
   acts_as_chat
 
   has_many :action_runs, class_name: "Orchestration::ActionRun", dependent: :nullify

--- a/app/models/concerns/batchable.rb
+++ b/app/models/concerns/batchable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Batchable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def destroy_by_ids(ids)
+      where(id: ids).destroy_all
+    end
+  end
+end

--- a/app/models/evaluation/dataset.rb
+++ b/app/models/evaluation/dataset.rb
@@ -6,5 +6,11 @@ module Evaluation
     validates :name, presence: true
 
     scope :for_agent, ->(name) { where(agent_name: name) }
+    scope :with_record_counts, -> {
+      left_joins(:dataset_samples)
+        .group("evaluation_datasets.id")
+        .select("evaluation_datasets.*, COUNT(evaluation_dataset_samples.id) AS record_count")
+        .order(:name)
+    }
   end
 end

--- a/app/models/evaluation/evaluation_result.rb
+++ b/app/models/evaluation/evaluation_result.rb
@@ -9,6 +9,10 @@ module Evaluation
 
     accepts_nested_attributes_for :justifications, allow_destroy: true
 
+    def self.overall_average(experiment)
+      where(experiment: experiment).average(:score)
+    end
+
     def self.per_metric_averages(experiment)
       joins(justification_join_source)
         .where(experiment: experiment)

--- a/app/models/evaluation/experiment.rb
+++ b/app/models/evaluation/experiment.rb
@@ -52,6 +52,10 @@ module Evaluation
       meta["pipeline_model"].presence || agent&.model.presence
     end
 
+    def self.completed_for_prompt_name(name) = joins(:prompt).where(status: :completed, evaluation_prompts: { name: name })
+
+    def self.sibling_for_prompt_name(name, excluding_id:) = joins(:prompt).where(evaluation_prompts: { name: name }).where.not(id: excluding_id)
+
     def newer_experiment
       return unless prompt
 

--- a/app/models/evaluation/experiment.rb
+++ b/app/models/evaluation/experiment.rb
@@ -48,7 +48,7 @@ module Evaluation
 
     def runner_model
       meta = metadata || empty_object
-      agent = agent_name ? Orchestration::Agent.find_by(name: agent_name) : nil
+      agent = agent_name ? Orchestration::Agent.named(agent_name) : nil
       meta["pipeline_model"].presence || agent&.model.presence
     end
 

--- a/app/models/evaluation/metric.rb
+++ b/app/models/evaluation/metric.rb
@@ -9,5 +9,6 @@ module Evaluation
 
     scope :for_agent, ->(agent_name) { where(agent_name: agent_name) }
     scope :active, -> { where(active: true) }
+    scope :active_for_agent, ->(agent_name) { active.for_agent(agent_name) }
   end
 end

--- a/app/models/evaluation/prompt.rb
+++ b/app/models/evaluation/prompt.rb
@@ -12,9 +12,15 @@ module Evaluation
 
     before_validation :assign_next_version, on: :create
 
+    scope :versions_for, ->(name) { where(name:).order(version: :desc) }
+
     def self.last_for_agent(agent_name)
       where(name: agent_name).order(version: :desc, id: :desc).first
     end
+
+    def self.metadata_versions_for(name) = versions_for(name).select(:id, :version, :metadata)
+
+    def self.other_versions_for(name, excluding_id:) = where(name:).where.not(id: excluding_id).order(version: :desc, id: :desc)
 
     private
 

--- a/app/models/evaluation/prompt.rb
+++ b/app/models/evaluation/prompt.rb
@@ -13,6 +13,7 @@ module Evaluation
     before_validation :assign_next_version, on: :create
 
     scope :versions_for, ->(name) { where(name:).order(version: :desc) }
+    scope :active_metadata_versions_for, ->(agent_names) { where(name: agent_names).where("json_extract(metadata, '$.active') = ?", true) }
 
     def self.last_for_agent(agent_name)
       where(name: agent_name).order(version: :desc, id: :desc).first

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,5 +1,6 @@
 class Interview < ApplicationRecord
   include Searchable
+  include Batchable
   validates :company, :job_title, presence: true
   validates :job_title, uniqueness: { scope: :company }
 

--- a/app/models/orchestration/action.rb
+++ b/app/models/orchestration/action.rb
@@ -12,6 +12,14 @@ module Orchestration
     validates :name, presence: true
     validate :kind_specific_fields_valid
 
+    scope :with_pipeline_counts, -> {
+      includes(:agent)
+        .left_joins(step_actions: { step: :pipeline })
+        .select("orchestration_actions.*, COUNT(DISTINCT orchestration_pipelines.id) AS pipeline_count")
+        .group("orchestration_actions.id")
+        .order("orchestration_actions.name")
+    }
+
     def input_schema
       agent? ? agent&.input_schema : agent_class&.safe_constantize&.input_schema
     end

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -21,6 +21,10 @@ module Orchestration
 
     before_destroy :ensure_not_referenced
 
+    def actions_with_usage
+      actions.includes(step_actions: { step: :pipeline }).order(:name)
+    end
+
     def self.available_tools
       Rails.root.glob("app/tools/**/*.rb")
         .filter_map { |path| tool_class_name_from_path(path) }

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -25,6 +25,8 @@ module Orchestration
       actions.includes(step_actions: { step: :pipeline }).order(:name)
     end
 
+    def self.named(name) = find_by(name:)
+
     def self.available_tools
       Rails.root.glob("app/tools/**/*.rb")
         .filter_map { |path| tool_class_name_from_path(path) }

--- a/app/models/orchestration/agent.rb
+++ b/app/models/orchestration/agent.rb
@@ -12,6 +12,12 @@ module Orchestration
     validate :tools_must_be_valid
 
     scope :enabled, -> { where(enabled: true) }
+    scope :with_action_counts, -> {
+      left_joins(:actions)
+        .select("orchestration_agents.*, COUNT(DISTINCT orchestration_actions.id) AS action_count")
+        .group("orchestration_agents.id")
+        .order("orchestration_agents.name")
+    }
 
     before_destroy :ensure_not_referenced
 

--- a/app/models/orchestration/pipeline.rb
+++ b/app/models/orchestration/pipeline.rb
@@ -8,6 +8,13 @@ module Orchestration
     validates :name, presence: true
     validate :cron_expression_parseable, if: -> { cron_expression.present? }
 
+    scope :with_step_counts, -> {
+      left_joins(:steps)
+        .select("orchestration_pipelines.*, COUNT(orchestration_steps.id) AS step_count")
+        .group("orchestration_pipelines.id")
+        .order("orchestration_pipelines.name")
+    }
+
     def validate_steps
       PipelineValidator.new(self).validate
     end

--- a/app/models/orchestration/pipeline.rb
+++ b/app/models/orchestration/pipeline.rb
@@ -19,6 +19,22 @@ module Orchestration
       PipelineValidator.new(self).validate
     end
 
+    def latest_run
+      pipeline_runs.recent_first.first
+    end
+
+    def run_in_progress?
+      pipeline_runs.in_progress.exists?
+    end
+
+    def enabled_steps
+      steps.where(enabled: true)
+    end
+
+    def steps_with_actions
+      steps.includes(step_actions: { action: :agent })
+    end
+
     def next_run_at(from: Time.current)
       return nil if cron_expression.blank?
       cron = Fugit::Cron.parse(cron_expression)

--- a/app/models/orchestration/pipeline_run.rb
+++ b/app/models/orchestration/pipeline_run.rb
@@ -3,6 +3,7 @@ module Orchestration
     self.table_name = "orchestration_pipeline_runs"
 
     STATUSES = %w[pending running completed failed].freeze
+    ACTIVE_STATUSES = %w[pending running].freeze
     TRIGGERED_BY = %w[manual schedule].freeze
 
     belongs_to :pipeline, class_name: "Orchestration::Pipeline"
@@ -10,5 +11,8 @@ module Orchestration
 
     validates :status, presence: true, inclusion: { in: STATUSES }
     validates :triggered_by, inclusion: { in: TRIGGERED_BY }, allow_nil: true
+
+    scope :recent_first, -> { order(created_at: :desc) }
+    scope :in_progress, -> { where(status: ACTIVE_STATUSES) }
   end
 end

--- a/app/models/orchestration/step.rb
+++ b/app/models/orchestration/step.rb
@@ -9,6 +9,14 @@ module Orchestration
     validates :name, presence: true
     validates :position, presence: true, uniqueness: { scope: :pipeline_id }
 
+    def previous_sibling
+      pipeline.steps.where("position < ?", position).order(position: :desc).first
+    end
+
+    def next_sibling
+      pipeline.steps.where("position > ?", position).order(position: :asc).first
+    end
+
     def swap_position_with(other)
       pos_a = position
       pos_b = other.position

--- a/app/services/application_mails/batch_service.rb
+++ b/app/services/application_mails/batch_service.rb
@@ -33,7 +33,7 @@ module ApplicationMails
     end
 
     def delete_records(count)
-      ApplicationMail.where(id: @ids).destroy_all
+      ApplicationMail.destroy_by_ids(@ids)
       Result.new(ok: true, message: "Deleted #{count} record(s).")
     end
 

--- a/app/services/chats/batch_service.rb
+++ b/app/services/chats/batch_service.rb
@@ -22,7 +22,7 @@ module Chats
 
       case @batch_action
       when "delete"
-        Chat.where(id: @ids).destroy_all
+        Chat.destroy_by_ids(@ids)
         Result.new(ok: true, message: "Deleted #{@ids.size} chat(s).")
       else
         Result.new(ok: false, message: "Unknown batch action.")

--- a/app/services/evaluation/agent_summary_query.rb
+++ b/app/services/evaluation/agent_summary_query.rb
@@ -115,8 +115,7 @@ module Evaluation
 
     def fetch_active_prompts(agent_names)
       Evaluation::Prompt
-        .where(name: agent_names)
-        .where("json_extract(metadata, '$.active') = ?", true)
+        .active_metadata_versions_for(agent_names)
         .order(version: :desc)
         .to_a # : Array[Evaluation::Prompt]
     end

--- a/app/services/evaluation/comparison.rb
+++ b/app/services/evaluation/comparison.rb
@@ -46,7 +46,7 @@ module Evaluation
     end
 
     def overall_average(experiment)
-      EvaluationResult.where(experiment: experiment).average(:score) # : Float?
+      EvaluationResult.overall_average(experiment)
     end
   end
 end

--- a/app/services/evaluation/sampler.rb
+++ b/app/services/evaluation/sampler.rb
@@ -54,7 +54,7 @@ module Evaluation
       agent_name = @experiment.agent_name
       return unless agent_name
 
-      Orchestration::Agent.find_by(name: agent_name)
+      Orchestration::Agent.named(agent_name)
     end
 
     def find_action_for(agent_record)

--- a/app/services/interviews/batch_service.rb
+++ b/app/services/interviews/batch_service.rb
@@ -36,7 +36,7 @@ module Interviews
     end
 
     def delete_interviews(count)
-      Interview.where(id: @ids).destroy_all
+      Interview.destroy_by_ids(@ids)
       Result.new(ok: true, message: "Deleted #{count} record(s).")
     end
 

--- a/lib/evaluation/create_experiment_from_draft.rb
+++ b/lib/evaluation/create_experiment_from_draft.rb
@@ -32,17 +32,14 @@ module Evaluation
     end
 
     def resolve_prompt
+      agent_name = payload["agent_name"] #: String?
       @prompt_id = payload["prompt_id"].presence ||
-                   Prompt
-                     .where(name: payload["agent_name"])
-                     .order(version: :desc, id: :desc)
-                     .pick(:id)
-                     &.to_s
+                   Prompt.last_for_agent(agent_name)&.id&.to_s
       @agent_name = Prompt.find_by(id: @prompt_id)&.name
     end
 
     def no_active_metrics?
-      @agent_name.present? && Metric.for_agent(@agent_name).where(active: true).none?
+      @agent_name.present? && Metric.active_for_agent(@agent_name).none?
     end
 
     def create_experiment!

--- a/lib/evaluation/evaluators/llm_judge_eval.rb
+++ b/lib/evaluation/evaluators/llm_judge_eval.rb
@@ -9,7 +9,7 @@ module Evaluation
       end
 
       def evaluate(sample, dataset_sample, agent_name:, model: self.class.judge_model)
-        metrics = Metric.for_agent(agent_name).where(active: true).to_a # : Array[Evaluation::Metric]
+        metrics = Metric.active_for_agent(agent_name).to_a # : Array[Evaluation::Metric]
         return [] if metrics.empty?
         return log_blank_sample_error if sample.tool_calls.blank? && sample.output.blank?
 

--- a/lib/evaluation/improvement/list_experiments_tool.rb
+++ b/lib/evaluation/improvement/list_experiments_tool.rb
@@ -31,7 +31,7 @@ module Evaluation
       end
 
       def load_metrics(prompt_name)
-        Metric.where(agent_name: prompt_name, active: true).to_a # : Array[Evaluation::Metric]
+        Metric.active_for_agent(prompt_name).to_a # : Array[Evaluation::Metric]
       end
 
       def bulk_per_metric_averages(experiments)

--- a/lib/evaluation/improvement/list_experiments_tool.rb
+++ b/lib/evaluation/improvement/list_experiments_tool.rb
@@ -24,8 +24,7 @@ module Evaluation
 
       def load_experiments(prompt_name, current_experiment_id)
         Experiment
-          .joins(:prompt)
-          .where(status: :completed, evaluation_prompts: { name: prompt_name })
+          .completed_for_prompt_name(prompt_name)
           .where.not(id: current_experiment_id)
           .includes(:prompt).order(:created_at) # : Evaluation::Experiment::relation
       end

--- a/lib/evaluation/improvement/load_schema_tool.rb
+++ b/lib/evaluation/improvement/load_schema_tool.rb
@@ -17,7 +17,7 @@ module Evaluation
       private
 
       def schema_for(prompt_name)
-        ::Orchestration::Agent.find_by(name: prompt_name)
+        ::Orchestration::Agent.named(prompt_name)
       end
     end
   end

--- a/lib/evaluation/prompt_improver.rb
+++ b/lib/evaluation/prompt_improver.rb
@@ -57,7 +57,7 @@ module Evaluation
     end
 
     def append_output_schema(message, agent_name)
-      agent_schema = Orchestration::Agent.find_by(name: agent_name)&.output_schema
+      agent_schema = Orchestration::Agent.named(agent_name)&.output_schema
       return message if agent_schema.blank?
 
       message + "\n\n<output_schema>\n#{agent_schema.to_json}\n</output_schema>"

--- a/lib/evaluation/prompt_improver.rb
+++ b/lib/evaluation/prompt_improver.rb
@@ -37,7 +37,7 @@ module Evaluation
     end
 
     def metrics(current_prompt)
-      Metric.where(agent_name: current_prompt.name.to_s, active: true).to_a
+      Metric.active_for_agent(current_prompt.name.to_s).to_a
     end
 
 

--- a/lib/orchestration/pipeline_runner.rb
+++ b/lib/orchestration/pipeline_runner.rb
@@ -21,7 +21,7 @@ module Orchestration
     end
 
     def process_steps(previous_outputs)
-      steps = @pipeline_run.pipeline.steps.where(enabled: true).order(:position).to_a # : Array[Step]
+      steps = @pipeline_run.pipeline.enabled_steps.to_a # : Array[Step]
       completed = steps.each do |step|
         action_runs = run_step(step, previous_outputs)
         break if handle_step_failure(action_runs)

--- a/lib/orchestration/pipeline_runner.rb
+++ b/lib/orchestration/pipeline_runner.rb
@@ -236,11 +236,7 @@ module Orchestration
       @prompt_cache ||= Hash.new
       return @prompt_cache[agent_class] if @prompt_cache.key?(agent_class)
 
-      @prompt_cache[agent_class] = Evaluation::Prompt
-        .where(name: agent_class)
-        .order(version: :desc, id: :desc)
-        .first
-        &.system_prompt
+      @prompt_cache[agent_class] = Evaluation::Prompt.last_for_agent(agent_class)&.system_prompt
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/orchestration/pipeline_validator.rb
+++ b/lib/orchestration/pipeline_validator.rb
@@ -30,7 +30,7 @@ module Orchestration
     end
 
     def ordered_step_actions
-      steps = @pipeline.steps.includes(step_actions: { action: :agent }).to_a # : Array[Orchestration::Step]
+      steps = @pipeline.steps_with_actions.to_a # : Array[Orchestration::Step]
       steps.flat_map do |step|
         step_actions = step.step_actions.to_a # : Array[Orchestration::StepAction]
         step_actions.sort_by { |sa| sa.position.to_i }

--- a/sig/app/models/application_mail.rbs
+++ b/sig/app/models/application_mail.rbs
@@ -2,12 +2,15 @@ class ApplicationMail < ApplicationRecord
   COLUMN_NAMES: Array[String]
 
   include Searchable
+  include Batchable
 
   type relation = _Relation[ApplicationMail, Integer]
 
   def self.tool_column_names: () -> Array[String]
   def self.search: (String? q) -> relation
   def self.groupped: () -> relation
+  def self.by_ids: (Array[Integer] ids) -> relation
+  def self.destroy_by_ids: (Array[Integer] | Array[String] ids) -> Array[ApplicationMail]
 
   def date: () -> String?
   def date=: (String?) -> String?

--- a/sig/app/models/chat.rbs
+++ b/sig/app/models/chat.rbs
@@ -1,5 +1,9 @@
 class Chat < ApplicationRecord
+  include Batchable
+
   type relation = _Relation[Chat, Integer]
+
+  def self.destroy_by_ids: (Array[Integer] | Array[String] ids) -> Array[Chat]
 
   def model_id: () -> Integer?
   def model_id=: (Integer?) -> Integer?

--- a/sig/app/models/concerns/batchable.rbs
+++ b/sig/app/models/concerns/batchable.rbs
@@ -1,0 +1,7 @@
+module Batchable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def destroy_by_ids: (Array[Integer] | Array[String] ids) -> Array[ActiveRecord::Base]
+  end
+end

--- a/sig/app/models/evaluation/dataset.rbs
+++ b/sig/app/models/evaluation/dataset.rbs
@@ -8,6 +8,7 @@ module Evaluation
     def self.where: (**top attrs) -> relation
     def self.left_joins: (*top) -> relation
     def self.create!: (**top attrs) -> Dataset
+    def self.with_record_counts: () -> relation
 
     def name: () -> String?
     def name=: (String?) -> String?

--- a/sig/app/models/evaluation/evaluation_result.rbs
+++ b/sig/app/models/evaluation/evaluation_result.rbs
@@ -10,6 +10,7 @@ module Evaluation
     def self.average: (Symbol column) -> Float?
     def self.pluck: (*(String | Symbol)) -> Array[json_object_value]
     def self.justification_join_source: () -> Array[Arel::Nodes::Join]
+    def self.overall_average: (Experiment experiment) -> Float?
     def self.per_metric_averages: (Experiment experiment) -> Hash[String, Float]
 
     def score: () -> Float?

--- a/sig/app/models/evaluation/experiment.rbs
+++ b/sig/app/models/evaluation/experiment.rbs
@@ -13,6 +13,8 @@ module Evaluation
     def self.includes: (*top) -> relation
     def self.order: (*top) -> relation
     def self.not: (*top) -> relation
+    def self.completed_for_prompt_name: (String? name) -> relation
+    def self.sibling_for_prompt_name: (String? name, excluding_id: Integer) -> relation
 
     def id: () -> Integer
     def created_at: () -> Time

--- a/sig/app/models/evaluation/metric.rbs
+++ b/sig/app/models/evaluation/metric.rbs
@@ -5,6 +5,7 @@ module Evaluation
     def self.table_name: () -> String
     def self.for_agent: (String? agent_name) -> relation
     def self.active: () -> relation
+    def self.active_for_agent: (String? agent_name) -> relation
     def self.find_or_initialize_by: (**top attrs) -> Metric
 
     def agent_name: () -> String?

--- a/sig/app/models/evaluation/prompt.rbs
+++ b/sig/app/models/evaluation/prompt.rbs
@@ -4,6 +4,7 @@ module Evaluation
 
     def self.last_for_agent: (String? agent_name) -> Prompt?
     def self.versions_for: (String? name) -> relation
+    def self.active_metadata_versions_for: (Array[String] agent_names) -> relation
     def self.metadata_versions_for: (String? name) -> relation
     def self.other_versions_for: (String? name, excluding_id: Integer) -> relation
 

--- a/sig/app/models/evaluation/prompt.rbs
+++ b/sig/app/models/evaluation/prompt.rbs
@@ -2,7 +2,10 @@ module Evaluation
   class Prompt < ApplicationRecord
     type relation = _Relation[Prompt, Integer]
 
-    def self.last_for_agent: (String agent_name) -> Prompt?
+    def self.last_for_agent: (String? agent_name) -> Prompt?
+    def self.versions_for: (String? name) -> relation
+    def self.metadata_versions_for: (String? name) -> relation
+    def self.other_versions_for: (String? name, excluding_id: Integer) -> relation
 
     def self.table_name: () -> String
     def self.find: (Integer id) -> Prompt

--- a/sig/app/models/interview.rbs
+++ b/sig/app/models/interview.rbs
@@ -2,12 +2,14 @@ class Interview < ApplicationRecord
   COLUMN_NAMES: Array[String]
 
   include Searchable
+  include Batchable
 
   type relation = _Relation[Interview, Integer]
 
   STATUSES: Array[String]
   def self.tool_column_names: () -> Array[String]
   def self.search: (String? q) -> relation
+  def self.destroy_by_ids: (Array[Integer] | Array[String] ids) -> Array[Interview]
 
   def company: () -> String?
   def company=: (String?) -> String?

--- a/sig/app/models/orchestration/action.rbs
+++ b/sig/app/models/orchestration/action.rbs
@@ -3,6 +3,7 @@ module Orchestration
     type relation = _Relation[Action, Integer]
 
     def self.table_name: () -> String
+    def self.with_pipeline_counts: () -> relation
 
     def name: () -> String?
     def name=: (String?) -> String?

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -4,6 +4,7 @@ module Orchestration
 
     ALLOWED_TOOL_NAMESPACES: Array[String]
 
+    def self.named: (String name) -> Agent?
     def self.available_tools: () -> Array[String]
     def self.tool_class_name_from_path: (String path) -> String?
     def self.available_models: () -> Array[[String, Array[String]]]

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -10,6 +10,7 @@ module Orchestration
     def self.with_action_counts: () -> relation
 
     def actions: () -> Action::relation
+    def actions_with_usage: () -> Action::relation
 
     def name: () -> String
     def name=: (String) -> String

--- a/sig/app/models/orchestration/agent.rbs
+++ b/sig/app/models/orchestration/agent.rbs
@@ -7,6 +7,7 @@ module Orchestration
     def self.available_tools: () -> Array[String]
     def self.tool_class_name_from_path: (String path) -> String?
     def self.available_models: () -> Array[[String, Array[String]]]
+    def self.with_action_counts: () -> relation
 
     def actions: () -> Action::relation
 

--- a/sig/app/models/orchestration/pipeline.rbs
+++ b/sig/app/models/orchestration/pipeline.rbs
@@ -20,6 +20,11 @@ module Orchestration
 
     def validate_steps: () -> Array[PipelineValidator::StepResult]
 
+    def latest_run: () -> PipelineRun?
+    def run_in_progress?: () -> bool
+    def enabled_steps: () -> Step::relation
+    def steps_with_actions: () -> Step::relation
+
     def next_run_at: (?from: Time) -> Time?
 
     def steps: () -> Step::ActiveRecord_Associations_CollectionProxy

--- a/sig/app/models/orchestration/pipeline.rbs
+++ b/sig/app/models/orchestration/pipeline.rbs
@@ -3,6 +3,7 @@ module Orchestration
     type relation = _Relation[Pipeline, Integer]
 
     def self.table_name: () -> String
+    def self.with_step_counts: () -> relation
 
     def name: () -> String?
     def name=: (String?) -> String?

--- a/sig/app/models/orchestration/pipeline_run.rbs
+++ b/sig/app/models/orchestration/pipeline_run.rbs
@@ -8,9 +8,12 @@ module Orchestration
     end
 
     STATUSES: Array[String]
+    ACTIVE_STATUSES: Array[String]
     TRIGGERED_BY: Array[String]
 
     def self.table_name: () -> String
+    def self.recent_first: () -> relation
+    def self.in_progress: () -> relation
 
     def status: () -> String?
     def status=: (String?) -> String?

--- a/sig/app/models/orchestration/step.rbs
+++ b/sig/app/models/orchestration/step.rbs
@@ -19,6 +19,9 @@ module Orchestration
     def enabled=: (bool) -> bool
     def enabled?: () -> bool
 
+    def previous_sibling: () -> Step?
+    def next_sibling: () -> Step?
+
     def swap_position_with: (Step other) -> void
 
     def self.derive_status: (Array[ActionRun] action_runs) -> String

--- a/spec/models/application_mail_spec.rb
+++ b/spec/models/application_mail_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe ApplicationMail do
     end
   end
 
+  describe '.by_ids' do
+    it 'returns only the records with the given ids' do
+      a = create(:application_mail, email_id: 'a@gmail.com')
+      b = create(:application_mail, email_id: 'b@gmail.com')
+      _c = create(:application_mail, email_id: 'c@gmail.com')
+
+      expect(described_class.by_ids([ a.id, b.id ])).to contain_exactly(a, b)
+    end
+
+    it 'returns an empty relation when no ids match' do
+      create(:application_mail, email_id: 'a@gmail.com')
+
+      expect(described_class.by_ids([])).to be_empty
+    end
+  end
+
   describe '.groupped' do
     it 'groups records by company and job_title' do
       create(:application_mail, company: 'Acme', job_title: 'Engineer', email_id: 'a@x.com')

--- a/spec/models/concerns/batchable_spec.rb
+++ b/spec/models/concerns/batchable_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Batchable do
+  describe ".destroy_by_ids" do
+    let!(:kept)     { create(:application_mail, email_id: "kept@gmail.com") }
+    let!(:doomed)   { create(:application_mail, email_id: "doomed@gmail.com") }
+    let!(:doomed_b) { create(:application_mail, email_id: "doomed_b@gmail.com") }
+
+    it "destroys exactly the records with the given ids" do
+      ApplicationMail.destroy_by_ids([ doomed.id, doomed_b.id ])
+
+      expect(ApplicationMail.exists?(doomed.id)).to be false
+      expect(ApplicationMail.exists?(doomed_b.id)).to be false
+    end
+
+    it "leaves other records untouched" do
+      ApplicationMail.destroy_by_ids([ doomed.id, doomed_b.id ])
+
+      expect(ApplicationMail.all).to contain_exactly(kept)
+    end
+
+    it "destroys nothing when given no ids" do
+      expect { ApplicationMail.destroy_by_ids([]) }.not_to change(ApplicationMail, :count)
+    end
+  end
+end

--- a/spec/models/evaluation/dataset_spec.rb
+++ b/spec/models/evaluation/dataset_spec.rb
@@ -20,4 +20,23 @@ RSpec.describe Evaluation::Dataset do
       expect(described_class.for_agent("Emails::ClassifyAgent")).not_to include(unnamed_dataset)
     end
   end
+
+  describe ".with_record_counts" do
+    before do
+      create(:evaluation_dataset, name: "Alpha")
+      dataset_b = create(:evaluation_dataset, name: "Bravo")
+      dataset_c = create(:evaluation_dataset, name: "Charlie")
+      create_list(:evaluation_dataset_sample, 3, dataset: dataset_c)
+      create(:evaluation_dataset_sample, dataset: dataset_b)
+    end
+
+    it "returns the exact record_count per dataset" do
+      counts = described_class.with_record_counts.to_h { |d| [ d.name, d.record_count.to_i ] }
+      expect(counts).to eq("Alpha" => 0, "Bravo" => 1, "Charlie" => 3)
+    end
+
+    it "orders datasets by name" do
+      expect(described_class.with_record_counts.map(&:name)).to eq(%w[Alpha Bravo Charlie])
+    end
+  end
 end

--- a/spec/models/evaluation/evaluation_result_spec.rb
+++ b/spec/models/evaluation/evaluation_result_spec.rb
@@ -50,4 +50,25 @@ RSpec.describe Evaluation::EvaluationResult do
       end
     end
   end
+
+  describe ".overall_average" do
+    it "returns the average score across all results for the experiment" do
+      make_eval_result(experiment: experiment, score: 3.0, metric_name: "accuracy")
+      make_eval_result(experiment: experiment, score: 5.0, metric_name: "relevance")
+
+      expect(described_class.overall_average(experiment)).to be_within(0.001).of(4.0)
+    end
+
+    it "ignores results from other experiments" do
+      make_eval_result(experiment: experiment, score: 4.0, metric_name: "accuracy")
+      other = create(:evaluation_experiment)
+      make_eval_result(experiment: other, score: 1.0, metric_name: "accuracy")
+
+      expect(described_class.overall_average(experiment)).to be_within(0.001).of(4.0)
+    end
+
+    it "returns nil when the experiment has no results" do
+      expect(described_class.overall_average(experiment)).to be_nil
+    end
+  end
 end

--- a/spec/models/evaluation/experiment_spec.rb
+++ b/spec/models/evaluation/experiment_spec.rb
@@ -13,6 +13,58 @@ RSpec.describe Evaluation::Experiment do
     end
   end
 
+  describe ".completed_for_prompt_name" do
+    let(:prompt) { create(:orchestration_prompt, name: "classifier") }
+    let(:other_prompt) { create(:orchestration_prompt, name: "summarizer") }
+
+    it "returns completed experiments matching the prompt name" do
+      match = create(:evaluation_experiment, prompt: prompt, status: "completed")
+      create(:evaluation_experiment, prompt: prompt, status: "pending")
+      create(:evaluation_experiment, prompt: other_prompt, status: "completed")
+
+      expect(described_class.completed_for_prompt_name("classifier")).to contain_exactly(match)
+    end
+
+    it "excludes experiments for a different prompt name" do
+      create(:evaluation_experiment, prompt: other_prompt, status: "completed")
+
+      expect(described_class.completed_for_prompt_name("classifier")).to be_empty
+    end
+
+    it "excludes non-completed experiments for the same prompt name" do
+      create(:evaluation_experiment, prompt: prompt, status: "sampling")
+
+      expect(described_class.completed_for_prompt_name("classifier")).to be_empty
+    end
+  end
+
+  describe ".sibling_for_prompt_name" do
+    let(:prompt) { create(:orchestration_prompt, name: "classifier") }
+    let(:other_prompt) { create(:orchestration_prompt, name: "summarizer") }
+
+    it "returns experiments matching the prompt name regardless of status" do
+      completed = create(:evaluation_experiment, prompt: prompt, status: "completed")
+      pending = create(:evaluation_experiment, prompt: prompt, status: "pending")
+
+      expect(described_class.sibling_for_prompt_name("classifier", excluding_id: -1))
+        .to contain_exactly(completed, pending)
+    end
+
+    it "excludes the given id" do
+      excluded = create(:evaluation_experiment, prompt: prompt, status: "completed")
+      other = create(:evaluation_experiment, prompt: prompt, status: "completed")
+
+      expect(described_class.sibling_for_prompt_name("classifier", excluding_id: excluded.id))
+        .to contain_exactly(other)
+    end
+
+    it "excludes experiments for a different prompt name" do
+      create(:evaluation_experiment, prompt: other_prompt, status: "completed")
+
+      expect(described_class.sibling_for_prompt_name("classifier", excluding_id: -1)).to be_empty
+    end
+  end
+
   describe "AASM state machine" do
     subject(:experiment) { create(:evaluation_experiment, status: "pending") }
 

--- a/spec/models/evaluation/metric_spec.rb
+++ b/spec/models/evaluation/metric_spec.rb
@@ -77,5 +77,13 @@ RSpec.describe Evaluation::Metric do
         expect(result).not_to include(inactive_metric)
       end
     end
+
+    describe '.active_for_agent' do
+      it 'returns only active metrics for the given agent' do
+        result = described_class.active_for_agent('AgentA')
+        expect(result).to include(active_metric)
+        expect(result).not_to include(inactive_metric, other_agent)
+      end
+    end
   end
 end

--- a/spec/models/evaluation/prompt_spec.rb
+++ b/spec/models/evaluation/prompt_spec.rb
@@ -24,4 +24,43 @@ RSpec.describe Evaluation::Prompt do
 
     expect(prompt.version).to eq(2)
   end
+
+  describe ".versions_for" do
+    it "returns all versions for the name ordered by version desc" do
+      v1 = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 1)
+      v3 = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 3)
+      v2 = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 2)
+      create(:orchestration_prompt, name: "Other::Agent", version: 1)
+
+      expect(described_class.versions_for("Emails::ClassifyAgent")).to eq([ v3, v2, v1 ])
+    end
+  end
+
+  describe ".metadata_versions_for" do
+    it "returns id, version and metadata for the name ordered by version desc" do
+      v1 = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 1)
+      v2 = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 2)
+
+      result = described_class.metadata_versions_for("Emails::ClassifyAgent")
+
+      expect(result.map(&:id)).to eq([ v2.id, v1.id ])
+      expect(result.map(&:version)).to eq([ 2, 1 ])
+    end
+  end
+
+  describe ".other_versions_for" do
+    it "excludes the given id and orders by version desc then id desc" do
+      current = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 3)
+      v2_low  = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 2)
+      v2_high = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 2)
+      v1      = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 1)
+      create(:orchestration_prompt, name: "Other::Agent", version: 2)
+
+      expect(v2_high.id).to be > v2_low.id
+
+      result = described_class.other_versions_for("Emails::ClassifyAgent", excluding_id: current.id)
+
+      expect(result).to eq([ v2_high, v2_low, v1 ])
+    end
+  end
 end

--- a/spec/models/evaluation/prompt_spec.rb
+++ b/spec/models/evaluation/prompt_spec.rb
@@ -48,6 +48,44 @@ RSpec.describe Evaluation::Prompt do
     end
   end
 
+  describe ".active_metadata_versions_for" do
+    it "returns prompts for the given names whose metadata has active: true" do
+      active = create(:orchestration_prompt, name: "AgentA", version: 1, metadata: '{"active":true}')
+      create(:orchestration_prompt, name: "AgentA", version: 2, metadata: '{"active":false}')
+      create(:orchestration_prompt, name: "AgentB", version: 1, metadata: '{"active":true}')
+
+      expect(described_class.active_metadata_versions_for([ "AgentA" ])).to eq([ active ])
+    end
+
+    it "matches across multiple agent names" do
+      a = create(:orchestration_prompt, name: "AgentA", version: 1, metadata: '{"active":true}')
+      b = create(:orchestration_prompt, name: "AgentB", version: 1, metadata: '{"active":true}')
+      create(:orchestration_prompt, name: "AgentC", version: 1, metadata: '{"active":true}')
+
+      expect(described_class.active_metadata_versions_for([ "AgentA", "AgentB" ])).to contain_exactly(a, b)
+    end
+
+    # Byte-identical SQL guarantees the extraction is a pure no-op vs. the original
+    # inline query in Evaluation::AgentSummaryQuery#fetch_active_prompts.
+    describe "generated SQL" do
+      let(:names) { [ "AgentA", "AgentB" ] }
+      let(:baseline_where_only) do
+        %(SELECT "evaluation_prompts".* FROM "evaluation_prompts" WHERE "evaluation_prompts"."name" IN ('AgentA', 'AgentB') AND (json_extract(metadata, '$.active') = TRUE))
+      end
+      let(:baseline_full) do
+        %(SELECT "evaluation_prompts".* FROM "evaluation_prompts" WHERE "evaluation_prompts"."name" IN ('AgentA', 'AgentB') AND (json_extract(metadata, '$.active') = TRUE) ORDER BY "evaluation_prompts"."version" DESC)
+      end
+
+      it "matches the original WHERE clause byte-for-byte" do
+        expect(described_class.active_metadata_versions_for(names).to_sql).to eq(baseline_where_only)
+      end
+
+      it "reproduces the original full query when chained with the preserved order" do
+        expect(described_class.active_metadata_versions_for(names).order(version: :desc).to_sql).to eq(baseline_full)
+      end
+    end
+  end
+
   describe ".other_versions_for" do
     it "excludes the given id and orders by version desc then id desc" do
       current = create(:orchestration_prompt, name: "Emails::ClassifyAgent", version: 3)

--- a/spec/models/orchestration/action_spec.rb
+++ b/spec/models/orchestration/action_spec.rb
@@ -117,4 +117,32 @@ RSpec.describe Orchestration::Action do
       end
     end
   end
+
+  describe ".with_pipeline_counts" do
+    before do
+      create(:orchestration_action, name: "Alpha")
+      action_b = create(:orchestration_action, name: "Bravo")
+      action_c = create(:orchestration_action, name: "Charlie")
+
+      pipeline_one = create(:orchestration_pipeline)
+      step_one = create(:orchestration_step, pipeline: pipeline_one)
+      step_two = create(:orchestration_step, pipeline: pipeline_one)
+      create(:orchestration_step_action, step: step_one, action: action_b)
+      create(:orchestration_step_action, step: step_two, action: action_b)
+
+      pipeline_two = create(:orchestration_pipeline)
+      pipeline_three = create(:orchestration_pipeline)
+      create(:orchestration_step_action, step: create(:orchestration_step, pipeline: pipeline_two), action: action_c)
+      create(:orchestration_step_action, step: create(:orchestration_step, pipeline: pipeline_three), action: action_c)
+    end
+
+    it "counts distinct pipelines per action, ignoring join fan-out" do
+      counts = described_class.with_pipeline_counts.to_h { |a| [ a.name, a.pipeline_count.to_i ] }
+      expect(counts).to eq("Alpha" => 0, "Bravo" => 1, "Charlie" => 2)
+    end
+
+    it "orders actions by name" do
+      expect(described_class.with_pipeline_counts.map(&:name)).to eq(%w[Alpha Bravo Charlie])
+    end
+  end
 end

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe Orchestration::Agent do
     end
   end
 
+  describe ".named" do
+    it "finds an agent by name" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      expect(described_class.named("Emails::ClassifyAgent")).to eq(agent)
+    end
+
+    it "returns nil for a non-existent name" do
+      expect(described_class.named("Does::NotExist")).to be_nil
+    end
+  end
+
   describe "#actions_with_usage" do
     it "returns the agent's actions ordered by name" do
       agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -77,6 +77,23 @@ RSpec.describe Orchestration::Agent do
     end
   end
 
+  describe "#actions_with_usage" do
+    it "returns the agent's actions ordered by name" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      action_b = create(:orchestration_action, kind: :agent, agent: agent, name: "Bravo")
+      action_a = create(:orchestration_action, kind: :agent, agent: agent, name: "Alpha")
+      expect(agent.actions_with_usage.to_a).to eq([ action_a, action_b ])
+    end
+
+    it "only includes the agent's own actions" do
+      agent = create(:orchestration_agent, name: "Emails::ClassifyAgent")
+      other_agent = create(:orchestration_agent, name: "Records::StoreAgent")
+      own = create(:orchestration_action, kind: :agent, agent: agent, name: "Own")
+      create(:orchestration_action, kind: :agent, agent: other_agent, name: "Other")
+      expect(agent.actions_with_usage.to_a).to eq([ own ])
+    end
+  end
+
   describe ".available_tools" do
     it "returns tool class name strings from app/tools/" do
       tools = described_class.available_tools

--- a/spec/models/orchestration/agent_spec.rb
+++ b/spec/models/orchestration/agent_spec.rb
@@ -127,4 +127,23 @@ RSpec.describe Orchestration::Agent do
       end
     end
   end
+
+  describe ".with_action_counts" do
+    before do
+      create(:orchestration_agent, name: "Alpha")
+      agent_b = create(:orchestration_agent, name: "Bravo")
+      agent_c = create(:orchestration_agent, name: "Charlie")
+      create_list(:orchestration_action, 3, kind: :agent, agent: agent_c)
+      create(:orchestration_action, kind: :agent, agent: agent_b)
+    end
+
+    it "returns the exact action_count per agent" do
+      counts = described_class.with_action_counts.to_h { |a| [ a.name, a.action_count.to_i ] }
+      expect(counts).to eq("Alpha" => 0, "Bravo" => 1, "Charlie" => 3)
+    end
+
+    it "orders agents by name" do
+      expect(described_class.with_action_counts.map(&:name)).to eq(%w[Alpha Bravo Charlie])
+    end
+  end
 end

--- a/spec/models/orchestration/pipeline_run_spec.rb
+++ b/spec/models/orchestration/pipeline_run_spec.rb
@@ -22,6 +22,30 @@ RSpec.describe Orchestration::PipelineRun do
     it 'contains expected STATUSES' do
       expect(Orchestration::PipelineRun::STATUSES).to eq(%w[pending running completed failed])
     end
+
+    it 'contains expected ACTIVE_STATUSES' do
+      expect(Orchestration::PipelineRun::ACTIVE_STATUSES).to eq(%w[pending running])
+    end
+  end
+
+  describe '.recent_first' do
+    it 'orders runs newest first by created_at' do
+      older = create(:orchestration_pipeline_run, created_at: 2.days.ago)
+      newer = create(:orchestration_pipeline_run, created_at: 1.hour.ago)
+      expect(described_class.recent_first.to_a).to eq([ newer, older ])
+    end
+  end
+
+  describe '.in_progress' do
+    it 'returns pending and running runs and excludes completed and failed' do
+      pending = create(:orchestration_pipeline_run, status: 'pending')
+      running = create(:orchestration_pipeline_run, status: 'running')
+      completed = create(:orchestration_pipeline_run, status: 'completed')
+      failed = create(:orchestration_pipeline_run, status: 'failed')
+      result = described_class.in_progress
+      expect(result).to include(pending, running)
+      expect(result).not_to include(completed, failed)
+    end
   end
 
   describe 'associations' do

--- a/spec/models/orchestration/pipeline_spec.rb
+++ b/spec/models/orchestration/pipeline_spec.rb
@@ -104,4 +104,23 @@ RSpec.describe Orchestration::Pipeline do
       expect(result).to be > Time.current
     end
   end
+
+  describe ".with_step_counts" do
+    before do
+      create(:orchestration_pipeline, name: "Alpha")
+      pipeline_b = create(:orchestration_pipeline, name: "Bravo")
+      pipeline_c = create(:orchestration_pipeline, name: "Charlie")
+      create_list(:orchestration_step, 3, pipeline: pipeline_c)
+      create(:orchestration_step, pipeline: pipeline_b)
+    end
+
+    it "returns the exact step_count per pipeline" do
+      counts = described_class.with_step_counts.to_h { |p| [ p.name, p.step_count.to_i ] }
+      expect(counts).to eq("Alpha" => 0, "Bravo" => 1, "Charlie" => 3)
+    end
+
+    it "orders pipelines by name" do
+      expect(described_class.with_step_counts.map(&:name)).to eq(%w[Alpha Bravo Charlie])
+    end
+  end
 end

--- a/spec/models/orchestration/pipeline_spec.rb
+++ b/spec/models/orchestration/pipeline_spec.rb
@@ -105,6 +105,74 @@ RSpec.describe Orchestration::Pipeline do
     end
   end
 
+  describe "#latest_run" do
+    it "returns the most recently created run" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_pipeline_run, pipeline: pipeline, created_at: 2.days.ago)
+      newest = create(:orchestration_pipeline_run, pipeline: pipeline, created_at: 1.hour.ago)
+      expect(pipeline.latest_run).to eq(newest)
+    end
+
+    it "returns nil when the pipeline has no runs" do
+      pipeline = create(:orchestration_pipeline)
+      expect(pipeline.latest_run).to be_nil
+    end
+  end
+
+  describe "#run_in_progress?" do
+    it "is true when a pending run exists" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "pending")
+      expect(pipeline.run_in_progress?).to be true
+    end
+
+    it "is true when a running run exists" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "running")
+      expect(pipeline.run_in_progress?).to be true
+    end
+
+    it "is false when only completed or failed runs exist" do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed")
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "failed")
+      expect(pipeline.run_in_progress?).to be false
+    end
+
+    it "is false when the pipeline has no runs" do
+      pipeline = create(:orchestration_pipeline)
+      expect(pipeline.run_in_progress?).to be false
+    end
+  end
+
+  describe "#enabled_steps" do
+    it "returns only enabled steps ordered by position" do
+      pipeline = create(:orchestration_pipeline)
+      step2 = create(:orchestration_step, pipeline: pipeline, position: 2, enabled: true)
+      create(:orchestration_step, pipeline: pipeline, position: 3, enabled: false)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1, enabled: true)
+      expect(pipeline.enabled_steps.to_a).to eq([ step1, step2 ])
+    end
+  end
+
+  describe "#steps_with_actions" do
+    it "returns the pipeline steps ordered by position" do
+      pipeline = create(:orchestration_pipeline)
+      step2 = create(:orchestration_step, pipeline: pipeline, position: 2)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+      expect(pipeline.steps_with_actions.to_a).to eq([ step1, step2 ])
+    end
+
+    it "eager loads each step's step_actions" do
+      pipeline = create(:orchestration_pipeline)
+      step = create(:orchestration_step, pipeline: pipeline)
+      action = create(:orchestration_action, kind: :agent)
+      create(:orchestration_step_action, step: step, action: action, position: 1)
+      loaded_step = pipeline.steps_with_actions.to_a.first
+      expect(loaded_step.step_actions).to be_loaded
+    end
+  end
+
   describe ".with_step_counts" do
     before do
       create(:orchestration_pipeline, name: "Alpha")

--- a/spec/models/orchestration/step_spec.rb
+++ b/spec/models/orchestration/step_spec.rb
@@ -50,6 +50,67 @@ RSpec.describe Orchestration::Step do
     end
   end
 
+  describe '#previous_sibling' do
+    # NOTE: characterizes current behavior. The `steps` association carries a
+    # default `order(:position)` (ASC) scope which composes ahead of the
+    # method's `order(position: :desc)`, so among several lower steps this
+    # returns the lowest-positioned one rather than the adjacent one.
+    it 'returns a lower-positioned sibling in the same pipeline' do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+      create(:orchestration_step, pipeline: pipeline, position: 2)
+      step3 = create(:orchestration_step, pipeline: pipeline, position: 3)
+      expect(step3.previous_sibling).to eq(step1)
+    end
+
+    it 'returns the adjacent lower step when it is the only lower one' do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+      step2 = create(:orchestration_step, pipeline: pipeline, position: 2)
+      expect(step2.previous_sibling).to eq(step1)
+    end
+
+    it 'returns nil for the first step' do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+      create(:orchestration_step, pipeline: pipeline, position: 2)
+      expect(step1.previous_sibling).to be_nil
+    end
+
+    it 'only considers steps within the same pipeline' do
+      pipeline = create(:orchestration_pipeline)
+      other = create(:orchestration_pipeline)
+      create(:orchestration_step, pipeline: other, position: 1)
+      step = create(:orchestration_step, pipeline: pipeline, position: 2)
+      expect(step.previous_sibling).to be_nil
+    end
+  end
+
+  describe '#next_sibling' do
+    it 'returns the nearest step with a higher position' do
+      pipeline = create(:orchestration_pipeline)
+      step1 = create(:orchestration_step, pipeline: pipeline, position: 1)
+      step2 = create(:orchestration_step, pipeline: pipeline, position: 2)
+      create(:orchestration_step, pipeline: pipeline, position: 3)
+      expect(step1.next_sibling).to eq(step2)
+    end
+
+    it 'returns nil for the last step' do
+      pipeline = create(:orchestration_pipeline)
+      create(:orchestration_step, pipeline: pipeline, position: 1)
+      last = create(:orchestration_step, pipeline: pipeline, position: 2)
+      expect(last.next_sibling).to be_nil
+    end
+
+    it 'only considers steps within the same pipeline' do
+      pipeline = create(:orchestration_pipeline)
+      other = create(:orchestration_pipeline)
+      create(:orchestration_step, pipeline: other, position: 3)
+      step = create(:orchestration_step, pipeline: pipeline, position: 2)
+      expect(step.next_sibling).to be_nil
+    end
+  end
+
   describe 'associations' do
     it 'destroys step_actions when step is destroyed' do
       pipeline = create(:orchestration_pipeline)

--- a/spec/requests/orchestration/all_pipeline_runs_spec.rb
+++ b/spec/requests/orchestration/all_pipeline_runs_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Orchestration::AllPipelineRuns" do
+  describe "GET /orchestration/pipeline_runs" do
+    it "returns 200 and lists runs across pipelines newest first" do
+      pipeline = create(:orchestration_pipeline, name: "My Pipeline")
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "completed",
+             created_at: 2.days.ago)
+      create(:orchestration_pipeline_run, pipeline: pipeline, status: "running",
+             created_at: 1.hour.ago)
+
+      get orchestration_pipeline_runs_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.index("Running")).to be < response.body.index("Completed")
+    end
+  end
+end

--- a/spec/services/application_mails/batch_service_spec.rb
+++ b/spec/services/application_mails/batch_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationMails::BatchService do
+  describe "#call" do
+    context "when action is delete" do
+      it "destroys exactly the selected records and leaves others untouched" do
+        doomed = create_list(:application_mail, 2)
+        kept   = create(:application_mail, email_id: "kept@gmail.com")
+
+        result = described_class.new(ids: doomed.map(&:id), batch_action: "delete").call
+
+        expect(result.ok?).to be true
+        expect(result.message).to eq("Deleted 2 record(s).")
+        expect(ApplicationMail.all).to contain_exactly(kept)
+      end
+    end
+
+    context "when no ids are provided" do
+      it "returns a failure result" do
+        result = described_class.new(ids: [], batch_action: "delete").call
+
+        expect(result.ok?).to be false
+        expect(result.message).to eq("No records selected.")
+      end
+    end
+  end
+end

--- a/spec/services/evaluation/agent_summary_query_spec.rb
+++ b/spec/services/evaluation/agent_summary_query_spec.rb
@@ -106,4 +106,44 @@ RSpec.describe Evaluation::AgentSummaryQuery do
       end
     end
   end
+
+  # Characterization of the private json_extract query. Locks in behavior across the
+  # extraction of Evaluation::Prompt.active_metadata_versions_for so the refactor is a no-op.
+  describe "#fetch_active_prompts (json_extract characterization)" do
+    subject(:fetched) { described_class.new.send(:fetch_active_prompts, [ "AgentA" ]) }
+
+    it "returns prompts whose metadata has active: true" do
+      active = create(:orchestration_prompt, name: "AgentA", version: 1, metadata: '{"active":true}')
+      expect(fetched).to eq([ active ])
+    end
+
+    it "excludes prompts whose metadata has active: false" do
+      create(:orchestration_prompt, name: "AgentA", version: 1, metadata: '{"active":false}')
+      expect(fetched).to eq([])
+    end
+
+    it "excludes prompts whose metadata omits the active key" do
+      create(:orchestration_prompt, name: "AgentA", version: 1, metadata: '{"other":true}')
+      expect(fetched).to eq([])
+    end
+
+    # Current behavior: SQLite's json_extract raises on non-JSON metadata rather than
+    # treating it as inactive. Locked in so the extraction preserves it exactly.
+    it "raises when a matching prompt has malformed / non-JSON metadata" do
+      create(:orchestration_prompt, name: "AgentA", version: 1, metadata: "not-json")
+      expect { fetched }.to raise_error(ActiveRecord::StatementInvalid, /malformed JSON/)
+    end
+
+    it "excludes prompts for other agent names even when active" do
+      create(:orchestration_prompt, name: "AgentB", version: 1, metadata: '{"active":true}')
+      expect(fetched).to eq([])
+    end
+
+    it "orders returned prompts by version desc" do
+      v1 = create(:orchestration_prompt, name: "AgentA", version: 1, metadata: '{"active":true}')
+      v3 = create(:orchestration_prompt, name: "AgentA", version: 3, metadata: '{"active":true}')
+      v2 = create(:orchestration_prompt, name: "AgentA", version: 2, metadata: '{"active":true}')
+      expect(fetched).to eq([ v3, v2, v1 ])
+    end
+  end
 end

--- a/spec/services/interviews/batch_service_spec.rb
+++ b/spec/services/interviews/batch_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Interviews::BatchService do
+  describe "#call" do
+    context "when action is delete" do
+      it "destroys exactly the selected records and leaves others untouched" do
+        doomed = create_list(:interview, 2)
+        kept   = create(:interview, company: "Kept Corp")
+
+        result = described_class.new(ids: doomed.map(&:id), batch_action: "delete").call
+
+        expect(result.ok?).to be true
+        expect(result.message).to eq("Deleted 2 record(s).")
+        expect(Interview.all).to contain_exactly(kept)
+      end
+    end
+
+    context "when no ids are provided" do
+      it "returns a failure result" do
+        result = described_class.new(ids: [], batch_action: "delete").call
+
+        expect(result.ok?).to be false
+        expect(result.message).to eq("No records selected.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Moves ActiveRecord query logic (where/joins/includes/order/pluck chains) out of controllers, services, jobs, and lib into named model scopes/class methods, then unifies duplicate query patterns. Executed as a 7-phase plan (RALPLAN-DR, consensus-reviewed by Planner/Architect/Critic before execution, each phase TDD'd and independently verified).

- **Phase 1** — `Evaluation::Prompt`/`Evaluation::Metric`: route reimplementations to existing `last_for_agent`; add `versions_for`, `metadata_versions_for`, `other_versions_for` (preserves the `id: :desc` tiebreaker), `active_for_agent`.
- **Phase 2** — index-count scopes (`with_action_counts`, `with_step_counts`, `with_pipeline_counts`, `with_record_counts`) on Agent/Pipeline/Action/Dataset, SQL preserved verbatim.
- **Phase 3** — `Experiment.completed_for_prompt_name` / `sibling_for_prompt_name` (kept distinct — different filters). `find_by(id: job.arguments[0])` in two SolidQueue job callbacks intentionally left alone (framework-coupling avoidance, documented inline).
- **Phase 4** — new `Batchable` concern (`destroy_by_ids`) on ApplicationMail/Interview/Chat; `ApplicationMail.by_ids` scope. `interviews/batch_service#merge_records` internals untouched (out of scope).
- **Phase 5** — gated Orchestration single-site extractions (`Pipeline#latest_run`, `#run_in_progress?`, `#enabled_steps`, `#steps_with_actions`, `Step#previous_sibling`/`#next_sibling`, `Agent#actions_with_usage`) — only extracted where reused ≥2x, encodes an invariant, or removes an association leak.
- **Phase 6** — gated Evaluation extractions plus a new `Prompt.active_metadata_versions_for` (json_extract scope), added with a characterization spec + byte-identical `.to_sql` assertion against the pre-refactor baseline.
- **Phase 7** — `Orchestration::Agent.named` unifies 5 duplicate `find_by(name:)` call sites.

Every phase is behavior-preserving by construction (no dropped SQL clauses/tiebreakers/DISTINCT); gate-failing candidates were left in place and documented rather than force-extracted.

## Known pre-existing issues found (not fixed — out of scope for this refactor)
1. `steps_controller#move_up` — a default-scope ordering bug selects the wrong sibling step (`Step#previous_sibling` mechanically reproduces it; characterized in specs).
2. `synthetic_dataset_job.rb` — looks up `Dataset` by `name` column against an agent-name value, despite a dedicated `agent_name` column existing.
3. The new json_extract scope raises `SQLite3::SQLException` on malformed metadata rather than handling it gracefully — this was the pre-existing behavior, now locked in by a characterization spec.

## Test plan
- [x] `bundle exec rspec` — 2128 examples, 1 failure (environmental: missing browser binary for a system spec, unrelated to this work)
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rbs validate` — clean
- [x] `bundle exec steep check` — no type errors
- [x] Independent architect re-verification pass (spot-checked extractions against source, confirmed gate honesty, confirmed no scope creep)
- [x] Deslop pass — reviewed all 74 changed files, no cleanup needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)